### PR TITLE
CDDSO-179 Use mip_era from request.json as default

### DIFF
--- a/cdds/cdds/prepare/command_line.py
+++ b/cdds/cdds/prepare/command_line.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017-2022, Met Office.
+# (C) British Crown Copyright 2017-2023, Met Office.
 # Please see LICENSE.rst for license details.
 """
 The :mod:`command_line` module contains the main functions for the


### PR DESCRIPTION
In `prepare_generate_variable_list`:
* If `--mip_era_defaults` is not set use `mip_era` in `request.json` as default and not `CMIP6` .