### PR TITLE
CDDSO-633 Update failing functional tests

### DIFF
--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_day_zg_deflation.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_day_zg_deflation.py
@@ -63,7 +63,7 @@ class TestCmip6DayZgDeflation(AbstractFunctionalTests):
                     'ap6': {'CMIP6_day': 'zg'}
                 },
                 other={
-                    'reference_version': 'v2',
+                    'reference_version': 'v1',
                     'filenames': ['zg_day_HadGEM3-GC31-LL_highres-future_r1i1p1f1_gn_19500101-19500130.nc'],
                     'ignore_history': True,
                     'other_options': '-e'

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cordex/test_cordex_cmip6_day_hus1000.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cordex/test_cordex_cmip6_day_hus1000.py
@@ -40,7 +40,7 @@ class TestCordexCmip6DayHus1000(AbstractFunctionalTests):
                     'ap6': {'CORDEX-CMIP6_day': 'hus1000'}
                 },
                 other={
-                    'reference_version': 'v2',
+                    'reference_version': 'v1',
                     'filenames': [
                         'hus1000_EUR-11_HadGEM3-GC31-LL_evaluation_r1i1p1f3_MOHC_HadREM3-GA7-05_v1-r1_day_'
                         '20220101-20220230.nc',

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cordex/test_cordex_mon_uv.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cordex/test_cordex_mon_uv.py
@@ -39,7 +39,7 @@ class TestCordexMonUv(AbstractFunctionalTests):
                     'apm': {'CORDEX-CMIP6_mon': 'uas vas'}
                 },
                 other={
-                    'reference_version': 'v2',
+                    'reference_version': 'v1',
                     'filenames': [
                         'uas_EUR-11_HadGEM3-GC31-LL_evaluation_r1i1p1f3_MOHC_HadREM3-GA7-05_v1-r1_mon_200001-200002.nc',
                         'vas_EUR-11_HadGEM3-GC31-LL_evaluation_r1i1p1f3_MOHC_HadREM3-GA7-05_v1-r1_mon_200001-200002.nc'


### PR DESCRIPTION
* Fixing failing tests after downgrade CMOR to 3.8