### PR TITLE
CDDSO-451 Move standard_names entries from metadata to common in request.cfg

### DIFF
--- a/cdds/cdds/common/request/common_section.py
+++ b/cdds/cdds/common/request/common_section.py
@@ -36,6 +36,8 @@ def common_defaults(model_id: str, experiment_id: str, variant_label: str) -> Di
     root_hybrid_heights_dir = '{}/vertical_coordinates/'.format(os.environ['CDDS_ETC'])
     root_replacement_coordinates_dir = '{}/horizontal_coordinates/'.format(os.environ['CDDS_ETC'])
     sites_file = '{}/cfmip2/cfmip2-sites-orog.txt'.format(os.environ['CDDS_ETC'])
+    standard_names_dir = '{}/standard_names/'.format(os.environ['CDDS_ETC'])
+
     return {
         'external_plugin': '',
         'external_plugin_location': '',
@@ -46,6 +48,8 @@ def common_defaults(model_id: str, experiment_id: str, variant_label: str) -> Di
         'root_hybrid_heights_dir': root_hybrid_heights_dir,
         'root_replacement_coordinates_dir': root_replacement_coordinates_dir,
         'sites_file': sites_file,
+        'standard_names_dir': standard_names_dir,
+        'standard_names_version': 'latest',
         'simulation': False,
         'workflow_basename': '{}_{}_{}'.format(model_id, experiment_id, variant_label)
     }
@@ -68,6 +72,8 @@ class CommonSection(Section):
     root_hybrid_heights_dir: str = ''
     root_replacement_coordinates_dir: str = ''
     sites_file: str = ''
+    standard_names_version: str = ''
+    standard_names_dir: str = ''
     simulation: bool = False
     log_level: str = 'INFO'
 
@@ -97,7 +103,8 @@ class CommonSection(Section):
         values = common_defaults(model_id, experiment_id, variant_label)
         config_items = load_types(dict(config.items('common')))
         expand_paths(config_items, ['root_proc_dir', 'root_data_dir', 'root_ancil_dir',
-                                    'root_hybrid_heights_dir', 'root_replacement_coordinates_dir', 'sites_file'])
+                                    'root_hybrid_heights_dir', 'root_replacement_coordinates_dir',
+                                    'sites_file', 'standard_names_dir'])
         values.update(config_items)
         return CommonSection(**values)
 

--- a/cdds/cdds/common/request/metadata_section.py
+++ b/cdds/cdds/common/request/metadata_section.py
@@ -26,7 +26,6 @@ def metadata_defaults(model_id: str) -> Dict[str, Any]:
     :rtype: Dict[str, Any]
     """
     license = PluginStore.instance().get_plugin().license()
-    standard_names_dir = '{}/standard_names/'.format(os.environ['CDDS_ETC'])
 
     return {
         'child_base_date': TimePoint(year=1850, month_of_year=1, day_of_month=1),
@@ -34,8 +33,6 @@ def metadata_defaults(model_id: str) -> Dict[str, Any]:
         'parent_base_date': TimePoint(year=1850, month_of_year=1, day_of_month=1),
         'parent_model_id': model_id,
         'parent_time_units': 'days since 1850-01-01',
-        'standard_names_dir': standard_names_dir,
-        'standard_names_version': 'latest',
     }
 
 
@@ -63,8 +60,6 @@ class MetadataSection(Section):
     parent_variant_label: str = ''
     sub_experiment_id: str = 'none'
     variant_label: str = ''
-    standard_names_version: str = ''
-    standard_names_dir: str = ''
     model_id: str = ''
     model_type: List[str] = field(default_factory=list)
 
@@ -91,7 +86,6 @@ class MetadataSection(Section):
         model_id = config.get('metadata', 'model_id')
         values = metadata_defaults(model_id)
         config_items = load_types(dict(config.items('metadata')), ['model_type'])
-        expand_paths(config_items, ['standard_names_dir'])
         values.update(config_items)
         return MetadataSection(**values)
 

--- a/cdds/cdds/qc/runner.py
+++ b/cdds/cdds/qc/runner.py
@@ -120,8 +120,8 @@ class QCRunner(object):
                 "relaxed_cmor": self.relaxed_cmor
             },
             "cf17": {
-                "standard_names_version": request.metadata.standard_names_version,
-                "standard_names_dir": request.metadata.standard_names_dir
+                "standard_names_version": request.common.standard_names_version,
+                "standard_names_dir": request.common.standard_names_dir
             },
             "cordex": {
                 "mip_tables_dir": mip_tables_dir,

--- a/cdds/cdds/tests/test_archive/functional/data/cdds_request_piControl_10096.cfg
+++ b/cdds/cdds/tests/test_archive/functional/data/cdds_request_piControl_10096.cfg
@@ -18,8 +18,6 @@ parent_time_units = days since 1850-01-01
 parent_variant_label = r1i1p1f2
 sub_experiment_id = none
 variant_label = r1i1p1f2
-standard_names_version = latest
-standard_names_dir = /etc/standard_names/
 model_id = UKESM1-0-LL
 model_type = AOGCM AER BGC CHEM
 
@@ -33,6 +31,8 @@ workflow_basename = UKESM1-0-LL_piControl_r1i1p1f2
 root_proc_dir =
 root_data_dir =
 root_ancil_dir =
+standard_names_version = latest
+standard_names_dir = /etc/standard_names/
 simulation = False
 log_level = INFO
 

--- a/cdds/cdds/tests/test_common/test_request/data/test_request.cfg
+++ b/cdds/cdds/tests/test_common/test_request/data/test_request.cfg
@@ -18,8 +18,6 @@ parent_time_units = days since 1850-01-01
 parent_variant_label = r1i1p1f2
 sub_experiment_id = none
 variant_label = r1i1p1f2
-standard_names_version = latest
-standard_names_dir = /etc/standard_names/
 model_id = UKESM1-0-LL
 model_type = AOGCM BGC AER CHEM
 
@@ -39,6 +37,8 @@ root_ancil_dir = /project/cdds/ancil/
 root_hybrid_heights_dir = /home/h03/cdds/etc/vertical_coordinates/
 root_replacement_coordinates_dir = /home/h03/cdds/etc/horizontal_coordinates/
 sites_file = /home/h03/cdds/etc/cfmip2/cfmip2-sites-orog.txt
+standard_names_version = latest
+standard_names_dir = /etc/standard_names/
 simulation = False
 log_level = INFO
 

--- a/cdds/cdds/tests/test_common/test_request/data/test_request_output.cfg
+++ b/cdds/cdds/tests/test_common/test_request/data/test_request_output.cfg
@@ -18,8 +18,6 @@ parent_time_units = days since 1850-01-01
 parent_variant_label = 
 sub_experiment_id = none
 variant_label = r1i1p1f2
-standard_names_version = latest
-standard_names_dir = /home/h03/cdds/etc/standard_names/
 model_id = UKESM1-0-LL
 model_type = 
 
@@ -38,6 +36,8 @@ root_ancil_dir = /home/h03/cdds/etc/ancil/
 root_hybrid_heights_dir = /home/h03/cdds/etc/vertical_coordinates/
 root_replacement_coordinates_dir = /home/h03/cdds/etc/horizontal_coordinates/
 sites_file = /home/h03/cdds/etc/cfmip2/cfmip2-sites-orog.txt
+standard_names_version = latest
+standard_names_dir = /home/h03/cdds/etc/standard_names/
 simulation = False
 log_level = INFO
 

--- a/cdds/cdds/tests/test_common/test_request/data_for_tests.py
+++ b/cdds/cdds/tests/test_common/test_request/data_for_tests.py
@@ -34,8 +34,6 @@ def expected_test_metadata():
         'parent_variant_label': 'r1i1p1f2',
         'sub_experiment_id': 'none',
         'variant_label': 'r1i1p1f2',
-        'standard_names_version': 'latest',
-        'standard_names_dir': '/etc/standard_names',
         'model_id': 'UKESM1-0-LL',
         'model_type': [
             'AOGCM', 'BGC', 'AER', 'CHEM'
@@ -63,6 +61,8 @@ def expected_test_common():
         'root_hybrid_heights_dir': '/home/h03/cdds/etc/vertical_coordinates',
         'root_replacement_coordinates_dir': '/home/h03/cdds/etc/horizontal_coordinates',
         'sites_file': '/home/h03/cdds/etc/cfmip2/cfmip2-sites-orog.txt',
+        'standard_names_version': 'latest',
+        'standard_names_dir': '/etc/standard_names',
         'simulation': False,
         'log_level': 'INFO'
     }
@@ -151,8 +151,6 @@ def expected_test_minimal_metadata():
         'parent_model_id': 'UKESM1-0-LL',
         'parent_time_units': 'days since 1850-01-01',
         'parent_variant_label': 'r1i1p1f2',
-        'standard_names_dir': '/home/h03/cdds/etc/standard_names/',
-        'standard_names_version': 'latest',
         'sub_experiment_id': 'none',
         'variant_label': 'r1i1p1f2'
     }
@@ -172,6 +170,8 @@ def expected_test_minimal_common():
         'root_hybrid_heights_dir': '/home/h03/cdds/etc/vertical_coordinates/',
         'root_replacement_coordinates_dir': '/home/h03/cdds/etc/horizontal_coordinates/',
         'sites_file': '/home/h03/cdds/etc/cfmip2/cfmip2-sites-orog.txt',
+        'standard_names_dir': '/home/h03/cdds/etc/standard_names/',
+        'standard_names_version': 'latest',
         'simulation': False,
         'workflow_basename': 'UKESM1-0-LL_piControl_r1i1p1f2'
     }

--- a/cdds/cdds/tests/test_common/test_request/test_common_section.py
+++ b/cdds/cdds/tests/test_common/test_request/test_common_section.py
@@ -33,6 +33,8 @@ class TestCommonDefaults(TestCase):
             'root_replacement_coordinates_dir': '/home/h03/cdds/etc/horizontal_coordinates/',
             'simulation': False,
             'sites_file': '/home/h03/cdds/etc/cfmip2/cfmip2-sites-orog.txt',
+            'standard_names_dir': '/home/h03/cdds/etc/standard_names/',
+            'standard_names_version': 'latest',
             'workflow_basename': self.workflow_basename
         }
 

--- a/cdds/cdds/tests/test_common/test_request/test_metadata_section.py
+++ b/cdds/cdds/tests/test_common/test_request/test_metadata_section.py
@@ -26,9 +26,7 @@ class TestMetadataDefaults(TestCase):
             'license': CMIP6_LICENSE,
             'parent_base_date': TimePoint(year=1850, month_of_year=1, day_of_month=1),
             'parent_model_id': self.model_id,
-            'parent_time_units': 'days since 1850-01-01',
-            'standard_names_dir': '/home/h03/cdds/etc/standard_names/',
-            'standard_names_version': 'latest',
+            'parent_time_units': 'days since 1850-01-01'
         }
 
         defaults = metadata_defaults(self.model_id)
@@ -65,8 +63,6 @@ class TestMetadataSection(TestCase):
             parent_variant_label='r1i1p1f2',
             sub_experiment_id='none',
             variant_label='r1i2p3f4',
-            standard_names_version='62',
-            standard_names_dir='/home/h04/cdds/standard_names',
             model_id='HadGEM3-GC31-LL',
             model_type=['AOGCM']
         )
@@ -91,8 +87,6 @@ class TestMetadataSection(TestCase):
             'parent_model_id': 'UKESM1-0-LL',
             'parent_time_units': 'days since 1850-01-01',
             'parent_variant_label': 'r1i1p1f2',
-            'standard_names_dir': '/home/h04/cdds/standard_names',
-            'standard_names_version': '62',
             'sub_experiment_id': 'none',
             'variant_label': 'r1i2p3f4'
         }
@@ -113,8 +107,6 @@ class TestMetadataSection(TestCase):
         self.assertEqual(metadata.parent_experiment_id, '')
         self.assertEqual(metadata.parent_model_id, 'HadGEM3-GC31-LL')
         self.assertEqual(metadata.parent_time_units, 'days since 1850-01-01')
-        self.assertEqual(metadata.standard_names_dir, '/home/h03/cdds/etc/standard_names/')
-        self.assertEqual(metadata.standard_names_version, 'latest')
         self.assertEqual(metadata.branch_date_in_child, None)
         self.assertEqual(metadata.branch_date_in_parent, None)
         self.assertEqual(metadata.branch_method, '')
@@ -151,8 +143,6 @@ class TestMetadataSection(TestCase):
         config.set('metadata', 'parent_variant_label', 'r1i1p1f2')
         config.set('metadata', 'sub_experiment_id', 'none')
         config.set('metadata', 'variant_label', 'r1i2p3f4')
-        config.set('metadata', 'standard_names_version', '6.2.0')
-        config.set('metadata', 'standard_names_dir', '/home/h04/cdds/standard_names')
         config.set('metadata', 'model_id', 'HadGEM3-GC31-LL')
         config.set('metadata', 'model_type', 'AOGCM BGC AER CHEM')
 
@@ -177,8 +167,6 @@ class TestMetadataSection(TestCase):
         self.assertEqual(metadata.parent_variant_label, 'r1i1p1f2')
         self.assertEqual(metadata.sub_experiment_id, 'none')
         self.assertEqual(metadata.variant_label, 'r1i2p3f4')
-        self.assertEqual(metadata.standard_names_version, '6.2.0')
-        self.assertEqual(metadata.standard_names_dir, '/home/h04/cdds/standard_names')
         self.assertEqual(metadata.model_id, 'HadGEM3-GC31-LL')
         self.assertListEqual(metadata.model_type, ['AOGCM', 'BGC', 'AER', 'CHEM'])
 

--- a/cdds/cdds/tests/test_prepare/test_request_file/data/functional_tests/cmip6_request_output.cfg
+++ b/cdds/cdds/tests/test_prepare/test_request_file/data/functional_tests/cmip6_request_output.cfg
@@ -18,8 +18,6 @@ parent_time_units = days since 1850-01-01
 parent_variant_label = r1i1p1f2
 sub_experiment_id = none
 variant_label = r1i1p1f2
-standard_names_version = latest
-standard_names_dir = /home/h03/cdds/etc/standard_names/
 model_id = UKESM1-0-LL
 model_type = AOGCM BGC AER CHEM
 
@@ -38,6 +36,8 @@ root_ancil_dir = /home/h03/cdds/etc/ancil/
 root_hybrid_heights_dir = /home/h03/cdds/etc/vertical_coordinates/
 root_replacement_coordinates_dir = /home/h03/cdds/etc/horizontal_coordinates/
 sites_file = /home/h03/cdds/etc/cfmip2/cfmip2-sites-orog.txt
+standard_names_version = latest
+standard_names_dir = /home/h03/cdds/etc/standard_names/
 simulation = False
 log_level = INFO
 

--- a/cdds/cdds/tests/test_prepare/test_request_file/data/functional_tests/gcmodeldev_request_output.cfg
+++ b/cdds/cdds/tests/test_prepare/test_request_file/data/functional_tests/gcmodeldev_request_output.cfg
@@ -18,8 +18,6 @@ parent_time_units = days since 1850-01-01
 parent_variant_label = r1i1p1f2
 sub_experiment_id = none
 variant_label = r1i1p1f90
-standard_names_version = latest
-standard_names_dir = /home/h03/cdds/etc/standard_names/
 model_id = HadGEM3-GC31-LL
 model_type = AOGCM AER
 
@@ -38,6 +36,8 @@ root_ancil_dir = /home/h03/cdds/etc/ancil/
 root_hybrid_heights_dir = /home/h03/cdds/etc/vertical_coordinates/
 root_replacement_coordinates_dir = /home/h03/cdds/etc/horizontal_coordinates/
 sites_file = /home/h03/cdds/etc/cfmip2/cfmip2-sites-orog.txt
+standard_names_version = latest
+standard_names_dir = /home/h03/cdds/etc/standard_names/
 simulation = False
 log_level = INFO
 


### PR DESCRIPTION
Move `standard_names_dir` and `standard_names_version` from `metadata` section to `common` section