### PR TITLE
CDDSO-624 setup script in ensemble processing workflow does not fail properly

### DIFF
--- a/cdds/cdds/workflows/processing/bin/run_cdds_convert
+++ b/cdds/cdds/workflows/processing/bin/run_cdds_convert
@@ -8,4 +8,4 @@ export REQUEST_PATH=${WORKING_DIRECTORY}/request.cfg
 
 cd ${WORKING_DIRECTORY}
 
-cdds_convert "${REQUEST_PATH}"
+cdds_convert "${REQUEST_PATH}" || exit

--- a/cdds/cdds/workflows/processing/bin/run_cdds_setup
+++ b/cdds/cdds/workflows/processing/bin/run_cdds_setup
@@ -24,6 +24,6 @@ fi
 
 export REQUEST_PATH=${WORKING_DIRECTORY}/request.cfg
 
-create_cdds_directory_structure "${WORKING_DIRECTORY}"/request.cfg
+create_cdds_directory_structure "${WORKING_DIRECTORY}"/request.cfg || exit
 
-prepare_generate_variable_list "${REQUEST_PATH}"
+prepare_generate_variable_list "${REQUEST_PATH}" || exit


### PR DESCRIPTION
This should make sure that when `cdds` commands fail within the `run_cdds_setup` and `run_cdds_convert` scripts, the exit code is handled correctly and the cylc task will fail.