### PR TITLE
CDDSO-495 Use cylc task log dir for mip convert log files

### DIFF
--- a/cdds/cdds/convert/mip_convert_wrapper/actions.py
+++ b/cdds/cdds/convert/mip_convert_wrapper/actions.py
@@ -15,6 +15,23 @@ from cdds.convert.exceptions import MipConvertWrapperDiskUsageError
 from cdds.convert.mip_convert_wrapper.common import print_env
 
 
+def copy_logs(mip_convert_log, cmor_log_file, target_dir):
+    """
+    Copy MIP convert and CMOR log files to given target directory.
+
+    :param mip_convert_log: Path to MIP convert log file
+    :type mip_convert_log: str
+    :param cmor_log_file: Path to CMOR log file
+    :type cmor_log_file: str
+    :param target_dir: Path to target directory
+    :type target_dir: str
+    """
+    target_mip_convert_log = os.path.join(target_dir, os.path.basename(mip_convert_log))
+    target_cmor_log = os.path.join(target_dir, os.path.basename(cmor_log_file))
+    shutil.copyfile(mip_convert_log, target_mip_convert_log)
+    shutil.copyfile(cmor_log_file, target_cmor_log)
+
+
 def manage_logs(stream, component, mip_convert_config_dir,
                 cylc_task_cycle_point):
     """

--- a/cdds/cdds/convert/mip_convert_wrapper/config_updater.py
+++ b/cdds/cdds/convert/mip_convert_wrapper/config_updater.py
@@ -48,7 +48,7 @@ def calculate_mip_convert_run_bounds(
 
 def setup_cfg_file(input_dir, output_dir, mip_convert_config_dir, component,
                    start_time, end_time, timestamp, user_config_template_name,
-                   cmor_log_dir, cmor_log_filename_template):
+                   cmor_log_file):
     """
     Construct the mip_convert.cfg file from the templates. The
     resulting config file is written to the current directory.
@@ -74,10 +74,8 @@ def setup_cfg_file(input_dir, output_dir, mip_convert_config_dir, component,
         Time stamp string to use in output file names.
     user_config_template_name: str
         The template for the name of the |user configuration file|.
-    cmor_log_dir: str
-        Path to the cmor log directory.
-    cmor_log_filename_template: str
-        The template for the name of the cmor log file.
+    cmor_log_file: str
+        The cmor log file.
     Returns
     -------
     : bool
@@ -120,8 +118,6 @@ def setup_cfg_file(input_dir, output_dir, mip_convert_config_dir, component,
                 logger.critical('Failed to create component directory. '
                                 'OSError: "{}"'.format(err.strerror))
                 raise
-
-    cmor_log_file = os.path.join(cmor_log_dir, cmor_log_filename_template.format(timestamp))
 
     jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(
         mip_convert_config_dir))


### PR DESCRIPTION
* Use cylc task directory for `cmor.log` and `mip_convert.log` files