### PR TITLE
CDDSO-571 regex fix

### DIFF
--- a/mip_convert/mip_convert/model_date.py
+++ b/mip_convert/mip_convert/model_date.py
@@ -282,7 +282,7 @@ class CdDate(object):
 
 
 class DateFormatComponent(object):
-    BASE_PATTERN = r'(?P<%s>\d{%d})'
+    BASE_PATTERN = r'(?P<%s>\\d{%d})'
 
     def __init__(self, format, name, alen):
         self.format = format

--- a/setup_env_for_devel
+++ b/setup_env_for_devel
@@ -8,7 +8,7 @@ export CDDS_PACKAGES
 CDDS_HOME=$(readlink -f ~cdds)
 CONDA=${CDDS_HOME}/software/miniconda3/bin/activate
 
-DEV_ENV='cdds-3.0_dev-1'
+DEV_ENV='cdds-3.0_dev-2'
 
 if [ -f ${CONDA} ]; then
     . ${CONDA} ${DEV_ENV}


### PR DESCRIPTION
When installing CDDS v3.0.5rc1 I've found an issue in that MIP Convert tests fail due to problems with regex;
```
Using MIP Convert version 3.0.5rc1
*** Starting conversions ***
bad escape \d at position 11
Traceback (most recent call last):
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/command_line.py", line 54, in main
    exit_code = convert(parameters)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/request.py", line 59, in convert
    setup_cmor(user_config, parameters.relaxed_cmor)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/save/setup_cmor.py", line 24, in setup_cmor
    cmor_lite.dataset(get_cmor_dataset(user_config, relaxed_cmor))
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/save/setup_cmor.py", line 44, in get_cmor_dataset
    cmor_dataset.validate_required_global_attributes()
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/save/cmor/cmor_dataset.py", line 53, in validate_required_global_attributes
    if attribute not in self.items:
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/save/cmor/cmor_dataset.py", line 168, in items
    branch_time = self._branch_time(branch_time_name, branch_date_name, base_date_name)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/save/cmor/cmor_dataset.py", line 294, in _branch_time
    value = (self._time_from_option(branch_date_name) - self._time_from_option(base_date_name))
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/save/cmor/cmor_dataset.py", line 300, in _time_from_option
    return model_date.strptime(value, self._user_config.TIMEFMT, self._user_config.calendar)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/model_date.py", line 353, in strptime
    args = date_format.getArgs(value)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/model_date.py", line 338, in getArgs
    if self.match(value):
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/model_date.py", line 321, in match
    return self._pattern.match(value)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/model_date.py", line 327, in _pattern
    expr = date_component.replaceWithPattern(expr)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/mip_convert/model_date.py", line 301, in replaceWithPattern
    return self._format_regex.sub(self._pattern, ystring)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/regex/regex.py", line 706, in _compile_replacement_helper
    is_group, items = _compile_replacement(source, pattern, is_unicode)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-3.0.5rc1/lib/python3.10/site-packages/regex/_regex_core.py", line 1730, in _compile_replacement
    raise error("bad escape \\%s" % ch, source.string, source.pos)
regex._regex_core.error: bad escape \d at position 11
```

I eventually traced this back to a change in how regex is interpreting `\d` in patterns.  Replacing this allowed tests to pass and MIP Convert to work.

I've also built a new development environment with the regex update in it.