### PR TITLE
CDDSO-648: Unify cell_methods when reading ocean data by removing "interval" specifications

### DIFF
--- a/mip_convert/mip_convert/load/iris_load_util.py
+++ b/mip_convert/mip_convert/load/iris_load_util.py
@@ -253,11 +253,9 @@ def load_cube(all_input_data, run_bounds, loadable, replacement_coordinates, anc
 
 
 def remove_cell_methods_intervals(cubes):
-    """Delete cube attributes that are not identical over all cubes in a group.
-
-    This function deletes any attributes which are not the same for all the
-    given cubes.  The cubes will then have identical attributes, and the
-    removed attributes are returned.  The given cubes are modified in-place.
+    """Remove intervals in cell methods in input cubes to avoid problems with
+    concatenation. This has been observed when ocean timesteps have been changed
+    mid year in model runs to avoid grid point storms.
 
     Args:
 
@@ -278,7 +276,7 @@ def remove_cell_methods_intervals(cubes):
 
     # If we have more than one set of cell methods in the cubes
     cell_methods_set = set([cube.cell_methods for cube in cubes])
-    if len(cell_methods_set) >1:
+    if len(cell_methods_set) > 1:
         logger.debug("Attempting to unify cell_methods by removing intervals")
         for cube in cubes:
             # get the cell methods
@@ -297,7 +295,7 @@ def remove_cell_methods_intervals(cubes):
                     logger.debug("overwrote intervals property in '{}'".format(cm))
                 else:
                     new_cellmethods_list.append(cm)
-            
+
             # overwrite cell methods in cube
             if changes:
                 cube.cell_methods = tuple(new_cellmethods_list)

--- a/mip_convert/mip_convert/load/iris_load_util.py
+++ b/mip_convert/mip_convert/load/iris_load_util.py
@@ -257,20 +257,8 @@ def remove_cell_methods_intervals(cubes):
     concatenation. This has been observed when ocean timesteps have been changed
     mid year in model runs to avoid grid point storms.
 
-    Args:
-
-    * cubes (iterable of :class:`iris.cube.Cube`):
-        A collection of cubes to compare and adjust.
-
-    Returns:
-
-    * removed (list):
-        A list of dicts holding the removed attributes.
-
-    Notes
-    ------
-    This function maintains laziness when called; it does not realise data.
-    See more at :doc:`/userguide/real_and_lazy_data`.
+    :param cubes: cube list to check for inconsistent cell method intervals
+    :type cubes: :class:`iris.cube.CubeList`
     """
     logger = logging.getLogger(__name__)
 

--- a/mip_convert/mip_convert/tests/test_load/test_iris_load_util.py
+++ b/mip_convert/mip_convert/tests/test_load/test_iris_load_util.py
@@ -9,12 +9,14 @@ import unittest
 from cftime import datetime
 import iris
 from iris.tests.stock import realistic_3d
+from iris.coords import CellMethod
 
 from cdds.common.constants import ANCIL_VARIABLES
 
 from mip_convert.load.iris_load_util import (
     ConstraintConstructor, pp_filter, compare_values, get_field_value,
-    remove_duplicate_cubes, split_netCDF_filename, rechunk)
+    remove_duplicate_cubes, split_netCDF_filename, rechunk, 
+    remove_cell_methods_intervals)
 from mip_convert.tests.common import DummyField, realistic_3d_atmos
 from mip_convert.new_variable import VariableModelToMIPMapping
 
@@ -477,6 +479,15 @@ class TestRechunking(unittest.TestCase):
         cube = realistic_3d_atmos(30, 324, 432, 85)
         rechunk(cube, {0: 'auto', 1: 20, 2: 324, 3: 432})
         self.assertEqual(cube.lazy_data().chunksize, (5, 20, 324, 432))
+
+
+class TestCellMethodsInterval(unittest.TestCase):
+    def test_interval_overwrite(self):
+        cubes = iris.cube.CubeList([realistic_3d(), realistic_3d()])
+        cubes[0].cell_methods = (CellMethod(method='mean', intervals=('2700 s',)),)
+        cubes[1].cell_methods = (CellMethod(method='mean', intervals=('1800 s',)),)
+        remove_cell_methods_intervals(cubes)
+        self.assertEqual(cubes[0].cell_methods, cubes[1].cell_methods)
 
 
 if __name__ == '__main__':

--- a/mip_convert/mip_convert/tests/test_load/test_iris_load_util.py
+++ b/mip_convert/mip_convert/tests/test_load/test_iris_load_util.py
@@ -15,7 +15,7 @@ from cdds.common.constants import ANCIL_VARIABLES
 
 from mip_convert.load.iris_load_util import (
     ConstraintConstructor, pp_filter, compare_values, get_field_value,
-    remove_duplicate_cubes, split_netCDF_filename, rechunk, 
+    remove_duplicate_cubes, split_netCDF_filename, rechunk,
     remove_cell_methods_intervals)
 from mip_convert.tests.common import DummyField, realistic_3d_atmos
 from mip_convert.new_variable import VariableModelToMIPMapping


### PR DESCRIPTION
Some UKESM models have experienced problems due to changes in ocean timestep being made mid year as this propagates into the cell_methods attribute attached to data variables in the model input files.

This change adds an extra step before cubes are concatenated together within MIP Convert where the cell_methods are checked and, if necessary, unified by removing the "intervals" component of the CellMethod.

Note: this change should not affect PP atmosphere data as the timestep is not encoded in the PP header.