### PR TITLE
CDDSO-547: modify AERday/ua10 and AEday/ua10 mappings for HadGEM3 to …

### DIFF
--- a/mip_convert/mip_convert/process/HadGEM3_mappings.cfg
+++ b/mip_convert/mip_convert/process/HadGEM3_mappings.cfg
@@ -141,6 +141,19 @@ reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
 status = ok
 units = %
 
+[ua10]
+comment = A division by the Heaviside function, as used in UKESM1-0-LL has 
+    been removed from the mapping used to calculate this variable. As the 
+    10 hPa level is well above the surface everywhere this should have no
+    impact on the scientific content of this variable
+component = atmos-physics
+dimension = longitude latitude p10 time
+expression = m01s30i201[blev=P10, lbproc=128]
+mip_table_id = AERday AEday
+reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+status = ok
+units = m s-1
+
 [vegFrac]
 component = land
 dimension = longitude latitude typeveg time


### PR DESCRIPTION
…remove Heaviside

Change to Mappings is fairly simple

MIP Convert functional test for `mip_convert.tests.test_functional.test_functional_cordex.test_cordex_cmip6_day_hus1000.TestCordexCmip6DayHus1000` is failing -- I think we might have missed a cherry pick at some point.

All other tests passing and I've confirmed that this mapping gets picked up correctly.