### PR TITLE
CDDSO-634 Support 365_day calendar

### DIFF
--- a/cdds/cdds/common/request/validations/section_validators.py
+++ b/cdds/cdds/common/request/validations/section_validators.py
@@ -100,7 +100,7 @@ class MetadataSectionValidator(SectionValidator):
     def _validate_allowed_values(self):
         values_allowed_dict = {
             'branch_method': (self.section.branch_method, ['no parent', 'standard']),
-            'calendar': (self.section.calendar, ['360_day', 'gregorian'])
+            'calendar': (self.section.calendar, ['360_day', 'gregorian', '365_day'])
         }
 
         allowed_values_validate = SectionValidatorFactory.allowed_values_validator()

--- a/cdds/cdds/tests/test_common/test_request/validations/test_section_validators.py
+++ b/cdds/cdds/tests/test_common/test_request/validations/test_section_validators.py
@@ -36,7 +36,7 @@ class TestCommonSectionValidator(TestCase):
             'If an external plugin is used the the "external_plugin_location" must be set.'
         ])
 
-    def test_eternal_plugin_failed(self):
+    def test_external_plugin_failed(self):
         self.section.external_plugin_location = '/path/to/external/plugin'
         validator = CommonSectionValidator(section=self.section)
         valid, messages = validator.validate()
@@ -97,7 +97,7 @@ class TestMetdataValidator(TestCase):
         valid, messages = validator.validate()
         self.assertFalse(valid)
         self.assertListEqual(messages, ['The "branch_method" must be set to "no parent, standard".',
-                                        'The "calendar" must be set to "360_day, gregorian".'])
+                                        'The "calendar" must be set to "360_day, gregorian, 365_day".'])
 
     def test_values_not_set(self):
         self.section.mip = ''


### PR DESCRIPTION
* Allow to set `calendar` in the metadata section of the request to `365_day`
* Every other tasks already supports a `365_day` calendar

* See workflow: https://cylchub/services/cylc-review/cycles/kerstin.schmatzer/?suite=cdds_HadREM-CP4A-4p5km_amip_r1i1p1f1_2025-01
  * `extract` task was manually killed and already existing data was copied from filesystem because MASS was really slow
  * Some MIP convert tasks failed because the temp directory is not unique anymore (other issue - not addressed here)
  * Skip `archive` task to avoid overloading MASS