### PR TITLE
CDDSO-585 Make hybrid heights files not necessary for ocean

### DIFF
--- a/cdds/cdds/common/plugins/base/base_grid.py
+++ b/cdds/cdds/common/plugins/base/base_grid.py
@@ -128,15 +128,6 @@ class BaseGridInfo(GridInfo, metaclass=ABCMeta):
             return self._values['ancil_variables']
         return []
 
-    def hybrid_heights_files(self) -> List[str]:
-        """
-        Returns the hybrid heights file names.
-
-        :return: Hybrid heights file names
-        :rtype: List[str]
-        """
-        return self._values['hybrid_heights_files']
-
     @staticmethod
     def _to_int(value: str) -> int:
         if value is None or value == '':
@@ -209,6 +200,16 @@ class OceanBaseGridInfo(BaseGridInfo):
         """
         return self._halo_options
 
+    def hybrid_heights_files(self) -> List[str]:
+        """
+        Returns the hybrid heights file names.
+        Ocean grids have no hybrid heights files. So, None will be returned.
+
+        :return: Hybrid heights file names
+        :rtype: List[str]
+        """
+        return None
+
     def bounds_coordinates(self, stream: str, substream: str) -> List[str]:
         """
         Returns a list of names of bounds coordinates
@@ -271,3 +272,12 @@ class AtmosBaseGridInfo(BaseGridInfo):
         :rtype: int
         """
         return self._values['atmos_timestep']
+
+    def hybrid_heights_files(self) -> List[str]:
+        """
+        Returns the hybrid heights file names.
+
+        :return: Hybrid heights file names
+        :rtype: List[str]
+        """
+        return self._values['hybrid_heights_files']

--- a/cdds/cdds/common/plugins/base/base_models.py
+++ b/cdds/cdds/common/plugins/base/base_models.py
@@ -320,8 +320,9 @@ class BaseModelParameters(ModelParameters, metaclass=ABCMeta):
         :return: Paths to the hybrid heights files
         :rtype: List[str]
         """
+        grids_to_consider = list(filter(lambda x: x != GridType.OCEAN, GridType))
         file_names = []
-        for grid_type in GridType:
+        for grid_type in grids_to_consider:
             grid_info = self.grid_info(grid_type)
             file_names.extend(grid_info.hybrid_heights_files())
         return list(map(

--- a/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-HH.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-HH.json
@@ -186,7 +186,6 @@
       "levels": 75,
       "replacement_coordinates_file": "cice_eORCA12_coords.nc",
       "ancil_filenames": [],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-HM.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-HM.json
@@ -192,7 +192,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-LL.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-LL.json
@@ -202,7 +202,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-MH.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-MH.json
@@ -186,7 +186,6 @@
       "levels": 75,
       "replacement_coordinates_file": "cice_eORCA12_coords.nc",
       "ancil_filenames": [],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-MM.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/HadGEM3-GC31-MM.json
@@ -193,7 +193,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/cmip6/data/model/HadREM3-GA7-05.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/HadREM3-GA7-05.json
@@ -52,7 +52,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
       },
       "halo_options": {

--- a/cdds/cdds/common/plugins/cmip6/data/model/UKESM1-0-LL.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/UKESM1-0-LL.json
@@ -198,7 +198,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/cmip6/data/model/UKESM1-1-LL.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/UKESM1-1-LL.json
@@ -198,7 +198,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/cmip6/data/model/UKESM1-ice-LL.json
+++ b/cdds/cdds/common/plugins/cmip6/data/model/UKESM1-ice-LL.json
@@ -198,7 +198,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/cmip6_plus/data/model/HadGEM3-GC31-LL.json
+++ b/cdds/cdds/common/plugins/cmip6_plus/data/model/HadGEM3-GC31-LL.json
@@ -202,7 +202,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/cordex/data/model/HadREM3-GA7-05.json
+++ b/cdds/cdds/common/plugins/cordex/data/model/HadREM3-GA7-05.json
@@ -84,7 +84,6 @@
       "replacement_coordinates_file": null,
       "ancil_filenames": [
       ],
-      "hybrid_heights_files": [],
       "masked": {
       },
       "halo_options": {

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC31-LL.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC31-LL.json
@@ -198,7 +198,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC31-MM.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC31-MM.json
@@ -192,7 +192,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC3p05-N216ORCA025.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC3p05-N216ORCA025.json
@@ -264,7 +264,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC3p05-N96ORCA1.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC3p05-N96ORCA1.json
@@ -270,7 +270,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC50-N216ORCA025.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC50-N216ORCA025.json
@@ -264,7 +264,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC50-N640ORCA12.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC50-N640ORCA12.json
@@ -186,7 +186,6 @@
         "levels": 75,
         "replacement_coordinates_file": "cice_eORCA12_coords.nc",
         "ancil_filenames": [],
-        "hybrid_heights_files": [],
         "masked": {
           "grid-V": {
             "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC50-N96ORCA1.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC50-N96ORCA1.json
@@ -264,7 +264,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC5c-N216ORCA025.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC5c-N216ORCA025.json
@@ -264,7 +264,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC5c-N96ORCA1.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC5c-N96ORCA1.json
@@ -216,7 +216,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC5p-N216ORCA025.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadGEM3-GC5p-N216ORCA025.json
@@ -264,7 +264,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/HadREM-CP4A-4p5km.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/HadREM-CP4A-4p5km.json
@@ -112,7 +112,6 @@
       "replacement_coordinates_file": null,
       "ancil_filenames": [
       ],
-      "hybrid_heights_files": [],
       "masked": {
       },
       "halo_options": {

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/UKESM1-0-LL.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/UKESM1-0-LL.json
@@ -198,7 +198,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/UKESM1-1-LL.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/UKESM1-1-LL.json
@@ -198,7 +198,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [

--- a/cdds/cdds/common/plugins/gcmodeldev/data/model/eUKESM1-1-ice-N96ORCA1.json
+++ b/cdds/cdds/common/plugins/gcmodeldev/data/model/eUKESM1-1-ice-N96ORCA1.json
@@ -198,7 +198,6 @@
         "diaptr_basin_masks.nc",
         "ocean_zostoga.nc"
       ],
-      "hybrid_heights_files": [],
       "masked": {
         "grid-V": {
           "slice_latitude": [


### PR DESCRIPTION
* Remove hybrid heights files from model parameters file
* Don't return any hybrid heights files in Ocean Grid
* Only get hybrid heights files from not Ocean Grid