### PR TITLE
CDDSO-366 CDDSO-366 Create a qc.db per stream

### DIFF
--- a/cdds/cdds/qc/command_line.py
+++ b/cdds/cdds/qc/command_line.py
@@ -134,7 +134,7 @@ def run_and_report(args: Namespace, request: Request) -> dict:  # TODO: kerstin 
     logger = logging.getLogger()
     output_dir = component_directory(request, 'qualitycheck') if request.misc.use_proc_dir else args.output_dir
     logger.info('Writing report to {}'.format(output_dir))
-    db_path = os.path.join(output_dir, QC_DB_FILENAME)
+    db_path = os.path.join(output_dir, f"qc_{args.stream}.db")
 
     basedir = output_data_directory(request)
     cdds_runner = QCRunner(db_path)

--- a/cdds/cdds/qc/command_line.py
+++ b/cdds/cdds/qc/command_line.py
@@ -134,7 +134,7 @@ def run_and_report(args: Namespace, request: Request) -> dict:  # TODO: kerstin 
     logger = logging.getLogger()
     output_dir = component_directory(request, 'qualitycheck') if request.misc.use_proc_dir else args.output_dir
     logger.info('Writing report to {}'.format(output_dir))
-    db_path = os.path.join(output_dir, f"qc_{args.stream}.db")
+    db_path = os.path.join(output_dir, QC_DB_FILENAME.format(stream_id=args.stream))
 
     basedir = output_data_directory(request)
     cdds_runner = QCRunner(db_path)

--- a/cdds/cdds/qc/constants.py
+++ b/cdds/cdds/qc/constants.py
@@ -42,7 +42,7 @@ DIURNAL_OFFSETS = [
     30,
     29,
 ]
-QC_DB_FILENAME = 'qc.db'
+QC_DB_FILENAME = 'qc_{stream_id}.db'
 QC_REPORT_FILENAME = 'report_{dt}.json'
 QC_REPORT_STREAM_FILENAME = 'report_{stream_id}_{dt}.json'
 RADIATION_TIMESTEP = 1.0 / 24.0  # 1 hour as a fractional day

--- a/cdds/cdds/qc/models.py
+++ b/cdds/cdds/qc/models.py
@@ -5,13 +5,13 @@
 import sqlite3
 import os
 from cdds.qc.constants import (
-    QC_DB_FILENAME, STATUS_WARNING, STATUS_ERROR, STATUS_IGNORED,
+    STATUS_WARNING, STATUS_ERROR, STATUS_IGNORED,
     DS_TYPE_SINGLE_FILE, DS_TYPE_DATASET, SUMMARY_STARTED,
     SUMMARY_FAILED, SUMMARY_PASSED
 )
 
 
-def setup_db(db_file=QC_DB_FILENAME):
+def setup_db(db_file):
     """
     Initialises a qc database.
 


### PR DESCRIPTION
This fixes a race condition occasionally seen when two `run_qc_*` tasks run at the same time and try to write to the same `.db`

```
Using CDDS QC version 2.5.2
Writing report to /project/cdds/proc/CMIP6/DAMIP/HadGEM3-GC31-LL_hist-nat_r14i1p1f3/round-1/qualitycheck
table qc_run already exists
Traceback (most recent call last):
  File "/home/h03/cdds/software/miniconda3/envs/cdds-2.5.2/lib/python3.8/site-packages/cdds/qc/command_line.py", line 50, in main_quality_control
    report = run_and_report(args, request)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-2.5.2/lib/python3.8/site-packages/cdds/qc/command_line.py", line 178, in run_and_report
    cdds_runner = QCRunner(db_path)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-2.5.2/lib/python3.8/site-packages/cdds/qc/runner.py", line 47, in __init__
    self.db = setup_db(db_path)
  File "/home/h03/cdds/software/miniconda3/envs/cdds-2.5.2/lib/python3.8/site-packages/cdds/qc/models.py", line 78, in setup_db
    cursor.execute(command)
sqlite3.OperationalError: table qc_run already exists
[FAIL] . $setup; cdds_qc ${REQUEST_JSON_PATH} --root_proc_dir ${ROOT_PROC_DIR} --root_data_dir ${ROOT_DATA_DIR} --use_proc_dir --stream ${STREAM} ${RELAXED_CMOR_OPTION} # return-code=1
```
This fix simply writes a separate `.db` for each stream, avoiding any possible race conditions.
