### PR TITLE
CDDSO-315 Fix start end date parsing in validate

### DIFF
--- a/cdds/cdds/extract/validate.py
+++ b/cdds/cdds/extract/validate.py
@@ -50,7 +50,6 @@ def validate_streams(streams, args):
 
     # generate expected filenames
     start, end = request.run_bounds.split()
-    start, end = "".join(start.split("-")[:3]), "".join(end.split("-")[:3])
     file_frequency = stream_file_info.file_frequencies[streams[0]].frequency
 
     if not stream_details:


### PR DESCRIPTION
Now that we are using the ISO format in the `request.json` I can simply remove the fragile string parsing that was required to make them work with `generate_time_points()`.