### PR TITLE
CDDSO-548: Monthly tas from daily for CORDEX HadREM3

### DIFF
--- a/cdds/cdds/common/plugins/cordex/data/model/HadREM3-GA7-05.json
+++ b/cdds/cdds/common/plugins/cordex/data/model/HadREM3-GA7-05.json
@@ -37,10 +37,10 @@
   },
   "sizing_info": {
     "1hr": {
-      "default": 5
+      "default": 1
     },
     "6hr": {
-      "default": 5
+      "default": 1
     },
     "day": {
       "default": 5

--- a/cdds/cdds/convert/concatenation/concatenation_setup.py
+++ b/cdds/cdds/convert/concatenation/concatenation_setup.py
@@ -390,14 +390,14 @@ def build_concatenation_work_dict(available_variables, config,
     """
     logger = logging.getLogger(__name__)
     all_concatenation_work = {}
-    for mip_table, variable_name in available_variables:
-        logger.info('MIP variable: {}/{}'.format(mip_table, variable_name))
-        filename_pattern = '{}_{}_*'.format(variable_name, mip_table)
+    for variable_facets in available_variables:
+        logger.info('MIP variable: {}'.format('_'.join(variable_facets)))
+        filename_pattern = '{}_*'.format('_'.join(variable_facets))
         input_files_dir = config['staging_location']
 
         input_filenames = list_cmor_files(input_files_dir,
                                           filename_pattern,
-                                          mip_table=mip_table,
+                                          # mip_table=mip_table,
                                           recursive=config['recursive'])
         if len(input_filenames) == 1:
             logger.info('Found single file {}'.format(input_filenames[0]))
@@ -489,7 +489,7 @@ def concatenation_setup(config_file, log_file, append_log):
     available_variables = set()
     for filename in list_cmor_files(config['staging_location'], '*',
                                     recursive=config['recursive']):
-        variable_tuple = tuple(os.path.basename(filename).split('_')[1::-1])
+        variable_tuple = tuple(os.path.basename(filename).split('_')[:-1])
         available_variables.add(variable_tuple)
 
     all_concatenation_work = build_concatenation_work_dict(

--- a/mip_convert/mip_convert/process/HadREM3_mon_mappings.cfg
+++ b/mip_convert/mip_convert/process/HadREM3_mon_mappings.cfg
@@ -1,0 +1,21 @@
+# (C) British Crown Copyright 2024, Met Office.
+# Please see LICENSE.rst for license details.
+#
+# This 'model to MIP mappings' configuration file contains sections
+# for each 'MIP requested variable name' that has a common
+# 'model to MIP mapping'. Please see the 'User Guide' for more
+# information.
+
+[DEFAULT]
+mip_table_id = mon
+positive = None
+reviewer = N/A
+status = embargoed
+
+[tas]
+component = atmos-physics
+dimension = longitude latitude height2m time
+expression = mon_mean_from_day(m01s03i236[lbproc=128])
+mip_table_id = mon
+units = K
+


### PR DESCRIPTION
Three changes here:
1. mon/tas mapping for HadREM3 -- constructs monthly data from daily means using a pre-existing processor function
2. Changes to sizing for HadREM3 -- matching up file sizes with CORDEX requirements
3. concatenation_setup: Found a bug when processing two tas datasets for CORDEX from the same stream (mon and day).  CORDEX has the frequency facet just before the date range rather than in the second position as in CMIP6.  Have rejigged code to use whole prefix of file name (i.e. everything other than the date range)

Nightly test workflow ran fine once missing merge was added back to v3.0 release branch.