### PR TITLE
CDDSO-264 implementing changes from release branch

### DIFF
--- a/cdds/cdds/qc/command_line.py
+++ b/cdds/cdds/qc/command_line.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2018-2022, Met Office.
+# (C) British Crown Copyright 2018-2023, Met Office.
 # Please see LICENSE.rst for license details.
 
 import argparse
@@ -116,6 +116,10 @@ def parse_args(arguments):
     parser.add_argument('-s', '--stream',
                         default=None,
                         help='Stream selection')
+    parser.add_argument('--relaxed_cmor',
+                        help='If specified, CMIP6 style validation is not performed by QC.',
+                        action='store_true'
+                        )
     output_dir_group = parser.add_mutually_exclusive_group()
     output_dir_group.add_argument(
         '-p', '--use_proc_dir', action='store_true', help=(
@@ -173,7 +177,7 @@ def run_and_report(args, request):
     ds = Cmip6Dataset(basedir, request, MipTables(full_paths.mip_table_dir),
                       args.mip_table, None, None, logging.getLogger(__name__), args.stream)
     ds.load_dataset(Dataset)
-    cdds_runner.init_suite(QCSuite(), ds)
+    cdds_runner.init_suite(QCSuite(), ds, args.relaxed_cmor)
     run_id = cdds_runner.run_tests(
         full_paths.mip_table_dir,
         args.standard_names_dir,

--- a/cdds/cdds/qc/plugins/base/validators.py
+++ b/cdds/cdds/qc/plugins/base/validators.py
@@ -5,7 +5,7 @@ import re
 
 from metomi.isodatetime.data import Calendar
 from metomi.isodatetime.parsers import TimePointParser
-from typing import Callable, List, Dict, Any
+from typing import Callable, List, Dict, Any, Union
 
 from cdds.common.validation import ValidationError
 from mip_convert.configuration.cv_config import CVConfig
@@ -149,7 +149,7 @@ class ValidatorFactory:
         return validator_function
 
     @classmethod
-    def value_in_validator(cls, allowed_values: List[Any]) -> Callable[[Any], None]:
+    def value_in_validator(cls, allowed_values: Union[str, List[Any]]) -> Callable[[Any], None]:
         """
         Returns a validator checking if x matches one of allowed_values
 
@@ -162,7 +162,7 @@ class ValidatorFactory:
             if value not in allowed_values:
                 raise ValidationError("Value: {}, Expected: {}".format(
                     value,
-                    ", ".join(allowed_values)
+                    ", ".join(allowed_values) if type(allowed_values) is not str else allowed_values
                 ))
 
         return validator_function

--- a/cdds/cdds/qc/runner.py
+++ b/cdds/cdds/qc/runner.py
@@ -47,7 +47,7 @@ class QCRunner(object):
         self.db = setup_db(db_path)
         self.logger = logging.getLogger(__name__)
 
-    def init_suite(self, check_suite, dataset):
+    def init_suite(self, check_suite, dataset, relaxed_cmor=False):
         """
         Configures IOOS QC checker and prepares a dataset to be checked
 
@@ -57,6 +57,8 @@ class QCRunner(object):
             An instance of ioos qc checker
         dataset: StructuredDataset
             An instance of a dataset to be qc-ed
+        relaxed_cmor: bool
+            If set to True then CMIP6 checks will be performed with relaxed CMOR validation
         """
 
         assert isinstance(check_suite, CheckSuite)
@@ -64,6 +66,7 @@ class QCRunner(object):
 
         self.check_suite = check_suite
         self.check_suite.load_all_available_checkers()
+        self.relaxed_cmor = relaxed_cmor
         self.dataset = dataset
 
     def get_checks(self, checker_name):
@@ -117,7 +120,8 @@ class QCRunner(object):
             "cmip6": {
                 "mip_tables_dir": mip_tables_dir,
                 "cv_location": cv_location,
-                "request": request
+                "request": request,
+                "relaxed_cmor": self.relaxed_cmor
             },
             "cf17": {
                 "standard_names_version": standard_names_version,
@@ -279,6 +283,8 @@ class QCRunner(object):
                 "{} issues found with the provided dataset,"
                 "please check the QC report in {}".format(
                     number_of_errors, dest_filename))
+        if self.relaxed_cmor:
+            output["relaxed_cmor"] = "Running QC with relaxed CMIP6 validation"
         if not process_all:
             output["ignored_errors"] = self.get_ignored_messages()
         with open(dest_filename, 'w') as outfile:


### PR DESCRIPTION
This is actually a re-implementation of changes done in https://github.com/MetOffice/CDDS/commits/CDDSO-264-relaxed-cmor-validation-in-qc, because amending dataset classes proved to be too messy and turns out I don't really need it (I used to think I would have to modify CV validation of filenames, but there isn't any -- so there is no real justification of storing the `relaxed_cmor` flag in the dataset itself). Passing the parameter down to checkers is a bit unorthodox but it seems to be the easiest way to preserve the interface.