### PR TITLE
CDDSO-644 remove module load nccmp from setup env for dev

### DIFF
--- a/setup_env_for_devel
+++ b/setup_env_for_devel
@@ -3,8 +3,6 @@ CDDS_DIR=${1:-$PWD}
 export CDDS_DIR
 export CDDS_PACKAGES="cdds mip_convert"
 
-export CDDS_PACKAGES
-
 CDDS_HOME=$(readlink -f ~cdds)
 DEV_ENV='cdds-3.1_dev-2'
 
@@ -21,10 +19,6 @@ if [ -f ${CONDA} ]; then
     . ${CONDA} ${DEV_ENV}
 else
     echo "Could not locate CDDS miniconda environment"
-fi
-
-if [[ "$(hostname -f)" =~ "spice.sc" ]]; then
-  module load nccmp
 fi
 
 for CDDS_PACKAGE in $CDDS_PACKAGES


### PR DESCRIPTION
The PR removes a redundant `module load nccmp` from the `setup_env_for_devel` script. (We already have `nccmp` in our conda environment).