### PR TITLE
CDDSO-375_cordex-mip-convert-changes

### DIFF
--- a/mip_convert/mip_convert/configuration/user_config.py
+++ b/mip_convert/mip_convert/configuration/user_config.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2020-2022, Met Office.
+# (C) British Crown Copyright 2020-2024, Met Office.
 # Please see LICENSE.rst for license details.
 # pylint: disable = no-member
 """

--- a/mip_convert/mip_convert/request.py
+++ b/mip_convert/mip_convert/request.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015-2022, Met Office.
+# (C) British Crown Copyright 2015-2024, Met Office.
 # Please see LICENSE.rst for license details.
 # pylint: disable=no-member, logging-format-interpolation
 """

--- a/mip_convert/mip_convert/save/cmor/cmor_dataset.py
+++ b/mip_convert/mip_convert/save/cmor/cmor_dataset.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017-2023, Met Office.
+# (C) British Crown Copyright 2017-2024, Met Office.
 # Please see LICENSE.rst for license details.
 """
 The :mod:`cmor_dataset` module contains the code required to assemble

--- a/mip_convert/mip_convert/save/cmor/cmor_outputter.py
+++ b/mip_convert/mip_convert/save/cmor/cmor_outputter.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2009-2021, Met Office.
+# (C) British Crown Copyright 2009-2024, Met Office.
 # Please see LICENSE.rst for license details.
 """
 Module contains classes to output variables through CMOR.

--- a/mip_convert/mip_convert/save/mip_config.py
+++ b/mip_convert/mip_convert/save/mip_config.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2009-2023, Met Office.
+# (C) British Crown Copyright 2009-2024, Met Office.
 # Please see LICENSE.rst for license details.
 """
 A set of classes to represent MIP table entities in object form.

--- a/mip_convert/mip_convert/tests/test_convert/test_output/testAxisMakers.py
+++ b/mip_convert/mip_convert/tests/test_convert/test_output/testAxisMakers.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015-2023, Met Office.
+# (C) British Crown Copyright 2015-2024, Met Office.
 # Please see LICENSE.rst for license details.
 
 import unittest

--- a/mip_convert/mip_convert/tests/test_convert/test_output/testCmorDomainFactory.py
+++ b/mip_convert/mip_convert/tests/test_convert/test_output/testCmorDomainFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015-2021, Met Office.
+# (C) British Crown Copyright 2015-2024, Met Office.
 # Please see LICENSE.rst for license details.
 
 import unittest

--- a/mip_convert/mip_convert/tests/test_convert/test_output/testMipTableFactory.py
+++ b/mip_convert/mip_convert/tests/test_convert/test_output/testMipTableFactory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2015-2021, Met Office.
+# (C) British Crown Copyright 2015-2024, Met Office.
 # Please see LICENSE.rst for license details.
 # pylint: disable = missing-docstring, invalid-name
 

--- a/mip_convert/mip_convert/tests/test_convert/test_output/test_json_mip_table_factory.py
+++ b/mip_convert/mip_convert/tests/test_convert/test_output/test_json_mip_table_factory.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016-2021, Met Office.
+# (C) British Crown Copyright 2016-2024, Met Office.
 # Please see LICENSE.rst for license details.
 # pylint: disable = missing-docstring
 import unittest

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cordex/test_cordex_mon_uv.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cordex/test_cordex_mon_uv.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2022, Met Office.
+# (C) British Crown Copyright 2022-2024, Met Office.
 # Please see LICENSE.rst for license details.
 import os
 

--- a/mip_convert/mip_convert/tests/test_functional/utils/configurations.py
+++ b/mip_convert/mip_convert/tests/test_functional/utils/configurations.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2022-2023, Met Office.
+# (C) British Crown Copyright 2022-2024, Met Office.
 # Please see LICENSE.rst for license details.
 """
 Module to specify the classes that are needed for storing the information of the test data for

--- a/mip_convert/mip_convert/tests/test_functional/utils/directories.py
+++ b/mip_convert/mip_convert/tests/test_functional/utils/directories.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2022-2023, Met Office.
+# (C) British Crown Copyright 2022-2024, Met Office.
 # Please see LICENSE.rst for license details.
 import os
 

--- a/mip_convert/mip_convert/tests/test_save/test_cmor/test_cmor_dataset.py
+++ b/mip_convert/mip_convert/tests/test_save/test_cmor/test_cmor_dataset.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017-2023, Met Office.
+# (C) British Crown Copyright 2017-2024, Met Office.
 # Please see LICENSE.rst for license details.
 # pylint: disable = missing-docstring, invalid-name, too-many-public-methods
 # pylint: disable = unused-argument


### PR DESCRIPTION
A host of things have been tweaked here.  CORDEX doesn't include some of the basic metadata that we rely on for CMIP6, and somewhat surprisingly CMOR works fine with this **provided it is run in relaxed mode**.

CORDEX are introducing a "project_id" (= CORDEX) and retaining mip_era as CMIP6. This slightly confuses things in our system as we've tended to interpret these as the same thing.

CORDEX is dropping some basic CMIP6 metadata fields; experiment_id, variant_label, branch_method in particular. CMOR accepts this so much of the change here is to work around these fields if they are not required.  For experiment_id and variant_label these are listed in the required_global_attributes list, hence why you'll see this in the change here.  A number of the changes here are related to code which looks up metadata in the CVs based on the provided metadata; see references to `self._cv_config._get_values_from_cv('required_global_attributes')`, but this doesn't work perfectly for all cases (branch_method for example).

There are similar tricks we could do in CORDEX (look up `domain` based on the `domain_id`), but this would have meant updating the CVConfig class, which is a bit further than I wanted to go with this change (at least initially).