### PR TITLE
CDDSO-631 Fix for archiving when sub-experiment id is not none

### DIFF
--- a/cdds/cdds/archive/mass.py
+++ b/cdds/cdds/archive/mass.py
@@ -93,8 +93,9 @@ def update_memberid_if_needed(request: Request):
         Request information containing sub experiment id and variant label
     """
     logger = logging.getLogger(__name__)
-    if request.metadata.sub_experiment_id != 'none':
-        member_id = '{}-{}'.format(request.metadata.sub_experiment_id, request.metadata.variant_label)
+    sub_experiment_id = request.metadata.sub_experiment_id
+    if sub_experiment_id != 'none' and sub_experiment_id not in request.metadata.variant_label:
+        member_id = '{}-{}'.format(sub_experiment_id, request.metadata.variant_label)
         request.metadata.variant_label = member_id
         logger.debug('Updated variant_label to be complete member id "{}"'.format(member_id))
 

--- a/cdds/cdds/tests/test_archive/test_mass.py
+++ b/cdds/cdds/tests/test_archive/test_mass.py
@@ -86,6 +86,24 @@ class TestMassPaths(unittest.TestCase):
         for ref_var, out_var in zip(reference_vars, output_vars):
             self.assertDictEqual(ref_var, out_var)
 
+    def test_update_memberid_no_subexpt(self):
+        # no sub experiment id
+        self.assertEqual(self.request.metadata.sub_experiment_id, 'none')
+        cdds.archive.mass.update_memberid_if_needed(self.request)
+        expected_member_id = 'dummyvariant'
+        self.assertEqual(self.request.metadata.variant_label, expected_member_id)
+    
+    def test_update_memberid_subexpt(self):
+        # first time should add sub experiment id as prefix
+        self.request.metadata.sub_experiment_id = 'this'
+        cdds.archive.mass.update_memberid_if_needed(self.request)
+        expected_member_id = 'this-dummyvariant'
+        self.assertEqual(self.request.metadata.variant_label, expected_member_id)
+        # second time should do nothing
+        cdds.archive.mass.update_memberid_if_needed(self.request)
+        expected_member_id = 'this-dummyvariant'
+        self.assertEqual(self.request.metadata.variant_label, expected_member_id)
+
     def test_get_stored_data(self):
         root_mass_path = 'moose://dummy/path/to/archived/file'
         state_id = 'EMBARGOED'

--- a/cdds/cdds/tests/test_archive/test_mass.py
+++ b/cdds/cdds/tests/test_archive/test_mass.py
@@ -92,7 +92,7 @@ class TestMassPaths(unittest.TestCase):
         cdds.archive.mass.update_memberid_if_needed(self.request)
         expected_member_id = 'dummyvariant'
         self.assertEqual(self.request.metadata.variant_label, expected_member_id)
-    
+
     def test_update_memberid_subexpt(self):
         # first time should add sub experiment id as prefix
         self.request.metadata.sub_experiment_id = 'this'


### PR DESCRIPTION
Between v2.5.8 and v3.1.0 something has changed in the code that constructs the member id for use in the archiving, leading to a sequence of directories such as 


```
.../CMIP6/DCPP/MOHC/HadGEM3-GC31-MM/dcppB-forecast/s2024-r1i1p1f3
.../CMIP6/DCPP/MOHC/HadGEM3-GC31-MM/dcppB-forecast/s2024-s2024-r1i1p1f3
.../CMIP6/DCPP/MOHC/HadGEM3-GC31-MM/dcppB-forecast/s2024-s2024-s2024-r1i1p1f3
...
.../CMIP6/DCPP/MOHC/HadGEM3-GC31-MM/dcppB-forecast/s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-s2024-r1i1p1f3
```
This is down to the update_memberid_if_needed() function in cdds.archive.mass being repeatedly applied and not checking if the member id had already been constructed correctly.

Change includes fix plus some tests.