### PR TITLE
CDDSO-125: Preparation for CDDS v2.3.0 Release

### DIFF
--- a/cdds_common/CHANGES.rst
+++ b/cdds_common/CHANGES.rst
@@ -3,11 +3,17 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+* Version string now includes git commit hash (CDDSO-93)
+
 Release 2.2.5, May 4, 2022
 ============================
 
-* The atmosphere timestep, used in some mappings, is now supplied via the 
-  ModelParameters class rather than a dictionary. This is only used for request 
+* The atmosphere timestep, used in some mappings, is now supplied via the
+  ModelParameters class rather than a dictionary. This is only used for request
   JSON file creation (#2571)
 
 Release 2.2.4, April 22, 2022

--- a/cdds_common/cdds_common/__init__.py
+++ b/cdds_common/cdds_common/__init__.py
@@ -5,6 +5,6 @@ The CDDS Common package contains a collection of generic Python code used by one
 """
 from cdds_common.versions import get_version
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('cdds_common')

--- a/cdds_configure/CHANGES.rst
+++ b/cdds_configure/CHANGES.rst
@@ -3,10 +3,15 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 
-* For non-CMIP6 projects the correct grid label and grid information is applied 
+* For non-CMIP6 projects the correct grid label and grid information is applied
   for variables where the grid is different to the default for that mip table (#2570)
 
 Release 2.2.4, April 22, 2022

--- a/cdds_configure/cdds_configure/__init__.py
+++ b/cdds_configure/cdds_configure/__init__.py
@@ -7,6 +7,6 @@ The CDDS Configure package enables a user to produce the
 from cdds_configure.versions import get_version
 
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('cdds_configure')

--- a/cdds_convert/CHANGES.rst
+++ b/cdds_convert/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 

--- a/cdds_convert/cdds_convert/__init__.py
+++ b/cdds_convert/cdds_convert/__init__.py
@@ -6,6 +6,6 @@ The CDDS Convert package is a tool for managing MIP Convert processes.
 from cdds_convert.versions import get_version
 
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('cdds_convert')

--- a/cdds_prepare/CHANGES.rst
+++ b/cdds_prepare/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ===========================
 

--- a/cdds_prepare/cdds_prepare/__init__.py
+++ b/cdds_prepare/cdds_prepare/__init__.py
@@ -7,6 +7,6 @@ The CDDS Prepare package generates and alters
 
 from cdds_prepare.versions import get_version
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('cdds_prepare')

--- a/cdds_qc/CHANGES.rst
+++ b/cdds_qc/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 

--- a/cdds_qc/cdds_qc/__init__.py
+++ b/cdds_qc/cdds_qc/__init__.py
@@ -7,6 +7,6 @@ files| conform to the WGCM CMIP standards.
 from cdds_qc.versions import get_version
 
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('cdds_qc')

--- a/cdds_qc_plugin_cf17/CHANGES.rst
+++ b/cdds_qc_plugin_cf17/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 

--- a/cdds_qc_plugin_cf17/cdds_qc_plugin_cf17/__init__.py
+++ b/cdds_qc_plugin_cf17/cdds_qc_plugin_cf17/__init__.py
@@ -7,6 +7,6 @@ some additional features and configurability.
 from cdds_qc_plugin_cf17.versions import get_version
 
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('cdds_qc_plugin_cf17')

--- a/cdds_qc_plugin_cmip6/CHANGES.rst
+++ b/cdds_qc_plugin_cmip6/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 

--- a/cdds_qc_plugin_cmip6/cdds_qc_plugin_cmip6/__init__.py
+++ b/cdds_qc_plugin_cmip6/cdds_qc_plugin_cmip6/__init__.py
@@ -7,6 +7,6 @@ The CMIP6 Compliance Checker Plugin provides a suite of tests related to CMIP6
 from cdds_qc_plugin_cmip6.versions import get_version
 
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('cdds_qc_plugin_cmip6')

--- a/cdds_template/CHANGES.rst
+++ b/cdds_template/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 

--- a/cdds_template/cdds_template/__init__.py
+++ b/cdds_template/cdds_template/__init__.py
@@ -6,6 +6,6 @@ The CDDS Template package [...].
 from cdds_template.versions import get_version
 
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('cdds_template')

--- a/cdds_transfer/CHANGES.rst
+++ b/cdds_transfer/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 

--- a/cdds_transfer/cdds_transfer/__init__.py
+++ b/cdds_transfer/cdds_transfer/__init__.py
@@ -8,6 +8,6 @@ download by the ESGF node run by CEDA.
 from cdds_transfer.versions import get_version
 
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('cdds_transfer')

--- a/extract/CHANGES.rst
+++ b/extract/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 

--- a/extract/extract/__init__.py
+++ b/extract/extract/__init__.py
@@ -7,6 +7,6 @@ MASS.
 from extract.versions import get_version
 
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('extract')

--- a/hadsdk/CHANGES.rst
+++ b/hadsdk/CHANGES.rst
@@ -3,13 +3,18 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 
-* For non-CMIP6 projects the correct grid label and grid information is applied 
+* For non-CMIP6 projects the correct grid label and grid information is applied
   for variables where the grid is different to the default for that mip table (#2570)
-* The atmosphere timestep, used in some mappings, is now supplied via the 
-  ModelParameters class rather than a dictionary. This is only used for request 
+* The atmosphere timestep, used in some mappings, is now supplied via the
+  ModelParameters class rather than a dictionary. This is only used for request
   JSON file creation (#2571)
 
 Release 2.2.4, April 22, 2022

--- a/hadsdk/hadsdk/__init__.py
+++ b/hadsdk/hadsdk/__init__.py
@@ -6,6 +6,6 @@ one or more of the CDDS components.
 """
 from hadsdk.versions import get_version
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('hadsdk')

--- a/hadsdk/hadsdk/global_arguments.json
+++ b/hadsdk/hadsdk/global_arguments.json
@@ -11,7 +11,7 @@
     "output_mass_suffix": "development",
     "output_mass_root": "moose:/adhoc/projects/cdds/",
     "root_inventory_dir": "/project/cdds/inventory/",
-    "rose_suite_branch": "trunk",
+    "rose_suite_branch": "tags/2.3.0",
     "root_ancil_dir": "/project/cdds/etc/ancil/",
     "root_hybrid_heights_dir": "/project/cdds/etc/vertical_coordinates",
     "root_replacement_coordinates_dir": "/project/cdds/etc/horizontal_coordinates/",

--- a/hadsdk/hadsdk/global_arguments_jasmin.json
+++ b/hadsdk/hadsdk/global_arguments_jasmin.json
@@ -12,7 +12,7 @@
     "output_mass_suffix": "",
     "output_mass_root": "",
     "root_inventory_dir": "/gws/smf/j04/cmip6_prep/cdds-env-python3/etc/inventory/",
-    "rose_suite_branch": "cdds_jasmin_2.2",
+    "rose_suite_branch": "cdds_jasmin_2.3",
     "root_ancil_dir": "/gws/smf/j04/cmip6_prep/cdds-env-python3/etc/ancil/",
     "root_hybrid_heights_dir": "/gws/smf/j04/cmip6_prep/cdds-env-python3/etc/vertical_coordinates",
     "root_replacement_coordinates_dir": "/gws/smf/j04/cmip6_prep/cdds-env-python3/etc/horizontal_coordinates/",

--- a/mip_convert/CHANGES.rst
+++ b/mip_convert/CHANGES.rst
@@ -3,6 +3,12 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+* Duplicate coordinates error rased when producing certain variables is now not raised (CDDSO-109)
+
 Release 2.2.5, May 4, 2022
 ============================
 

--- a/mip_convert/mip_convert/__init__.py
+++ b/mip_convert/mip_convert/__init__.py
@@ -15,6 +15,6 @@ environ["MKL_NUM_THREADS"] = "1"
 environ["VECLIB_MAXIMUM_THREADS"] = "1"
 environ["NUMEXPR_NUM_THREADS"] = "1"
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('mip_convert')

--- a/setup_env_for_devel
+++ b/setup_env_for_devel
@@ -7,7 +7,7 @@ export CDDS_TEST_ATTRIBUTES="integration inprogress data_request crem dbsql mapp
 
 export CDDS_PACKAGES
 
-. ~cdds/software/miniconda3/bin/activate cdds-2.2_dev-1
+. ~cdds/software/miniconda3/bin/activate cdds-2.3_dev
 
 for CDDS_PACKAGE in $CDDS_PACKAGES
 do

--- a/transfer/CHANGES.rst
+++ b/transfer/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.3.0, May 24, 2022
+============================
+
+* Development moved to github
+
 Release 2.2.5, May 4, 2022
 ============================
 

--- a/transfer/transfer/__init__.py
+++ b/transfer/transfer/__init__.py
@@ -7,6 +7,6 @@ The CDDS Transfer package enables a user to archive the
 from transfer.versions import get_version
 
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.3.0'
 __version__ = get_version('transfer')


### PR DESCRIPTION
Includes:
* Deactivate DEV mode (*/*/__init__.py)
* Release notes (*/CHANGES.rst)
* Conversion suite branches (hadsdk/hadsdk/*.json)
* setup_env_for_devel script update