### PR TITLE
CDDSO-419 v2.5.9 release

### DIFF
--- a/cdds/CHANGES.rst
+++ b/cdds/CHANGES.rst
@@ -3,6 +3,12 @@
 
 .. include:: common.txt
 
+Release 2.5.9, June 25, 2024
+============================
+* Fixed a bug in submission code that made archiving script unusable (CDDSO-477)
+* QC now allows missing standard name attribute if it is defined as empty
+  in MIP Tables (CDDSO-478)
+
 Release 2.5.8, February 29, 2024
 ================================
 * Added submission queues to support CMIP6Plus publication (CDDSO-413)

--- a/cdds/cdds/__init__.py
+++ b/cdds/cdds/__init__.py
@@ -2,6 +2,6 @@
 # Please see LICENSE.rst for license details.
 from cdds.versions import get_version
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.5.9'
 __version__ = get_version('cdds')

--- a/cdds/cdds/global_arguments.json
+++ b/cdds/cdds/global_arguments.json
@@ -5,7 +5,7 @@
     "mass_data_class": "crum",
     "output_mass_root": "moose:/adhoc/projects/cdds/",
     "output_mass_suffix": "development",
-    "processing_workflow_branch": "cdds_2.5.8",
+    "processing_workflow_branch": "cdds_2.5.9",
     "root_ancil_dir": "${CDDS_ETC}/ancil/",
     "root_data_dir": "/project/cdds_data",
     "root_hybrid_heights_dir": "${CDDS_ETC}/vertical_coordinates",

--- a/mip_convert/CHANGES.rst
+++ b/mip_convert/CHANGES.rst
@@ -3,6 +3,11 @@
 
 .. include:: common.txt
 
+Release 2.5.9, June 25, 2024
+============================
+* Added new MIP tables (GC3hrPtUV, GCAmon6hr, GCAmonUV, GC3hr, GC1hr) and mappings for CP4A, along with
+  sizing and memory configuration tuning for new diagnostics (CDDSO-414, CDDSO-463).
+
 Release 2.5.8, February 29, 2024
 ================================
 * No changes

--- a/mip_convert/mip_convert/__init__.py
+++ b/mip_convert/mip_convert/__init__.py
@@ -15,6 +15,6 @@ environ["MKL_NUM_THREADS"] = "1"
 environ["VECLIB_MAXIMUM_THREADS"] = "1"
 environ["NUMEXPR_NUM_THREADS"] = "1"
 
-_DEV = True
+_DEV = False
 _NUMERICAL_VERSION = '2.5.9'
 __version__ = get_version('mip_convert')


### PR DESCRIPTION
This is a minor release, hopefully the final one in the `v2.5` branch, containing a few bugfixes and a bunch of new mappings and configuration changes for the CP4A project. 