### PR TITLE
CDDSO-509 Remove unrecognised parameter

### DIFF
--- a/cdds/cdds/convert/process/__init__.py
+++ b/cdds/cdds/convert/process/__init__.py
@@ -814,7 +814,6 @@ class ConvertProcess(object):
             'CALENDAR': self._request.metadata.calendar,
             'DEV_MODE': _DEV,
             'END_DATE': str(end_date),
-            'MODEL_PARAMS_DIR': self._request.conversion.model_params_dir,
             'INPUT_DIR': input_data_directory(self._request),
             'OUTPUT_MASS_ROOT': self._request.data.output_mass_root,
             'OUTPUT_MASS_SUFFIX': self._request.data.output_mass_suffix,

--- a/cdds/cdds/tests/test_convert/test_process/test_process.py
+++ b/cdds/cdds/tests/test_convert/test_process/test_process.py
@@ -420,7 +420,6 @@ class ConvertProcessTest(unittest.TestCase):
             'INPUT_DIR': input_dir,
             'MIP_CONVERT_CONFIG_DIR': mip_convert_config_dir,
             'MODEL_ID': 'dummymodel',
-            'MODEL_PARAMS_DIR': '',
             'NTHREADS_CONCATENATE': NTHREADS_CONCATENATE,
             'OUTPUT_DIR': output_dir,
             'PARALLEL_TASKS': PARALLEL_TASKS,


### PR DESCRIPTION
Remove not recognised parameter (was removed in `3.0.0`)

Also, see changes in convert suite: https://code.metoffice.gov.uk/trac/roses-u/changeset?old_path=%2Fa%2Fk%2F2%2F8%2F3%2Ftrunk&old=296459&new_path=%2Fa%2Fk%2F2%2F8%2F3%2FCDDSO-509_unrecognised_parameter&new=296459