### PR TITLE
CDDSO-371 cmip6 sub experiment id in submission code

### DIFF
--- a/cdds/cdds/deprecated/general_config/CMIP6/v1.0.1/general/CMIP6.cfg
+++ b/cdds/cdds/deprecated/general_config/CMIP6/v1.0.1/general/CMIP6.cfg
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2019, Met Office.
+# (C) British Crown Copyright 2019-2023, Met Office.
 # Please see LICENSE.rst for license details.
 #
 # This general config file lists settings used throughout CDDS
@@ -24,7 +24,7 @@ varfilemap = programme|project|experiment|model
 
 [transfer_facetmaps]
 valid = mip|date|experiment_id|grid|institution_id|mip_era|variant_label|model_id|table_id|variable|stream|package|output|sub_experiment_id
-atomic = mip|date|experiment_id|grid|institution_id|mip_era|variant_label|model_id|table_id|variable|package
+atomic = mip|date|experiment_id|grid|institution_id|mip_era|variant_label|model_id|table_id|variable|package|sub_experiment_id
 name = variable|table_id|model_id|experiment_id|variant_label|grid|[date]
 dataset_id = mip_era|mip|institution_id|model_id|experiment_id|variant_label|table_id|variable|grid
 local = mip_era|mip|model_id|experiment_id|variant_label|package


### PR DESCRIPTION
This is a quick fix following an oversight in the work done for CMIP6Plus; the sub_experiment_id field was added to the list of "facets" that identify a list of datasets for CMIP6Plus, and the same was done in the code, but this change was not applied to CMIP6 leading to the failure of the code when attempting to submit data.

