### PR TITLE
CDDSO-568 quarterly extract and convert fixes

### DIFF
--- a/cdds/cdds/common/__init__.py
+++ b/cdds/cdds/common/__init__.py
@@ -989,6 +989,7 @@ def generate_datestamps_pp(start_date: TimePoint,
              "10 day": ["P10D", "%Y%m%d"],
              "monthly": ["P1M", "%Y%b"],
              "season": ["P3M", "%Y"],
+             "quarterly": ["P3M", "%Y%m%d"],
              "hourly": ["PT1H", "%Y%m%d_%H"]}
 
     seasons = {3: "mam", 6: "jja", 9: "son", 12: "djf"}

--- a/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-LL.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-LL.json
@@ -1,7 +1,8 @@
 {
   "stream_file_frequency": {
     "quarterly": [
-      "ond"
+      "ond",
+      "apg"
     ],
     "monthly": [
       "ap4",
@@ -22,6 +23,7 @@
   },
   "cycle_length": {
     "ap4": "P5Y",
+    "apg": "P5Y",
     "ap5": "P5Y",
     "apm": "P5Y",
     "apu": "P5Y",
@@ -37,6 +39,7 @@
   },
   "memory": {
     "ap4": "12G",
+    "apg": "12G",
     "ap5": "8G",
     "apm": "8G",
     "apu": "8G",
@@ -52,6 +55,7 @@
   },
   "temp_space": {
     "ap4": 98304,
+    "apg": 98304,
     "ap5": 40960,
     "apm": 8192,
     "apu": 20480,

--- a/cdds/cdds/common/plugins/cmip6_plus/data/model/HadGEM3-GC31-LL.json
+++ b/cdds/cdds/common/plugins/cmip6_plus/data/model/HadGEM3-GC31-LL.json
@@ -1,7 +1,8 @@
 {
   "stream_file_frequency": {
     "quarterly": [
-      "ond"
+      "ond",
+      "apg"
     ],
     "monthly": [
       "ap4",
@@ -22,6 +23,7 @@
   },
   "cycle_length": {
     "ap4": "P5Y",
+    "apg": "P5Y",
     "ap5": "P5Y",
     "apm": "P5Y",
     "apu": "P5Y",
@@ -37,6 +39,7 @@
   },
   "memory": {
     "ap4": "12G",
+    "apg": "12G",
     "ap5": "8G",
     "apm": "8G",
     "apu": "8G",
@@ -52,6 +55,7 @@
   },
   "temp_space": {
     "ap4": 98304,
+    "apg": 98304,
     "ap5": 40960,
     "apm": 8192,
     "apu": 20480,

--- a/cdds/cdds/convert/mip_convert_wrapper/file_management.py
+++ b/cdds/cdds/convert/mip_convert_wrapper/file_management.py
@@ -177,7 +177,7 @@ def _ap_stream_prefix(model_id: str, stream: str) -> str:
     stream_file_info = plugin.models_parameters(model_id).stream_file_info()
     frequency = stream_file_info.file_frequencies[stream].frequency
 
-    if frequency == 'daily':
+    if frequency in ['daily', 'quarterly']:
         return 'ap_daily'
 
     if frequency == '10 day':

--- a/cdds/cdds/extract/filters.py
+++ b/cdds/cdds/extract/filters.py
@@ -429,7 +429,7 @@ class Filters(object):
 
         if file_frequency == "monthly":
             start, end = 1, 12
-        elif file_frequency == "season":
+        elif file_frequency in ["season", "quarterly"]:
             start, end = 3, 12
 
         start_date, end_date = pp_filelist[0]["timepoint"], pp_filelist[-1]["timepoint"]


### PR DESCRIPTION
Changes to Extract and Convert steps needed to support the use of quarterly output files. Tested against LESFMIP.

Changes include:
* adding apg stream to model config files for HadGEM3-GC31-LL
* adding "quarterly" to several dictionaries that determine file patterns and expected frequencies of output
*  update to file_managment module to ensure that these files are recognised by the mip_convert_wrapper when running mip convert so that files are copied across.