### PR TITLE
CDDSO-34 ensure python logger sends messages to the appropriate place

### DIFF
--- a/cdds/cdds/common/__init__.py
+++ b/cdds/cdds/common/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2017-2023, Met Office.
+# (C) British Crown Copyright 2017-2024, Met Office.
 # Please see LICENSE.rst for license details.
 """
 The :mod:`common` module contains common library functions used by


### PR DESCRIPTION
@mo-jareddrayton 's changes to the logger.

I've confirmed this works fine, but I had to rebase to allow the `checkout_processing_workflow` to work.  There is an issue with log files going to the wrong location but that needs to be dealt with separately.

This needs a tweak to `u-ak283` to work, see CDDSO-34 for details.