### PR TITLE
CDDSO-633 cmor downgrade

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
-name: cdds-3.1_dev-1
+name: cdds-3.1_dev-2
 channels:
   - conda-forge
-  # - nodefaults include when accessible
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - _openmp_mutex=4.5=2_gnu
   - alabaster=0.7.16=pyhd8ed1ab_0
   - antlr-python-runtime=4.11.1=pyhd8ed1ab_0
-  - attrs=25.1.0=pyh71513ae_0
+  - attrs=25.3.0=pyh71513ae_0
   - babel=2.17.0=pyhd8ed1ab_0
   - blosc=1.21.6=he440d0b_1
   - brotli=1.1.0=hb9d3cd8_2
@@ -17,7 +17,7 @@ dependencies:
   - c-ares=1.34.4=hb9d3cd8_0
   - ca-certificates=2025.1.31=hbcca054_0
   - cartopy=0.24.0=py310h5eaa309_0
-  - certifi=2024.12.14=pyhd8ed1ab_0
+  - certifi=2025.1.31=pyhd8ed1ab_0
   - cf-units=3.2.0=py310hf462985_6
   - cffi=1.17.1=py310h8deb56e_0
   - cfgv=3.3.1=pyhd8ed1ab_1
@@ -25,25 +25,25 @@ dependencies:
   - charset-normalizer=3.4.1=pyhd8ed1ab_0
   - click=8.1.8=pyh707e725_0
   - cloudpickle=3.1.1=pyhd8ed1ab_0
-  - cmor=3.9.0=py310hdd51eb4_4
+  - cmor=3.8.0=py310h4d2ae63_2
   - colorama=0.4.6=pyhd8ed1ab_1
   - compliance-checker=4.3.4=pyhd8ed1ab_0
   - contourpy=1.3.1=py310h3788b33_0
-  - coverage=7.6.10=py310h89163eb_0
-  - curl=8.11.1=h332b0f4_0
+  - coverage=7.7.0=py310h89163eb_0
+  - curl=8.12.1=h332b0f4_0
   - cycler=0.12.1=pyhd8ed1ab_1
   - dask-core=2023.5.1=pyhd8ed1ab_0
   - debugpy=1.6.6=py310heca2aa9_0
   - distlib=0.3.9=pyhd8ed1ab_1
   - docutils=0.17.1=py310hff52083_7
   - esmf=8.8.0=nompi_h4441c20_0
-  - filelock=3.17.0=pyhd8ed1ab_0
-  - fonttools=4.55.8=py310h89163eb_0
-  - freetype=2.12.1=h267a509_2
-  - fsspec=2025.2.0=pyhd8ed1ab_0
-  - geos=3.13.0=h5888daf_0
+  - filelock=3.18.0=pyhd8ed1ab_0
+  - fonttools=4.56.0=py310h89163eb_0
+  - freetype=2.13.3=h48d6fc4_0
+  - fsspec=2025.3.0=pyhd8ed1ab_0
+  - geos=3.13.1=h97f6797_0
   - ghp-import=2.1.0=pyhd8ed1ab_2
-  - griffe=1.5.6=pyhd8ed1ab_0
+  - griffe=1.6.0=pyhd8ed1ab_0
   - gsl=2.7=he838d99_0
   - gsw=3.6.19=py310hf462985_1
   - h2=4.2.0=pyhd8ed1ab_0
@@ -51,7 +51,8 @@ dependencies:
   - hdf5=1.14.3=nompi_h2d575fe_109
   - hpack=4.1.0=pyhd8ed1ab_0
   - hyperframe=6.1.0=pyhd8ed1ab_0
-  - identify=2.6.6=pyhd8ed1ab_0
+  - icu=75.1=he02047a_0
+  - identify=2.6.9=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_1
   - imagesize=1.4.1=pyhd8ed1ab_0
   - importlib-metadata=8.6.1=pyha770c72_0
@@ -61,13 +62,13 @@ dependencies:
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - iris=3.7.1=pyha770c72_0
   - isodate=0.7.2=pyhd8ed1ab_1
-  - jinja2=3.1.5=pyhd8ed1ab_0
-  - json-c=0.18=h6688a6e_0
+  - jinja2=3.1.6=pyhd8ed1ab_0
+  - json-c=0.17=h1220068_1
   - keyutils=1.6.1=h166bdaf_0
   - kiwisolver=1.4.7=py310h3788b33_0
   - krb5=1.21.3=h659f571_0
   - lcms2=2.15=haa2dc70_1
-  - ld_impl_linux-64=2.43=h712a8e2_2
+  - ld_impl_linux-64=2.43=h712a8e2_4
   - lerc=4.0.0=h27087fc_0
   - libaec=1.1.3=h59595ed_0
   - libblas=3.9.0=20_linux64_openblas
@@ -75,19 +76,19 @@ dependencies:
   - libbrotlidec=1.1.0=hb9d3cd8_2
   - libbrotlienc=1.1.0=hb9d3cd8_2
   - libcblas=3.9.0=20_linux64_openblas
-  - libcurl=8.11.1=h332b0f4_0
+  - libcurl=8.12.1=h332b0f4_0
   - libdeflate=1.18=h0b41bf4_0
   - libedit=3.1.20250104=pl5321h7949ede_0
   - libev=4.33=hd590300_2
   - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.2=h7f98852_5
-  - libgcc=14.2.0=h77fa898_1
-  - libgcc-ng=14.2.0=h69a702a_1
-  - libgfortran=14.2.0=h69a702a_1
-  - libgfortran-ng=14.2.0=h69a702a_1
-  - libgfortran5=14.2.0=hd5240d6_1
-  - libgomp=14.2.0=h77fa898_1
-  - libiconv=1.17=hd590300_2
+  - libffi=3.4.6=h2dba641_0
+  - libgcc=14.2.0=h767d61c_2
+  - libgcc-ng=14.2.0=h69a702a_2
+  - libgfortran=14.2.0=h69a702a_2
+  - libgfortran-ng=14.2.0=h69a702a_2
+  - libgfortran5=14.2.0=hf1ad2bd_2
+  - libgomp=14.2.0=h767d61c_2
+  - libiconv=1.18=h4ce23a2_1
   - libjpeg-turbo=2.1.5.1=hd590300_1
   - liblapack=3.9.0=20_linux64_openblas
   - liblzma=5.6.4=hb9d3cd8_0
@@ -97,28 +98,28 @@ dependencies:
   - libnghttp2=1.64.0=h161d5f1_0
   - libnsl=2.0.1=hd590300_0
   - libopenblas=0.3.25=pthreads_h413a1c8_0
-  - libpng=1.6.46=h943b412_0
-  - libsqlite=3.48.0=hee588c1_1
+  - libpng=1.6.47=h943b412_0
+  - libsqlite=3.49.1=hee588c1_2
   - libssh2=1.11.1=hf672d98_0
-  - libstdcxx=14.2.0=hc0a3c3a_1
-  - libstdcxx-ng=14.2.0=h4852527_1
+  - libstdcxx=14.2.0=h8f9b012_2
+  - libstdcxx-ng=14.2.0=h4852527_2
   - libtiff=4.5.1=h8b53f26_1
   - libudunits2=2.2.28=h40f5838_3
   - libuuid=2.38.1=h0b41bf4_0
   - libwebp-base=1.5.0=h851e524_0
   - libxcb=1.15=h0b41bf4_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.13.5=h0d44e9d_1
+  - libxml2=2.13.6=h8d12d68_0
   - libxslt=1.1.39=h76b75d6_0
   - libzip=1.11.2=h6991a6a_0
   - libzlib=1.3.1=hb9d3cd8_2
   - locket=1.0.0=pyhd8ed1ab_0
-  - lxml=5.3.0=py310h6ee67d5_2
+  - lxml=5.3.1=py310h6ee67d5_0
   - lz4-c=1.10.0=h5888daf_1
   - markdown=3.5.2=pyhd8ed1ab_0
   - markdown-it-py=2.2.0=pyhd8ed1ab_0
   - markupsafe=3.0.2=py310h89163eb_1
-  - matplotlib-base=3.10.0=py310h68603db_0
+  - matplotlib-base=3.10.1=py310h68603db_0
   - mdit-py-plugins=0.4.2=pyhd8ed1ab_1
   - mdurl=0.1.2=pyhd8ed1ab_1
   - mergedeep=1.3.4=pyhd8ed1ab_1
@@ -137,7 +138,7 @@ dependencies:
   - mypy=0.981=py310h5764c6d_0
   - mypy_extensions=0.4.3=py310hff52083_6
   - myst-parser=0.18.1=pyhd8ed1ab_0
-  - nccmp=1.9.1.0=hd7f915c_6
+  - nccmp=1.9.1.0=h315b275_7
   - nco=5.3.2=h657489c_0
   - ncurses=6.5=h2d0b736_3
   - netcdf-fortran=4.6.1=nompi_h22f9119_108
@@ -146,7 +147,7 @@ dependencies:
   - numpy=1.24.4=py310ha4c1d20_0
   - openblas=0.3.25=pthreads_h7a3da1a_0
   - openjpeg=2.5.0=hfec8fc6_2
-  - openssl=3.4.0=h7b32b05_1
+  - openssl=3.4.1=h7b32b05_0
   - owslib=0.32.1=pyhd8ed1ab_0
   - packaging=24.2=pyhd8ed1ab_2
   - pandas=2.0.3=py310h7cbd5c2_1
@@ -162,7 +163,7 @@ dependencies:
   - pooch=1.8.2=pyhd8ed1ab_1
   - pre-commit=2.20.0=py310hff52083_1
   - proj=9.2.0=h8ffa02c_0
-  - psutil=6.1.1=py310ha75aee5_0
+  - psutil=7.0.0=py310ha75aee5_0
   - pthread-stubs=0.4=hb9d3cd8_1002
   - py=1.11.0=pyhd8ed1ab_1
   - pyaml=25.1.0=pyhd8ed1ab_0
@@ -180,18 +181,18 @@ dependencies:
   - python=3.10.14=hd12c33a_0_cpython
   - python-dateutil=2.9.0.post0=pyhff2d567_1
   - python-tzdata=2025.1=pyhd8ed1ab_0
-  - python-xxhash=3.5.0=py310ha75aee5_1
+  - python-xxhash=3.5.0=py310ha75aee5_2
   - python_abi=3.10=5_cp310
   - pytz=2025.1=pyhd8ed1ab_0
   - pyyaml=6.0.2=py310h89163eb_2
   - pyyaml-env-tag=0.1=pyhd8ed1ab_1
   - qhull=2020.2=h434a139_5
-  - readline=8.2=h8228510_1
+  - readline=8.2=h8c095d6_2
   - regex=2024.11.6=py310ha75aee5_0
   - requests=2.32.3=pyhd8ed1ab_1
   - scipy=1.10.1=py310ha4c1d20_3
-  - setuptools=75.8.0=pyhff2d567_0
-  - shapely=2.0.7=py310had3dfd6_0
+  - setuptools=75.8.2=pyhff2d567_0
+  - shapely=2.0.7=py310h247727d_1
   - six=1.17.0=pyhd8ed1ab_0
   - snappy=1.2.1=h8bd8927_1
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
@@ -202,7 +203,7 @@ dependencies:
   - sphinxcontrib-jsmath=1.0.1=pyhd8ed1ab_1
   - sphinxcontrib-qthelp=1.0.3=py_0
   - sphinxcontrib-serializinghtml=1.1.5=pyhd8ed1ab_2
-  - sqlite=3.48.0=h9eae976_1
+  - sqlite=3.49.1=h9eae976_2
   - tempest-remap=2.2.0=heeae502_5
   - time-machine=2.16.0=py310ha75aee5_0
   - tk=8.6.13=noxft_h4845f30_101
@@ -218,20 +219,20 @@ dependencies:
   - urllib3=2.3.0=pyhd8ed1ab_0
   - validators=0.34.0=pyhd8ed1ab_1
   - verspec=0.1.0=pyh29332c3_2
-  - virtualenv=20.29.1=pyhd8ed1ab_0
+  - virtualenv=20.29.3=pyhd8ed1ab_0
   - watchdog=6.0.0=py310hff52083_0
   - wheel=0.45.1=pyhd8ed1ab_1
   - xorg-libxau=1.0.12=hb9d3cd8_0
   - xorg-libxdmcp=1.1.5=hb9d3cd8_0
-  - xxhash=0.8.2=hd590300_0
+  - xxhash=0.8.3=hb9d3cd8_0
   - xz=5.6.4=hbcc6ac9_0
   - xz-gpl-tools=5.6.4=hbcc6ac9_0
   - xz-tools=5.6.4=hb9d3cd8_0
   - yaml=0.2.5=h7f98852_2
   - zipp=3.21.0=pyhd8ed1ab_1
   - zlib=1.3.1=hb9d3cd8_2
-  - zstandard=0.23.0=py310ha39cb0e_1
-  - zstd=1.5.6=ha6fb4c9_0
+  - zstandard=0.23.0=py310ha75aee5_1
+  - zstd=1.5.7=hb8e6e7a_1
   - pip:
     - dreqpy==1.0.29
     - mkdocs-section-index==0.3.8
@@ -242,4 +243,4 @@ variables:
   CYLC_VERSION: 8
   LC_ALL: en_GB.UTF-8
   TZ: UTC
-prefix: /home/users/cdds/conda_environments/cdds-3.1_dev-1
+prefix: /home/users/cdds/conda_environments/cdds-3.1_dev-2

--- a/environment.yml
+++ b/environment.yml
@@ -239,8 +239,8 @@ dependencies:
     #- git+ssh://git@github.com-deploy/MetOffice/CDDS.git@v<location>#egg=cdds&subdirectory=cdds
     #- git+ssh://git@github.com-deploy/MetOffice/CDDS.git@v<location>#egg=mip_convert&subdirectory=mip_convert
 variables:
-  CDDS_ETC: /home/users/cdds/etc
+  CDDS_ETC: $CDDS_HOME/etc
   CYLC_VERSION: 8
   LC_ALL: en_GB.UTF-8
   TZ: UTC
-prefix: /home/users/cdds/conda_environments/cdds-3.1_dev-2
+prefix: $CDDS_HOME/conda_environments/cdds-3.1_dev-2

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,4 +1,4 @@
-name: /home/users/cdds/conda_environments/cdds-3.1_dev-2
+name: $CDDS_HOME/conda_environments/cdds-3.1_dev-2
 channels:
   - conda-forge
   - nodefaults
@@ -237,8 +237,8 @@ dependencies:
       - dreqpy==1.0.29
       - mkdocs-section-index==0.3.8
 variables:
-  CDDS_ETC: /home/users/cdds/etc
+  CDDS_ETC: $CDDS_HOME/etc
   CYLC_VERSION: 8
   LC_ALL: en_GB.UTF-8
   TZ: UTC
-prefix: /home/users/cdds/conda_environments/cdds-3.1_dev-2
+prefix: $CDDS_HOME/conda_environments/cdds-3.1_dev-2

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,13 +1,13 @@
-name: cdds-3.1_dev-1
+name: /home/users/cdds/conda_environments/cdds-3.1_dev-2
 channels:
   - conda-forge
-  # - nodefaults include when accessible
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - alabaster=0.7.16=pyhd8ed1ab_0
   - antlr-python-runtime=4.11.1=pyhd8ed1ab_0
-  - attrs=25.1.0=pyh71513ae_0
+  - attrs=25.3.0=pyh71513ae_0
   - babel=2.17.0=pyhd8ed1ab_0
   - blosc=1.21.6=he440d0b_1
   - brotli=1.1.0=hb9d3cd8_2
@@ -17,7 +17,7 @@ dependencies:
   - c-ares=1.34.4=hb9d3cd8_0
   - ca-certificates=2025.1.31=hbcca054_0
   - cartopy=0.24.0=py310h5eaa309_0
-  - certifi=2024.12.14=pyhd8ed1ab_0
+  - certifi=2025.1.31=pyhd8ed1ab_0
   - cf-units=3.2.0=py310hf462985_6
   - cffi=1.17.1=py310h8deb56e_0
   - cfgv=3.3.1=pyhd8ed1ab_1
@@ -25,25 +25,25 @@ dependencies:
   - charset-normalizer=3.4.1=pyhd8ed1ab_0
   - click=8.1.8=pyh707e725_0
   - cloudpickle=3.1.1=pyhd8ed1ab_0
-  - cmor=3.9.0=py310hdd51eb4_4
+  - cmor=3.8.0=py310h4d2ae63_2
   - colorama=0.4.6=pyhd8ed1ab_1
   - compliance-checker=4.3.4=pyhd8ed1ab_0
   - contourpy=1.3.1=py310h3788b33_0
-  - coverage=7.6.10=py310h89163eb_0
-  - curl=8.11.1=h332b0f4_0
+  - coverage=7.7.0=py310h89163eb_0
+  - curl=8.12.1=h332b0f4_0
   - cycler=0.12.1=pyhd8ed1ab_1
   - dask-core=2023.5.1=pyhd8ed1ab_0
   - debugpy=1.6.6=py310heca2aa9_0
   - distlib=0.3.9=pyhd8ed1ab_1
   - docutils=0.17.1=py310hff52083_7
   - esmf=8.8.0=nompi_h4441c20_0
-  - filelock=3.17.0=pyhd8ed1ab_0
-  - fonttools=4.55.8=py310h89163eb_0
-  - freetype=2.12.1=h267a509_2
-  - fsspec=2025.2.0=pyhd8ed1ab_0
-  - geos=3.13.0=h5888daf_0
+  - filelock=3.18.0=pyhd8ed1ab_0
+  - fonttools=4.56.0=py310h89163eb_0
+  - freetype=2.13.3=h48d6fc4_0
+  - fsspec=2025.3.0=pyhd8ed1ab_0
+  - geos=3.13.1=h97f6797_0
   - ghp-import=2.1.0=pyhd8ed1ab_2
-  - griffe=1.5.6=pyhd8ed1ab_0
+  - griffe=1.6.0=pyhd8ed1ab_0
   - gsl=2.7=he838d99_0
   - gsw=3.6.19=py310hf462985_1
   - h2=4.2.0=pyhd8ed1ab_0
@@ -51,7 +51,8 @@ dependencies:
   - hdf5=1.14.3=nompi_h2d575fe_109
   - hpack=4.1.0=pyhd8ed1ab_0
   - hyperframe=6.1.0=pyhd8ed1ab_0
-  - identify=2.6.6=pyhd8ed1ab_0
+  - icu=75.1=he02047a_0
+  - identify=2.6.9=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_1
   - imagesize=1.4.1=pyhd8ed1ab_0
   - importlib-metadata=8.6.1=pyha770c72_0
@@ -61,13 +62,13 @@ dependencies:
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - iris=3.7.1=pyha770c72_0
   - isodate=0.7.2=pyhd8ed1ab_1
-  - jinja2=3.1.5=pyhd8ed1ab_0
-  - json-c=0.18=h6688a6e_0
+  - jinja2=3.1.6=pyhd8ed1ab_0
+  - json-c=0.17=h1220068_1
   - keyutils=1.6.1=h166bdaf_0
   - kiwisolver=1.4.7=py310h3788b33_0
   - krb5=1.21.3=h659f571_0
   - lcms2=2.15=haa2dc70_1
-  - ld_impl_linux-64=2.43=h712a8e2_2
+  - ld_impl_linux-64=2.43=h712a8e2_4
   - lerc=4.0.0=h27087fc_0
   - libaec=1.1.3=h59595ed_0
   - libblas=3.9.0=20_linux64_openblas
@@ -75,19 +76,19 @@ dependencies:
   - libbrotlidec=1.1.0=hb9d3cd8_2
   - libbrotlienc=1.1.0=hb9d3cd8_2
   - libcblas=3.9.0=20_linux64_openblas
-  - libcurl=8.11.1=h332b0f4_0
+  - libcurl=8.12.1=h332b0f4_0
   - libdeflate=1.18=h0b41bf4_0
   - libedit=3.1.20250104=pl5321h7949ede_0
   - libev=4.33=hd590300_2
   - libexpat=2.6.4=h5888daf_0
-  - libffi=3.4.2=h7f98852_5
-  - libgcc=14.2.0=h77fa898_1
-  - libgcc-ng=14.2.0=h69a702a_1
-  - libgfortran=14.2.0=h69a702a_1
-  - libgfortran-ng=14.2.0=h69a702a_1
-  - libgfortran5=14.2.0=hd5240d6_1
-  - libgomp=14.2.0=h77fa898_1
-  - libiconv=1.17=hd590300_2
+  - libffi=3.4.6=h2dba641_0
+  - libgcc=14.2.0=h767d61c_2
+  - libgcc-ng=14.2.0=h69a702a_2
+  - libgfortran=14.2.0=h69a702a_2
+  - libgfortran-ng=14.2.0=h69a702a_2
+  - libgfortran5=14.2.0=hf1ad2bd_2
+  - libgomp=14.2.0=h767d61c_2
+  - libiconv=1.18=h4ce23a2_1
   - libjpeg-turbo=2.1.5.1=hd590300_1
   - liblapack=3.9.0=20_linux64_openblas
   - liblzma=5.6.4=hb9d3cd8_0
@@ -97,28 +98,28 @@ dependencies:
   - libnghttp2=1.64.0=h161d5f1_0
   - libnsl=2.0.1=hd590300_0
   - libopenblas=0.3.25=pthreads_h413a1c8_0
-  - libpng=1.6.46=h943b412_0
-  - libsqlite=3.48.0=hee588c1_1
+  - libpng=1.6.47=h943b412_0
+  - libsqlite=3.49.1=hee588c1_2
   - libssh2=1.11.1=hf672d98_0
-  - libstdcxx=14.2.0=hc0a3c3a_1
-  - libstdcxx-ng=14.2.0=h4852527_1
+  - libstdcxx=14.2.0=h8f9b012_2
+  - libstdcxx-ng=14.2.0=h4852527_2
   - libtiff=4.5.1=h8b53f26_1
   - libudunits2=2.2.28=h40f5838_3
   - libuuid=2.38.1=h0b41bf4_0
   - libwebp-base=1.5.0=h851e524_0
   - libxcb=1.15=h0b41bf4_0
   - libxcrypt=4.4.36=hd590300_1
-  - libxml2=2.13.5=h0d44e9d_1
+  - libxml2=2.13.6=h8d12d68_0
   - libxslt=1.1.39=h76b75d6_0
   - libzip=1.11.2=h6991a6a_0
   - libzlib=1.3.1=hb9d3cd8_2
   - locket=1.0.0=pyhd8ed1ab_0
-  - lxml=5.3.0=py310h6ee67d5_2
+  - lxml=5.3.1=py310h6ee67d5_0
   - lz4-c=1.10.0=h5888daf_1
   - markdown=3.5.2=pyhd8ed1ab_0
   - markdown-it-py=2.2.0=pyhd8ed1ab_0
   - markupsafe=3.0.2=py310h89163eb_1
-  - matplotlib-base=3.10.0=py310h68603db_0
+  - matplotlib-base=3.10.1=py310h68603db_0
   - mdit-py-plugins=0.4.2=pyhd8ed1ab_1
   - mdurl=0.1.2=pyhd8ed1ab_1
   - mergedeep=1.3.4=pyhd8ed1ab_1
@@ -137,7 +138,7 @@ dependencies:
   - mypy=0.981=py310h5764c6d_0
   - mypy_extensions=0.4.3=py310hff52083_6
   - myst-parser=0.18.1=pyhd8ed1ab_0
-  - nccmp=1.9.1.0=hd7f915c_6
+  - nccmp=1.9.1.0=h315b275_7
   - nco=5.3.2=h657489c_0
   - ncurses=6.5=h2d0b736_3
   - netcdf-fortran=4.6.1=nompi_h22f9119_108
@@ -146,7 +147,7 @@ dependencies:
   - numpy=1.24.4=py310ha4c1d20_0
   - openblas=0.3.25=pthreads_h7a3da1a_0
   - openjpeg=2.5.0=hfec8fc6_2
-  - openssl=3.4.0=h7b32b05_1
+  - openssl=3.4.1=h7b32b05_0
   - owslib=0.32.1=pyhd8ed1ab_0
   - packaging=24.2=pyhd8ed1ab_2
   - pandas=2.0.3=py310h7cbd5c2_1
@@ -162,7 +163,7 @@ dependencies:
   - pooch=1.8.2=pyhd8ed1ab_1
   - pre-commit=2.20.0=py310hff52083_1
   - proj=9.2.0=h8ffa02c_0
-  - psutil=6.1.1=py310ha75aee5_0
+  - psutil=7.0.0=py310ha75aee5_0
   - pthread-stubs=0.4=hb9d3cd8_1002
   - py=1.11.0=pyhd8ed1ab_1
   - pyaml=25.1.0=pyhd8ed1ab_0
@@ -180,18 +181,18 @@ dependencies:
   - python=3.10.14=hd12c33a_0_cpython
   - python-dateutil=2.9.0.post0=pyhff2d567_1
   - python-tzdata=2025.1=pyhd8ed1ab_0
-  - python-xxhash=3.5.0=py310ha75aee5_1
+  - python-xxhash=3.5.0=py310ha75aee5_2
   - python_abi=3.10=5_cp310
   - pytz=2025.1=pyhd8ed1ab_0
   - pyyaml=6.0.2=py310h89163eb_2
   - pyyaml-env-tag=0.1=pyhd8ed1ab_1
   - qhull=2020.2=h434a139_5
-  - readline=8.2=h8228510_1
+  - readline=8.2=h8c095d6_2
   - regex=2024.11.6=py310ha75aee5_0
   - requests=2.32.3=pyhd8ed1ab_1
   - scipy=1.10.1=py310ha4c1d20_3
-  - setuptools=75.8.0=pyhff2d567_0
-  - shapely=2.0.7=py310had3dfd6_0
+  - setuptools=75.8.2=pyhff2d567_0
+  - shapely=2.0.7=py310h247727d_1
   - six=1.17.0=pyhd8ed1ab_0
   - snappy=1.2.1=h8bd8927_1
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
@@ -202,7 +203,7 @@ dependencies:
   - sphinxcontrib-jsmath=1.0.1=pyhd8ed1ab_1
   - sphinxcontrib-qthelp=1.0.3=py_0
   - sphinxcontrib-serializinghtml=1.1.5=pyhd8ed1ab_2
-  - sqlite=3.48.0=h9eae976_1
+  - sqlite=3.49.1=h9eae976_2
   - tempest-remap=2.2.0=heeae502_5
   - time-machine=2.16.0=py310ha75aee5_0
   - tk=8.6.13=noxft_h4845f30_101
@@ -218,26 +219,26 @@ dependencies:
   - urllib3=2.3.0=pyhd8ed1ab_0
   - validators=0.34.0=pyhd8ed1ab_1
   - verspec=0.1.0=pyh29332c3_2
-  - virtualenv=20.29.1=pyhd8ed1ab_0
+  - virtualenv=20.29.3=pyhd8ed1ab_0
   - watchdog=6.0.0=py310hff52083_0
   - wheel=0.45.1=pyhd8ed1ab_1
   - xorg-libxau=1.0.12=hb9d3cd8_0
   - xorg-libxdmcp=1.1.5=hb9d3cd8_0
-  - xxhash=0.8.2=hd590300_0
+  - xxhash=0.8.3=hb9d3cd8_0
   - xz=5.6.4=hbcc6ac9_0
   - xz-gpl-tools=5.6.4=hbcc6ac9_0
   - xz-tools=5.6.4=hb9d3cd8_0
   - yaml=0.2.5=h7f98852_2
   - zipp=3.21.0=pyhd8ed1ab_1
   - zlib=1.3.1=hb9d3cd8_2
-  - zstandard=0.23.0=py310ha39cb0e_1
-  - zstd=1.5.6=ha6fb4c9_0
+  - zstandard=0.23.0=py310ha75aee5_1
+  - zstd=1.5.7=hb8e6e7a_1
   - pip:
-    - dreqpy==1.0.29
-    - mkdocs-section-index==0.3.8
+      - dreqpy==1.0.29
+      - mkdocs-section-index==0.3.8
 variables:
   CDDS_ETC: /home/users/cdds/etc
   CYLC_VERSION: 8
   LC_ALL: en_GB.UTF-8
   TZ: UTC
-prefix: /home/users/cdds/conda_environments/cdds-3.1_dev-1
+prefix: /home/users/cdds/conda_environments/cdds-3.1_dev-2

--- a/environment_minimal.yml
+++ b/environment_minimal.yml
@@ -1,11 +1,11 @@
 name: cdds-dev
 channels:
   - conda-forge
-  # - nodefaults include when accessible
+  - nodefaults 
 dependencies:
   - cf-units=3.2.0
   - cftime=1.6.2
-  - cmor=3.9.0
+  - cmor=3.8.0
   - compliance-checker=4.3.4
   - dask-core=2023.5
   - debugpy=1.6.6

--- a/environment_minimal.yml
+++ b/environment_minimal.yml
@@ -49,8 +49,8 @@ dependencies:
 #    - git+ssh://git@github.com-deploy/MetOffice/CDDS.git@v<location>#egg=cdds
 #    - git+ssh://git@github.com-deploy/MetOffice/CDDS.git@v<location>#egg=mip_convert&subdirectory=mip_convert
 variables:
-    CDDS_ETC: /home/users/cdds/etc
+    CDDS_ETC: $CDDS_HOME/etc
     CYLC_VERSION: 8
     LC_ALL: en_GB.UTF-8
     TZ: UTC
-prefix: /home/users/cdds/conda_environments/cdds-dev
+prefix: $CDDS_HOME/conda_environments/cdds-dev

--- a/mip_convert/mip_convert/process/RAMIPday_mappings.cfg
+++ b/mip_convert/mip_convert/process/RAMIPday_mappings.cfg
@@ -1,5 +1,5 @@
-# (C) British Crown Copyright 2018, Met Office.
-# Please see LICENSE.rst for license details.
+# (C) British Crown Copyright 2018-2025, Met Office.
+# Please see LICENSE.md for license details.
 #
 # This 'model to MIP mappings' configuration file contains sections
 # for each 'MIP requested variable name' that has an RAMIPday

--- a/setup_env_for_devel
+++ b/setup_env_for_devel
@@ -6,7 +6,7 @@ export CDDS_PACKAGES="cdds mip_convert"
 export CDDS_PACKAGES
 
 CDDS_HOME=$(readlink -f ~cdds)
-DEV_ENV='cdds-3.1_dev-1'
+DEV_ENV='cdds-3.1_dev-2'
 
 if [[ "$(hostname -f)" =~ "spice.sc" ]]; then
     CONDA=/opt/conda/bin/activate

--- a/setup_env_for_devel
+++ b/setup_env_for_devel
@@ -10,7 +10,7 @@ DEV_ENV='cdds-3.1_dev-2'
 
 if [[ "$(hostname -f)" =~ "spice.sc" ]]; then
     CONDA=/opt/conda/bin/activate
-    DEV_ENV="/home/users/cdds/conda_environments/${DEV_ENV}"
+    DEV_ENV="$CDDS_HOME/conda_environments/${DEV_ENV}"
 elif [[ "$(hostname -f)" =~ "jasmin" ]]; then
     CONDA=${CDDS_HOME}/software/miniconda3/bin/activate
 else


### PR DESCRIPTION
Downgrading CMOR due to difference in behaviour w.r.t. v3.8 -- intention is to pick up v3.10 as soon as released.

Updates to environments which include removing of absolute paths where possible.

One additional change due to missed test failure (copyright headers) in #435 was causing problems, so that has been fixed too.