### PR TITLE
CDDSO-216 Adjust expectations of set external plugins options

### DIFF
--- a/cdds/cdds/convert/process/__init__.py
+++ b/cdds/cdds/convert/process/__init__.py
@@ -1033,10 +1033,12 @@ class ConvertProcess(object):
             'RUN_TRANSFER': not self.skip_transfer,
             'START_YEAR': year_bounds[0],
             'TARGET_SUITE_NAME': self.target_suite_name,
-            'USE_EXTERNAL_PLUGIN': use_external_plugin,
-            'EXTERNAL_PLUGIN': external_plugin,
-            'EXTERNAL_PLUGIN_LOCATION': external_plugin_location,
+            'USE_EXTERNAL_PLUGIN': use_external_plugin
         }
+        if use_external_plugin:
+            changes_to_apply_all['EXTERNAL_PLUGIN'] = external_plugin
+            changes_to_apply_all['EXTERNAL_PLUGIN_LOCATION'] = external_plugin_location
+
         if 'CDDS_DIR' in os.environ:
             changes_to_apply_all['CDDS_DIR'] = os.environ['CDDS_DIR']
         else:

--- a/cdds/cdds/tests/test_convert/test_process/test_process.py
+++ b/cdds/cdds/tests/test_convert/test_process/test_process.py
@@ -456,9 +456,7 @@ class ConvertProcessTest(unittest.TestCase):
             'OUTPUT_MASS_ROOT': 'moose://dummy/archive/path',
             'OUTPUT_MASS_SUFFIX': 'fake_suffix',
             'EMAIL_NOTIFICATIONS': self.process._arguments.email_notifications,
-            'USE_EXTERNAL_PLUGIN': False,
-            'EXTERNAL_PLUGIN': '',
-            'EXTERNAL_PLUGIN_LOCATION': '',
+            'USE_EXTERNAL_PLUGIN': False
         }
         if 'CDDS_DIR' in os.environ:
             expected_update_kwargs_suite['CDDS_DIR'] = os.environ['CDDS_DIR']


### PR DESCRIPTION
In `cdds_convert`:
* Don't expect that `EXTERNAL_PLUGIN` is defined if no external plugin is used
* Don't expect that `EXTERNAL_PLUGIN_LOCATION` is defined if no external plugin is used