### PR TITLE
fixing bugs in extract and qc plugin installation

### DIFF
--- a/cdds/cdds/extract/command_line.py
+++ b/cdds/cdds/extract/command_line.py
@@ -47,7 +47,7 @@ def parse_cdds_extract_command_line(user_arguments):
     : :class:`hadsdk.arguments.Arguments` object
         The names of the command line arguments and their validated values.
     """
-    arguments = read_default_arguments('extract', 'cdds_extract')
+    arguments = read_default_arguments('cdds.extract', 'cdds_extract')
 
     parser = argparse.ArgumentParser(description='Extract the requested data from MASS on SPICE via a batch job')
     parser.add_argument('request',

--- a/cdds/setup.py
+++ b/cdds/setup.py
@@ -128,4 +128,9 @@ setup(
     scripts=find_scripts(['bin']),
     include_package_data=True,
     zip_safe=False,
+    entry_points={'compliance_checker.suites': [
+        'cf17 = cdds.qc.plugins.cf17:CF17Check',
+        'cmip6 = cdds.qc.plugins.cmip6:CMIP6Check'
+    ]
+    }
 )


### PR DESCRIPTION
Fortunately this is a quick fix, although I managed to confuse myself about the source of the problem.

I added missing entry points to the setup script (they are used by `compliance_checker` via the `pkg_resources.working_set` mechanism to check and load installed packages), and fixed a namespace bug within the extract.