### PR TITLE
CDDSO-458 Correct handling of mip_convert exit codes

### DIFF
--- a/cdds/cdds/convert/mip_convert_wrapper/wrapper.py
+++ b/cdds/cdds/convert/mip_convert_wrapper/wrapper.py
@@ -176,8 +176,8 @@ def run_mip_convert_wrapper(arguments):
         manage_critical_issues(
             cdds_convert_proc_dir, mip_convert_log,
             fields_to_log=[cylc_task_name, cylc_task_cycle_point, cylc_task_try])
-        does_mip_convert_failed = (exit_code == 1 or exit_code == 2)
-        if does_mip_convert_failed and arguments.continue_if_mip_convert_failed:
+        mip_convert_internal_failure = (exit_code == 1 or exit_code == 2)
+        if mip_convert_internal_failure and arguments.continue_if_mip_convert_failed:
             exit_code = 0
 
     # move file from staging directory to output directory


### PR DESCRIPTION
* Check `if_continue_mip_convert_failed` then continue if exit code is 1 or 2, otherwise fail
* When exit code is >0 and not 1 or 2, then fail regardless how `if_continue_mip_convert_failed` is set