### PR TITLE
CDDSO-657 Remove email addresses in v3.1

### DIFF
--- a/cdds/bin/cdds_extract
+++ b/cdds/bin/cdds_extract
@@ -6,13 +6,7 @@
 Climate Data Dissemination System script to handle model data
 extractions from MASS
    - supports pp and nc file types
-   - optionally supports file filtering based on required variables mapping
-   - supports request extraction configuration from CREM or JSON data file
-   - optionally supports logging status to CREM
-   - optionally supports email notification of script start, exit and end.
-
-Author:
-    Mark Elkington (mark.elkington@metoffice.gov.uk)
+   - supports file filtering based on required variables mapping
 """
 
 import sys

--- a/docs/operational_procedure/cmip6.md
+++ b/docs/operational_procedure/cmip6.md
@@ -417,7 +417,7 @@ The conversion workflows run the following steps
             and contact the [CDDS Team](mailto:cdds@metoffice.gov.uk) for advice.
 
     !!! important "VERY IMPORTANT"
-        **Do not delete data from MASS without consultation with [Matt Mizielinski](mailto:matthew.mizielinski@metoffice.gov.uk).**
+        **Do not delete data from MASS without consultation with [CDDS support](mailto:cdds@metoffice.gov.uk).**
 
 - [x] `completion_<stream>`
 

--- a/docs/operational_procedure/gcmodeldev.md
+++ b/docs/operational_procedure/gcmodeldev.md
@@ -331,7 +331,7 @@ The conversion workflows run the following steps
             and contact the [CDDS Team](mailto:cdds@metoffice.gov.uk) for advice.
 
     !!! important "VERY IMPORTANT"
-        **Do not delete data from MASS without consultation with [Matt Mizielinski](mailto:matthew.mizielinski@metoffice.gov.uk).**
+        **Do not delete data from MASS without consultation with [CDDS support](mailto:cdds@metoffice.gov.uk).**
 
 - [x] `completion_<stream>`
 

--- a/docs/operational_procedure/sim_review.md
+++ b/docs/operational_procedure/sim_review.md
@@ -93,4 +93,4 @@ expected to do this part.
 
 - [x] Create a new file `~/.cdds_credentials`.
 
-- [x] Contact [Matt Mizielinski](mailto:matthew.mizielinski@metoffice.gov.uk) for the required settings.
+- [x] Contact Matt Mizielinski for the required settings.

--- a/docs/operational_procedure/sim_review.md
+++ b/docs/operational_procedure/sim_review.md
@@ -93,4 +93,4 @@ expected to do this part.
 
 - [x] Create a new file `~/.cdds_credentials`.
 
-- [x] Contact [Matt Mizielinski](mailto:matt.mizielinski@metoffice.gov.uk) for the required settings.
+- [x] Contact [Matt Mizielinski](mailto:matthew.mizielinski@metoffice.gov.uk) for the required settings.

--- a/mip_convert/mip_convert/process/3hr_mappings.cfg
+++ b/mip_convert/mip_convert/process/3hr_mappings.cfg
@@ -14,37 +14,37 @@ status = embargoed
 [huss]
 dimension = longitude latitude height2m time1
 expression = m01s03i237[lbproc=0]
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 
 [mrsos]
 dimension = longitude latitude sdepth1 time1
 expression = m01s08i223[blev=0.05, lbproc=0]
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [tas]
 component = atmos-physics
 dimension = longitude latitude height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-    Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+    Jeremy Walton (Met Office)
 status = ok
 
 [uas]
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [vas]
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/6hrLev_mappings.cfg
+++ b/mip_convert/mip_convert/process/6hrLev_mappings.cfg
@@ -18,39 +18,39 @@ uva_native_levels = Note that the vertical levels for this variable correspond
 [ec550aer]
 dimension = longitude latitude alevel lambda500nm time1
 expression = m01s02i530[lbplev=3, lbproc=0] + m01s02i540[lbplev=3, lbproc=0]
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 
 [hus]
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-    Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+    Jeremy Walton (Met Office)
 status = ok
 
 [pfull]
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i408[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-    Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+    Jeremy Walton (Met Office)
 status = ok
 
 [ps]
 component = atmos-physics
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-    Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+    Jeremy Walton (Met Office)
 status = ok
 
 [ta]
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s30i111[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-    Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+    Jeremy Walton (Met Office)
 status = ok
 
 [ua]
@@ -58,8 +58,8 @@ comment = ${COMMON:uva_native_levels}
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i002[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-    Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+    Jeremy Walton (Met Office)
 status = ok
 
 [va]
@@ -67,6 +67,6 @@ comment = ${COMMON:uva_native_levels}
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i003[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-    Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+    Jeremy Walton (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/6hrPlevPt_mappings.cfg
+++ b/mip_convert/mip_convert/process/6hrPlevPt_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [psl]
 dimension = longitude latitude time1
 expression = m01s16i222[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [rv850]
@@ -25,7 +25,7 @@ expression = m01s30i455[blev=P850, lbproc=0]
 dimension = longitude latitude plev3 time1
 expression = m01s30i294[blev=PLEV3, lbproc=0]
     / m01s30i304[blev=PLEV3, lbproc=0]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [tsl]
@@ -36,46 +36,46 @@ expression = m01s08i225[blev=0.05, lbproc=0]
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
     / m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 
 [ua]
 dimension = longitude latitude plev3 time1
 expression = m01s30i201[blev=PLEV3, lbproc=0]
     / m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [uas]
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [va7h]
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
     / m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 
 [va]
 dimension = longitude latitude plev3 time1
 expression = m01s30i202[blev=PLEV3, lbproc=0]
     / m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [vas]
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [zg500]
 dimension = longitude latitude p500 time1
 expression = m01s30i297[blev=P500, lbproc=0] / m01s30i304[blev=P500, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/AERday_mappings.cfg
+++ b/mip_convert/mip_convert/process/AERday_mappings.cfg
@@ -13,5 +13,5 @@ status = embargoed
 
 [toz]
 expression = m01s50i219[lblev=1, lbproc=128]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok

--- a/mip_convert/mip_convert/process/AERmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/process/AERmonZ_mappings.cfg
@@ -15,60 +15,60 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
     * m01s51i009[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 
 [hcl]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL)
     * m01s51i992[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-    Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Guang Zeng (NIWA),
+    Ben Johnson (Met Office)
 status = ok
 
 [hno3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3)
     * m01s51i007[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
     * m01s51i049[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
     * m01s51i001[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 
 [oh]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH)
     * m01s51i081[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 
 [ta]
 expression = m01s30i294[blev=PLEV39, lbproc=192]
     / m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [ua]
 expression = m01s30i201[blev=PLEV39, lbproc=192]
     / m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [va]
 expression = m01s30i202[blev=PLEV39, lbproc=192]
     / m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [zg]
 expression = m01s30i297[blev=PLEV39, lbproc=192]
     / m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/AERmon_mappings.cfg
+++ b/mip_convert/mip_convert/process/AERmon_mappings.cfg
@@ -15,32 +15,32 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
     * m01s34i009[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
     * m01s34i049[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
     * m01s34i001[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/APday_mappings.cfg
+++ b/mip_convert/mip_convert/process/APday_mappings.cfg
@@ -16,62 +16,62 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [hus]
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [ta]
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [sfcWindmax]
 expression = m01s03i230[lbproc=8192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [tasmax]
 expression = m01s03i236[lbproc=8192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [tasmin]
 expression = m01s03i236[lbproc=4096]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [ua]
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
     / m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [va]
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
     / m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [wap]
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [zg]
 dimension = longitude latitude plev8 time
 expression = m01s30i297[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/APmon_mappings.cfg
+++ b/mip_convert/mip_convert/process/APmon_mappings.cfg
@@ -17,5 +17,5 @@ dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
     / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/Amon_mappings.cfg
+++ b/mip_convert/mip_convert/process/Amon_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
     / m01s30i304[blev=PLEV19, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [sbl]

--- a/mip_convert/mip_convert/process/CF3hr_mappings.cfg
+++ b/mip_convert/mip_convert/process/CF3hr_mappings.cfg
@@ -20,19 +20,19 @@ units = 1.0
 [clc]
 dimension = longitude latitude alevel time1
 expression = m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clic]
 dimension = longitude latitude alevel time1
 expression = m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clis]
 dimension = longitude latitude alevel time1
 expression = m01s02i309[lbproc=0] - m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clivi]
@@ -42,7 +42,7 @@ expression = m01s02i392[lbproc=0]
 [cls]
 dimension = longitude latitude alevel time1
 expression = m01s02i312[lbproc=0] + m01s02i313[lbproc=0] - m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clt]
@@ -53,13 +53,13 @@ expression = m01s02i204[lbproc=0]
 [clwc]
 dimension = longitude latitude alevel time1
 expression = m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clws]
 dimension = longitude latitude alevel time1
 expression = m01s02i308[lbproc=0] - m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clwvi]
@@ -116,7 +116,7 @@ expression = m01s05i215[lbproc=0]
 component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i228[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [prw]
@@ -127,7 +127,7 @@ expression = m01s30i461[lbproc=0]
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [psl]
@@ -139,28 +139,28 @@ expression = m01s16i222[lbproc=0]
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [reffclis]
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [reffclwc]
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [reffclws]
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [rlds]
@@ -251,5 +251,5 @@ expression = m01s03i461[lbproc=0]
 [ts]
 dimension = longitude latitude time1
 expression = m01s00i024[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/CFday_mappings.cfg
+++ b/mip_convert/mip_convert/process/CFday_mappings.cfg
@@ -15,30 +15,30 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [wap]
 expression = m01s30i008[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/CFmon_mappings.cfg
+++ b/mip_convert/mip_convert/process/CFmon_mappings.cfg
@@ -15,10 +15,10 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/CFsubhr_mappings.cfg
+++ b/mip_convert/mip_convert/process/CFsubhr_mappings.cfg
@@ -22,87 +22,87 @@ rld_rldcs = Physically, the radiation scheme used in this model ignores any
 [ci]
 dimension = site time1
 expression = m01s05i269[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [cl]
 dimension = alevel site time1
 expression = m01s02i261[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [cli]
 dimension = alevel site time1
 expression = m01s02i309[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [clivi]
 dimension = site time1
 expression = m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [clt]
 dimension = site time1
 expression = m01s02i204[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [clw]
 dimension = alevel site time1
 expression = m01s02i308[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [clwvi]
 dimension = site time1
 expression = m01s02i391[lbproc=0] + m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [evspsbl]
 dimension = site time1
 expression = m01s03i223[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [hfls]
 comment = Includes both evaporation and sublimation.
 dimension = site time1
 expression = m01s03i234[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [hfss]
 dimension = site time1
 expression = m01s03i217[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [hur]
 dimension = alevel site time1
 expression = m01s30i113[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [hurs]
 dimension = site height2m time1
 expression = m01s03i245[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [hus]
 component = cftables
 dimension = alevel site time1
 expression = m01s00i010[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [huss]
 dimension = site height2m time1
 expression = m01s03i237[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [mc]
@@ -112,88 +112,88 @@ component = cftables
 dimension = alevhalf site time1
 expression = (m01s05i250[lbproc=0] - m01s05i251[lbproc=0]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 positive = up
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>, William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [pfull]
 dimension = alevel site time1
 expression = m01s00i408[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [phalf]
 dimension = alevhalf site time1
 expression = m01s00i407[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [pr]
 dimension = site time1
 expression = m01s05i216[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [prc]
 dimension = site time1
 expression = m01s05i205[lbproc=0] + m01s05i206[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [prsn]
 dimension = site time1
 expression = m01s05i215[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [prw]
 dimension = site time1
 expression = m01s30i461[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [ps]
 dimension = site time1
 expression = m01s00i409[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [psl]
 dimension = site time1
 expression = m01s16i222[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rld]
 comment = ${COMMON:rld_rldcs}
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i218[lbproc=0])
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rldcs]
 comment = ${COMMON:rld_rldcs}
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i220[lbproc=0])
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rlds]
 dimension = site time1
 expression = m01s02i207[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rldscs]
 dimension = site time1
 expression = m01s02i208[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rlus]
 dimension = site time1
 expression = m01s02i207[lbproc=0] - m01s02i201[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rlu]
@@ -201,7 +201,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i217[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -210,7 +210,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i219[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -218,80 +218,80 @@ units = W m-2
 component = cftables
 dimension = site time1
 expression = m01s02i205[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rlutcs]
 dimension = site time1
 expression = m01s02i206[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsd]
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i218[lbproc=0])
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsdcs]
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i220[lbproc=0])
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsds]
 dimension = site time1
 expression = m01s01i235[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsdscs]
 dimension = site time1
 expression = m01s01i210[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsdt]
 dimension = site time1
 expression = m01s01i207[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsu]
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i217[lbproc=0])
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsucs]
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i219[lbproc=0])
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsus]
 component = cftables
 dimension = site time1
 expression = m01s01i235[lbproc=0] - m01s01i201[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsuscs]
 dimension = site time1
 expression = m01s01i211[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsut]
 dimension = site time1
 expression = m01s01i208[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rsutcs]
 dimension = site time1
 expression = m01s01i209[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [rtmt]
@@ -303,14 +303,14 @@ component = boundary-layer
 dimension = site time1
 expression = m01s03i298[lbproc=0]
 positive = None
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [sci]
 dimension = site time1
 expression = m01s05i270[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [sfcWind]
@@ -318,51 +318,51 @@ comment = This is the mean of the speed, not the speed computed from the mean u
     and v components of wind.
 dimension = site height10m time1
 expression = m01s03i230[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [ta]
 component = cftables
 dimension = alevel site time1
 expression = m01s30i111[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tas]
 dimension = site height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tauu]
 dimension = site time1
 expression = m01s03i460[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tauv]
 dimension = site time1
 expression = m01s03i461[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tnhus]
 dimension = alevel site time1
 expression = m01s30i182[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tnhusa]
 dimension = alevel site time1
 expression = (m01s12i182[lbproc=0] + m01s12i382[lbproc=0])
     / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tnhusc]
 dimension = alevel site time1
 expression = m01s05i162[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tnhusmp]
@@ -371,7 +371,7 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
     + m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
     + m01s04i982[lbproc=0] + m01s05i182[lbproc=0] + m01s16i162[lbproc=0]
     + m01s16i182[lbproc=0] + m01s35i025[lbproc=0] ) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tnhusscpbl]
@@ -380,13 +380,13 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
     + m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
     + m01s05i182[lbproc=0] - m01s05i162[lbproc=0] + m01s16i162[lbproc=0]
     + m01s16i182[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tnt]
 dimension = alevel site time1
 expression = m01s30i181[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tnta]
@@ -398,7 +398,7 @@ expression = (m01s10i181[lbproc=0]
 [tntc]
 dimension = alevel site time1
 expression = m01s05i161[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tntmp]
@@ -413,7 +413,7 @@ notes = A stash code for SKEB2 term is now 35029, instead of 35024.
 [tntr]
 dimension = alevel site time1
 expression = (m01s01i161[lbproc=0] + m01s02i161[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [tntscpbl]
@@ -423,51 +423,51 @@ expression = (m01s03i181[lbproc=0] + m01s04i141[lbproc=0]
     + m01s01i181[lbproc=0] - m01s01i161[lbproc=0] + m01s02i181[lbproc=0]
     - m01s02i161[lbproc=0] + m01s05i181[lbproc=0] - m01s05i161[lbproc=0])
     / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [ts]
 dimension = site time1
 expression = m01s00i024[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [ua]
 component = cftables
 dimension = alevel site time1
 expression = m01s00i002[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [uas]
 dimension = site height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [va]
 component = cftables
 dimension = alevel site time1
 expression = m01s00i003[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [vas]
 dimension = site height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [wap]
 component = cftables
 dimension = alevel site time1
 expression = m01s30i008[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 
 [zg]
 component = cftables
 dimension = alevel site time1
 expression = m01s16i201[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/E3hrPt_mappings.cfg
+++ b/mip_convert/mip_convert/process/E3hrPt_mappings.cfg
@@ -14,13 +14,13 @@ status = embargoed
 [cfadDbze94]
 dimension = longitude latitude alt40 dbze time1
 expression = m01s02i372[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [cfadLidarsr532]
 dimension = longitude latitude alt40 scatratio time1
 expression = m01s02i370[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [ch4]
@@ -32,20 +32,20 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i371[lbproc=0] / m01s02i325[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clhcalipso]
 component = cloud
 dimension = longitude latitude p220 time1
 expression = m01s02i346[blev=P220, lbproc=0] / m01s02i323[blev=P220, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clisccp]
 dimension = longitude latitude plev7c tau time1
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [cllcalipso]
@@ -53,20 +53,20 @@ comment = CALIPSO Low Level Cloud Fraction
 component = cloud
 dimension = longitude latitude p840 time1
 expression = m01s02i344[blev=P840, lbproc=0] / m01s02i321[blev=P840, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clmcalipso]
 component = cloud
 dimension = longitude latitude p560 time1
 expression = m01s02i345[blev=P560, lbproc=0] / m01s02i322[blev=P560, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [clmisr]
 dimension = longitude latitude alt16 tau time1
 expression = fix_clmisr_height(m01s02i360[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -74,13 +74,13 @@ units = 1
 component = cloud
 dimension = longitude latitude time1
 expression = m01s02i347[lbproc=0] / m01s02i324[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [hus]
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 
 [hus7h]
@@ -90,13 +90,13 @@ expression = m01s30i295[blev=PLEV7H, lbproc=0]
 [jpdftaureicemodis]
 dimension = longitude latitude plev7c effectRadIc tau time1
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [jpdftaureliqmodis]
 dimension = longitude latitude plev7c effectRadLi tau time1
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [n2o]
@@ -112,13 +112,13 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 [parasolRefl]
 dimension = longitude latitude sza5 time1
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [psl]
@@ -172,12 +172,12 @@ expression = m01s00i024[lbproc=0]
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
     / m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [va7h]
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
     / m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/EdayZ_mappings.cfg
+++ b/mip_convert/mip_convert/process/EdayZ_mappings.cfg
@@ -15,45 +15,45 @@ status = embargoed
 dimension = latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=192]
     / m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [ta]
 dimension = latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=192]
     / m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [ua]
 dimension = latitude plev39 time
 expression = m01s30i201[blev=PLEV39, lbproc=192]
     / m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 
 [utendogw]
 dimension = latitude plev39 time
 expression = m01s06i247[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 
 [va]
 dimension = latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=192]
     / m01s30i301[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [zg]
 dimension = latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=192]
     / m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/Eday_mappings.cfg
+++ b/mip_convert/mip_convert/process/Eday_mappings.cfg
@@ -18,13 +18,13 @@ notes = Merge with common mappings when approved
 [hfls]
 expression = land_class_mean(m01s03i330[lbproc=128], m01s03i317[lbproc=128],
     land_class='all')
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 
 [hfss]
 expression = land_class_mean(m01s03i290[lbproc=128], m01s03i317[lbproc=128],
     land_class='all')
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 
 [rss]

--- a/mip_convert/mip_convert/process/EmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/process/EmonZ_mappings.cfg
@@ -14,5 +14,5 @@ status = embargoed
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/Emon_mappings.cfg
+++ b/mip_convert/mip_convert/process/Emon_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 dimension = longitude latitude plev7h time
 expression = m01s30i295[blev=PLEV7H, lbproc=128]
     / m01s30i304[blev=PLEV7H, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [orog]
@@ -23,11 +23,11 @@ comment = Monthly mean orography (needed if land ice has time varying
     altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [wap]
 dimension = longitude latitude alevel time
 expression = m01s30i008[lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/GA7mon_mappings.cfg
+++ b/mip_convert/mip_convert/process/GA7mon_mappings.cfg
@@ -12,20 +12,20 @@ status = Internal
 
 [pr]
 expression = m01s05i216[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 
 [ts]
 expression = m01s00i024[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 
 [ua]
 dimension = longitude latitude plev17 time
 expression = m01s30i201[blev=PLEV17, lbproc=128]
     / m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 
 [va]
 dimension = longitude latitude plev17 time
 expression = m01s30i202[blev=PLEV17, lbproc=128]
     / m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)

--- a/mip_convert/mip_convert/process/HadGEM3-GC3p05-N216ORCA025_mappings.cfg
+++ b/mip_convert/mip_convert/process/HadGEM3-GC3p05-N216ORCA025_mappings.cfg
@@ -330,7 +330,7 @@ component = atmos-physics
 dimension = longitude latitude p10 time
 expression = m01s30i201[blev=P10, lbproc=128, lbtim_ia=6]
     / m01s30i301[blev=P10, lbproc=128, lbtim_ia=6]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 

--- a/mip_convert/mip_convert/process/HadGEM3_LImon_mappings.cfg
+++ b/mip_convert/mip_convert/process/HadGEM3_LImon_mappings.cfg
@@ -14,7 +14,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i578[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [hflsIs]
@@ -26,7 +26,7 @@ expression = land_class_mean(m01s03i330[lbproc=128],
     land_class='ice')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [hfssIs]
@@ -38,7 +38,7 @@ expression = land_class_mean(m01s03i290[lbproc=128],
     land_class='ice')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [litemptopIs]
@@ -49,7 +49,7 @@ expression = land_class_mean(m01s08i225[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
 notes = mapping changed from the UKESM1 one
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [mrroIs]
@@ -60,7 +60,7 @@ expression = land_class_mean(m01s08i583[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
 notes = UM: ISMIP snowpack runoff definition not necessarily the same as UM.
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [rldsIs]
@@ -72,7 +72,7 @@ expression = land_class_mean(m01s03i384[lbproc=128],
     land_class='ice')
 notes = UM
 positive = down
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [rlusIs]
@@ -83,7 +83,7 @@ expression = land_class_mean(m01s03i383[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [sblIs]
@@ -94,7 +94,7 @@ expression = land_class_mean(m01s03i331[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [sftgif]
@@ -104,7 +104,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='ice')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = %
 
 [snicefreezIs]
@@ -115,7 +115,7 @@ expression = land_class_mean(m01s08i580[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snicemIs]
@@ -126,7 +126,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snmIs]
@@ -137,7 +137,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [tasIs]
@@ -148,7 +148,7 @@ expression = land_class_mean(m01s03i328[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [tsIs]
@@ -159,5 +159,5 @@ expression = land_class_mean(m01s03i316[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='ice')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K

--- a/mip_convert/mip_convert/process/HadGEM3_mappings.cfg
+++ b/mip_convert/mip_convert/process/HadGEM3_mappings.cfg
@@ -17,7 +17,7 @@ dimension = longitude latitude typebare time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='bareSoil')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -27,7 +27,7 @@ dimension = longitude latitude typec3pft time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='c3')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -37,7 +37,7 @@ dimension = longitude latitude typec4pft time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='c4')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -47,7 +47,7 @@ dimension = longitude latitude typenatgr time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='grass')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -57,7 +57,7 @@ dimension = longitude latitude time
 expression = hfcorr
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Matthew Couldrey <m.p.couldrey@reading.ac.uk>
+reviewer = Matthew Couldrey (University of Reading)
 status = ok
 units = W m-2
 
@@ -67,7 +67,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i318[lbproc=128], m01s03i317[lbproc=128],
     land_class='natural')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = 1
 
@@ -76,7 +76,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = pathetao
 mip_table_id = Emon OPmonLev
-reviewer = Matthew Couldrey <m.p.couldrey@reading.ac.uk>
+reviewer = Matthew Couldrey (University of Reading)
 status = ok
 units = degC
 
@@ -85,7 +85,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = prthetao
 mip_table_id = Emon OPmonLev
-reviewer = Matthew Couldrey <m.p.couldrey@reading.ac.uk>
+reviewer = Matthew Couldrey (University of Reading)
 status = ok
 units = degC
 
@@ -97,7 +97,7 @@ dimension = longitude latitude typeresidual time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='residual')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -107,7 +107,7 @@ dimension = longitude latitude typeshrub time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='shrub')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -117,7 +117,7 @@ dimension = longitude latitude typetree time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='tree')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -127,7 +127,7 @@ dimension = longitude latitude typetreebd time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='broadLeafTreeDeciduous')
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -137,7 +137,7 @@ dimension = longitude latitude typetreene time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='needleLeafTreeEvergreen')
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -150,7 +150,7 @@ component = atmos-physics
 dimension = longitude latitude p10 time
 expression = m01s30i201[blev=P10, lbproc=128]
 mip_table_id = AERday AEday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -160,6 +160,6 @@ dimension = longitude latitude typeveg time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='natural')
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %

--- a/mip_convert/mip_convert/process/HadREM-CP4A-4p5km_GC3hrPt_mappings.cfg
+++ b/mip_convert/mip_convert/process/HadREM-CP4A-4p5km_GC3hrPt_mappings.cfg
@@ -6,7 +6,7 @@
 # 'model to MIP mapping'. Please see the 'User Guide' for more
 # information.
 # This list follows the same order as the "CP4A variables to be 
-# CMORised" spreadsheet, contact joshua.macholl@metoffice.gov.uk 
+# CMORised" spreadsheet, contact Joshua Macholl 
 
 [DEFAULT]
 mip_table_id = GC3hrPt

--- a/mip_convert/mip_convert/process/HadREM-CP4A-4p5km_mappings.cfg
+++ b/mip_convert/mip_convert/process/HadREM-CP4A-4p5km_mappings.cfg
@@ -6,7 +6,7 @@
 # 'model to MIP mapping'. Please see the 'User Guide' for more
 # information.
 # This list follows the same order as the "CP4A variables to be 
-# CMORised" spreadsheet, contact joshua.macholl@metoffice.gov.uk 
+# CMORised" spreadsheet, contact Joshua Macholl 
 
 [DEFAULT]
 positive = None

--- a/mip_convert/mip_convert/process/LPmon_mappings.cfg
+++ b/mip_convert/mip_convert/process/LPmon_mappings.cfg
@@ -16,5 +16,5 @@ comment = Monthly mean orography (needed if land ice has time varying
     altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/Omon_mappings.cfg
+++ b/mip_convert/mip_convert/process/Omon_mappings.cfg
@@ -17,10 +17,10 @@ comment = Computed as the total mass of liquid water falling as liquid rain
     into the ice-free portion of the ocean divided by the area of the ocean
     portion of the grid cell.
 expression = pr
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 
 [prsn]
 expression = prsn
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/SIday_mappings.cfg
+++ b/mip_convert/mip_convert/process/SIday_mappings.cfg
@@ -13,7 +13,7 @@ status = embargoed
 
 [siconc]
 expression = aice
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 
 [sisnthick]

--- a/mip_convert/mip_convert/process/UKESM1_E3hr_mappings.cfg
+++ b/mip_convert/mip_convert/process/UKESM1_E3hr_mappings.cfg
@@ -15,6 +15,6 @@ status = embargoed
 component = carbon
 dimension = longitude latitude time
 expression = m01s03i261[lbproc=128]
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1

--- a/mip_convert/mip_convert/process/UKESM1_LImon_mappings.cfg
+++ b/mip_convert/mip_convert/process/UKESM1_LImon_mappings.cfg
@@ -14,7 +14,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i578[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [hflsIs]
@@ -26,7 +26,7 @@ expression = land_class_mean(m01s03i330[lbproc=128],
     land_class='iceElev')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [hfssIs]
@@ -38,7 +38,7 @@ expression = land_class_mean(m01s03i290[lbproc=128],
     land_class='iceElev')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [litemptopIs]
@@ -49,7 +49,7 @@ expression = land_class_mean(m01s08i576[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = HadGEM3_variable_mapping:m01s08i225: UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [mrroIs]
@@ -60,7 +60,7 @@ expression = land_class_mean(m01s08i583[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM: ISMIP snowpack runoff definition not necessarily the same as UM.
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [rldsIs]
@@ -72,7 +72,7 @@ expression = land_class_mean(m01s03i384[lbproc=128],
     land_class='iceElev')
 notes = UM
 positive = down
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [rlusIs]
@@ -83,7 +83,7 @@ expression = land_class_mean(m01s03i383[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [sblIs]
@@ -94,7 +94,7 @@ expression = land_class_mean(m01s03i331[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [sftgif]
@@ -104,7 +104,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='iceElev')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = %
 
 [snicefreezIs]
@@ -115,7 +115,7 @@ expression = land_class_mean(m01s08i580[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snicemIs]
@@ -126,7 +126,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snmIs]
@@ -137,7 +137,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [tasIs]
@@ -148,7 +148,7 @@ expression = land_class_mean(m01s03i328[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [tsIs]
@@ -159,5 +159,5 @@ expression = land_class_mean(m01s03i316[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K

--- a/mip_convert/mip_convert/process/UKESM1_mappings.cfg
+++ b/mip_convert/mip_convert/process/UKESM1_mappings.cfg
@@ -34,7 +34,7 @@ dimension = longitude latitude typebare time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='bareSoil')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -44,7 +44,7 @@ dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T + ZMI_E3T + ZME_E3T + DET_E3T)
     * FE_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -55,7 +55,7 @@ expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]
     + ZMI_E3T[depth=0] + ZME_E3T[depth=0]
     + DET_E3T[depth=0]) * FE_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -65,7 +65,7 @@ dimension = longitude latitude olevel time
 expression = PDS_E3T / thkcello
 mip_table_id = Omon
 notes = AXY: mostly a units thing; overlooking fast detritus Si
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -74,7 +74,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = PDS_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -84,7 +84,7 @@ dimension = longitude latitude typec3pft time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='c3')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -94,7 +94,7 @@ dimension = longitude latitude typec4pft time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='c4')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -104,7 +104,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CFC11_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = umol m-3
 
@@ -114,7 +114,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CFC12_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = umol m-3
 
@@ -123,7 +123,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (CHN_E3T + CHD_E3T) / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -132,7 +132,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CHD_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -141,7 +141,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = CHD_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -154,7 +154,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (CHN_E3T[depth=0] + CHD_E3T[depth=0]) / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -163,7 +163,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CHN_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -172,7 +172,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = CHN_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -183,8 +183,8 @@ expression = m01s19i002[lbtim_ia=240,lbproc=128] + m01s19i016[lbtim_ia=240,lbpro
     + m01s19i032[lbtim_ia=240,lbproc=128] + m01s19i033[lbtim_ia=240,lbproc=128]
     + m01s19i034[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -193,8 +193,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i026[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -204,7 +204,7 @@ dimension = longitude latitude alevel time
 expression = m01s00i252[lbproc=128]
     * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO2)
 mip_table_id = AERmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = mol mol-1
 
@@ -214,7 +214,7 @@ dimension = longitude latitude alevel time
 expression = m01s00i252[lbproc=128]
 mip_table_id = Emon
 notes = Available from emissions-driven runs only.
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg kg-1
 
@@ -225,7 +225,7 @@ expression = m01s00i252[lblev=1, lbproc=128]
     * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO2)
 mip_table_id = Emon
 notes = Available from emissions-driven runs only.
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = mol mol-1
 
@@ -236,7 +236,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CO33
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -249,7 +249,7 @@ expression = CO33 / CO3SATARAG3
 mip_table_id = Omon
 notes = AXY: think this needs calculating; but should it be?;
     MEDUSA ignores aragonite.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -267,7 +267,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CO33 / CO3SATCALC3
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -287,7 +287,7 @@ expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP
     * (m01s38i507[lbproc=128] + m01s38i510[lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-3
 
@@ -300,7 +300,7 @@ expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP
     + m01s38i506[lbproc=128] + m01s38i507[lbproc=128] + m01s38i508[lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-3
 
@@ -311,7 +311,7 @@ dimension = longitude latitude alevel time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i504[lbproc=128]
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-3
 
@@ -321,8 +321,8 @@ dimension = longitude latitude time
 expression = m01s19i032[lbtim_ia=240,lbproc=128] + m01s19i033[lbtim_ia=240,lbproc=128]
     + m01s19i034[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -331,8 +331,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i030[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -342,8 +342,8 @@ dimension = longitude latitude time typecrop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='crop')
 mip_table_id = Lmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -353,7 +353,7 @@ dimension = longitude latitude time typec3crop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='c3Crop')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -363,7 +363,7 @@ dimension = longitude latitude time typec4crop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='c4Crop')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -372,8 +372,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i016[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -383,7 +383,7 @@ dimension = longitude latitude time
 expression = m01s19i021[lbtim_ia=240,lbproc=128] + m01s19i022[lbtim_ia=240,lbproc=128]
     + m01s19i023[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2
 
@@ -392,7 +392,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i024[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2
 
@@ -401,8 +401,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i028[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -411,8 +411,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i002[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -422,8 +422,8 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='grass')
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -433,7 +433,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -443,7 +443,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -454,7 +454,7 @@ expression = DTC_E3T / thkcello
 mip_table_id = Omon
 notes = AXY: partly a units thing, but need to modify code to produce
     combined slow- and fast-sinking detritus.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -470,7 +470,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = FER_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -479,7 +479,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = FER_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -488,7 +488,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = DIC_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -504,7 +504,7 @@ component = obgc
 dimension = longitude latitude time
 expression = DMS_SURF
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = nmol L-1
 
@@ -513,7 +513,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = OCN_PCO2 - ATM_PCO2
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = uatm
 
@@ -525,8 +525,8 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C,
     + m01s38i222[lbproc=128] + m01s38i223[lbproc=128],
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>,
-    Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Nicolas Bellouin (University of Reading),
+    Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -539,7 +539,7 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C * CONV_C_ORGM,
     + m01s38i227[lbproc=128] + m01s38i228[lbproc=128],
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -549,7 +549,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO2,
     m01s50i154[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -561,7 +561,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
     + m01s38i217[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -572,7 +572,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL,
     m01s38i218[lbproc=128] + m01s38i219[lbproc=128],
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -585,7 +585,7 @@ expression = achem_emdrywet( ATOMIC_MASS_OF_C * CONV_C_ORGM,
     + m01s38i302[lbproc=128] + m01s38i303[lbproc=128] + m01s38i304[lbproc=128]
     + m01s38i305[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -595,7 +595,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epC100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -605,7 +605,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epCALC100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -615,7 +615,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epN100 * FE_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -625,7 +625,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epN100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -636,7 +636,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epN100 * P_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -646,7 +646,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epSI100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -658,7 +658,7 @@ dimension = longitude latitude olevel time
 expression = EXPC3
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -670,7 +670,7 @@ dimension = longitude latitude olevel time
 expression = FD_CAL3
 mip_table_id = Emon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -684,7 +684,7 @@ mip_table_id = Emon
 notes = AXY: already post-processable, but would be better if sinking fluxes
     are done more systematically; see earlier remarks.
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -698,7 +698,7 @@ mip_table_id = Emon
 notes = AXY: already post-processable, but would be better if sinking fluxes
     are done more systematically; see earlier remarks.
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -712,7 +712,7 @@ dimension = longitude latitude olevel time
 expression = EXPN3 * P_TO_N_RATIO
 mip_table_id = Emon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -724,7 +724,7 @@ dimension = longitude latitude olevel time
 expression = FD_SIL3
 mip_table_id = Emon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -733,7 +733,7 @@ component = land-use
 dimension = longitude latitude time
 expression = (m01s19i044[lbtim_ia=240,lbproc=128])/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -743,7 +743,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_ALK_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdic]
@@ -752,7 +752,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_DiC_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdife]
@@ -761,7 +761,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_FER_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdin]
@@ -770,7 +770,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_DIN_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdip]
@@ -782,7 +782,7 @@ expression = sum_over_upper_100m(SMS_DIN_E3T, thkcello)
     * P_TO_N_RATIO
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdisi]
@@ -793,7 +793,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_SIL_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fBNF]
@@ -802,8 +802,8 @@ dimension = longitude latitude time
 expression = m01s19i113[lbtim_ia=240,lbproc=128]
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -817,7 +817,7 @@ expression = m01s00i251[lbproc=128]
     + mdi_to_zero(m01s19i044[lbtim_ia=240,lbproc=128])) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Amon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -828,7 +828,7 @@ expression = m01s00i251[lbproc=128]
     * (ATOMIC_MASS_OF_C / MOLECULAR_MASS_OF_CO2)
 mip_table_id = Amon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -849,7 +849,7 @@ notes = For emissions driven runs. The land fraction use here is being sampled
     every 6 hours rather than being a true time average. However, this appears
     to be a constant field so there is no impact for current model configurations.
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -884,7 +884,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(TOT_DIN_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fddtdip]
@@ -896,7 +896,7 @@ expression = sum_over_upper_100m(TOT_DIN_E3T, thkcello)
     * P_TO_N_RATIO
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fddtdisi]
@@ -907,7 +907,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(TOT_SIL_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fDeforestToProduct]
@@ -918,8 +918,8 @@ expression = (m01s19i036[lbtim_ia=240,lbproc=128]
     + m01s19i038[lbtim_ia=240,lbproc=128])
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -930,7 +930,7 @@ dimension = longitude latitude time
 expression = qtrCFC11
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mol m-2 s-1
 
@@ -941,7 +941,7 @@ dimension = longitude latitude time
 expression = qtrCFC12
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mol m-2 s-1
 
@@ -951,8 +951,8 @@ dimension = longitude latitude time depth0m
 expression = CO2FLUX * ATOMIC_MASS_OF_C
 mip_table_id = Omon
 positive = down
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andrew Yool <axy@noc.ac.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andrew Yool (NOC)
 status = ok
 units = mg m-2 d-1
 
@@ -962,7 +962,7 @@ dimension = longitude latitude time depth0m
 expression = O2FLUX
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -973,7 +973,7 @@ dimension = longitude latitude time
 expression = qtrSF6
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mol m-2 s-1
 
@@ -983,7 +983,7 @@ dimension = longitude latitude time
 expression = m01s19i044[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -993,8 +993,8 @@ dimension = longitude latitude time
 expression = m01s19i044[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1006,7 +1006,7 @@ expression = (m01s19i039[lbtim_ia=240,lbproc=128]
     + m01s19i041[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1016,8 +1016,8 @@ dimension = longitude latitude time
 expression = (m01s19i120[lbtim_ia=240,lbproc=128] + m01s19i122[lbtim_ia=240,lbproc=128])
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1026,8 +1026,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i126[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1036,8 +1036,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i117[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1046,8 +1046,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i117[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1056,8 +1056,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i114[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1066,8 +1066,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i118[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1077,8 +1077,8 @@ dimension = longitude latitude time
 expression = (m01s19i181[lbtim_ia=240,lbproc=128] - m01s19i171[lbtim_ia=240,lbproc=128])
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1087,7 +1087,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i122[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1097,7 +1097,7 @@ dimension = longitude latitude time
 expression = (m01s19i160[lbtim_ia=240,lbproc=128] - m01s19i113[lbtim_ia=240,lbproc=128])
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1106,8 +1106,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i124[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1116,7 +1116,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i042[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1125,7 +1125,7 @@ component = land-use
 dimension = longitude latitude landUse time
 expression = land_use_tile_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = %
 
@@ -1134,7 +1134,7 @@ component = obgc
 dimension = longitude latitude time
 expression = IBEN_CA
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1143,7 +1143,7 @@ component = obgc
 dimension = longitude latitude time
 expression = IBEN_C
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1153,7 +1153,7 @@ dimension = longitude latitude time depth0m
 expression = AEOLIAN + BENTHIC
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1162,8 +1162,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i005[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1172,7 +1172,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i183[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1183,8 +1183,8 @@ expression = land_class_mean(
     m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1195,7 +1195,7 @@ expression = land_use_tile_mean(
      m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
      m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1206,8 +1206,8 @@ expression = land_class_mean(
     m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1218,8 +1218,8 @@ expression = land_class_mean(
     m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1229,7 +1229,7 @@ dimension = longitude latitude typenatgr time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='grass')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1239,7 +1239,7 @@ dimension = longitude latitude typec3pft typenatgr time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='c3Grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1249,7 +1249,7 @@ dimension = longitude latitude typec4pft typenatgr time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='c4Grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1260,7 +1260,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (MIGRAZP3 + MEGRAZP3) * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -1270,7 +1270,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i330[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -1280,7 +1280,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i290[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -1289,7 +1289,7 @@ component = land-use
 dimension = longitude latitude height2m landUse time
 expression = land_use_tile_mean(m01s03i329[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = 1
 
@@ -1298,7 +1298,7 @@ component = obgc
 dimension = longitude latitude time
 expression = INTDISSIC * ATOMIC_MASS_OF_C
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-2
 
@@ -1307,7 +1307,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (PRN + PRD) * FE_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1316,7 +1316,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PRN + PRD
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1327,7 +1327,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (PRN + PRD) * P_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1336,7 +1336,7 @@ component = obgc
 dimension = longitude latitude time
 expression = OPAL
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1345,7 +1345,7 @@ component = obgc
 dimension = longitude latitude time
 expression = FASTCA
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1356,7 +1356,7 @@ expression = (((INT_PN + INT_PD) * C_TO_N_RATIO)
     + ((INT_ZMI + INT_ZME) * C_TO_N_RATIO_ZOO)
     + INT_DTC) * ATOMIC_MASS_OF_C
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-2
 
@@ -1365,7 +1365,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (PRN + PRD) * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1374,7 +1374,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PRD * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1383,7 +1383,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PRN * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1394,7 +1394,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i014[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
    land_class='veg')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = 1
 
@@ -1403,7 +1403,7 @@ component = land-use
 dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s19i014[lbtim_ia=240,lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = 1
 
@@ -1412,7 +1412,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PD_FELIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1421,7 +1421,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PN_FELIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1430,7 +1430,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PD_JLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1439,7 +1439,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PN_JLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1448,7 +1448,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PD_NLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1457,7 +1457,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PN_NLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1467,7 +1467,7 @@ dimension = longitude latitude time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i525[lbproc=128]
 mip_table_id = Eday
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1477,7 +1477,7 @@ dimension = longitude latitude time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i531[lbproc=128]
 mip_table_id = Eday
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1489,7 +1489,7 @@ expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4)
     * m01s38i520[lbproc=128]
 mip_table_id = Eday Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1499,7 +1499,7 @@ dimension = longitude latitude time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i539[lbproc=128]
 mip_table_id = Eday Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1509,7 +1509,7 @@ dimension = longitude latitude alevel time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i545[lbproc=128]
 mip_table_id = AERmon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -1523,8 +1523,8 @@ expression = (m01s19i102[lbtim_ia=240,lbproc=128]
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = down
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1536,7 +1536,7 @@ expression = (m01s19i102[lbtim_ia=240,lbproc=128] - m01s19i053[lbtim_ia=240,lbpr
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
 positive = down
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1545,8 +1545,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i147[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1557,7 +1557,7 @@ expression = land_class_mean(m01s19i132[lbtim_ia=240,lbproc=128], m01s19i013[lbt
     land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1566,8 +1566,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i146[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1578,7 +1578,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = DIN_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1589,7 +1589,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = DIN_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1599,7 +1599,7 @@ dimension = longitude latitude time
 expression = m01s19i102[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = down
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1610,7 +1610,7 @@ expression = land_class_mean(
     m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1621,7 +1621,7 @@ expression = land_use_tile_mean(
     m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1632,7 +1632,7 @@ expression = land_class_mean(
     m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1643,7 +1643,7 @@ expression = land_class_mean(
     m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1654,7 +1654,7 @@ expression = land_class_mean(m01s19i133[lbtim_ia=240,lbproc=128], m01s19i013[lbt
     land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1663,8 +1663,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i145[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1675,7 +1675,7 @@ expression = land_class_mean(m01s19i131[lbtim_ia=240,lbproc=128], m01s19i013[lbt
     land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1684,8 +1684,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i137[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1694,7 +1694,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = OXY_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1711,7 +1711,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = OXY_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1722,7 +1722,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = O2SAT3
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1733,7 +1733,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = O2SAT3[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1744,8 +1744,8 @@ dimension = longitude latitude time typepasture
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='pasture')
 mip_table_id = Lmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1755,7 +1755,7 @@ dimension = longitude latitude time typec3pastures
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='c3Pasture')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1765,7 +1765,7 @@ dimension = longitude latitude time typec4pastures
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='c4Pasture')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1776,7 +1776,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PH3
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1785,7 +1785,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PH3[depth=0]
 mip_table_id = Omon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 
@@ -1794,7 +1794,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * C_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1807,7 +1807,7 @@ dimension = longitude latitude time
 expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0])
     * C_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1816,7 +1816,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PHD_E3T * C_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1832,7 +1832,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * FE_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1841,7 +1841,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1850,7 +1850,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]) / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1861,7 +1861,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * P_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1877,7 +1877,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PHN_E3T * C_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1889,7 +1889,7 @@ dimension = longitude latitude time depth0m
 expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0])
     * P_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1898,7 +1898,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PDS_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1919,7 +1919,7 @@ mip_table_id = Omon
 notes = AXY: phosphate not in model; and not a good idea to estimate it by
     converting DIN to DIP using fixed N:P ratio; though this is not a
     terrible idea.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1938,7 +1938,7 @@ expression = (PHN_E3T + PHD_E3T + ZMI_E3T + ZME_E3T + DET_E3T) / thkcello
 mip_table_id = Omon
 notes = AXY: partly a units thing, but need to modify code to produce
     combined slow- and fast-sinking detritus.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1949,7 +1949,7 @@ expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]
     + ZMI_E3T[depth=0] + ZME_E3T[depth=0]
     + DET_E3T[depth=0]) / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1961,7 +1961,7 @@ dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T + ZMI_E3T + ZME_E3T + DET_E3T)
     * P_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1974,7 +1974,7 @@ expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]
     + ZMI_E3T[depth=0] + ZME_E3T[depth=0] + DET_E3T[depth=0])
     * P_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1985,7 +1985,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = TPP3 * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -1996,7 +1996,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = TPPD3 * C_TO_N_RATIO
 mip_table_id = Emon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -2007,7 +2007,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (TPP3 - TPPD3) * C_TO_N_RATIO
 mip_table_id = Emon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -2017,8 +2017,8 @@ dimension = longitude latitude time
 expression = m01s19i185[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2029,7 +2029,7 @@ expression = land_class_mean(
     m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2040,7 +2040,7 @@ expression = land_use_tile_mean(
     m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2051,7 +2051,7 @@ expression = land_class_mean(
     m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2062,7 +2062,7 @@ expression = land_class_mean(
     m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2072,7 +2072,7 @@ dimension = longitude latitude typeresidual time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='residual')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2082,8 +2082,8 @@ dimension = longitude latitude time
 expression = m01s19i053[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2093,7 +2093,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i383[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -2104,7 +2104,7 @@ expression = land_use_tile_mean_difference(m01s01i235[lbproc=128],
     m01s03i382[lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -2119,7 +2119,7 @@ expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4)
     + m01s38i488[lblev=1, lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-3
 
@@ -2131,7 +2131,7 @@ expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP
     + m01s38i499[lblev=1, lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-3
 
@@ -2141,7 +2141,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = SF6_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = umol m-3
 
@@ -2151,7 +2151,7 @@ dimension = longitude latitude typeshrub time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='shrub')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2160,7 +2160,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = SIL_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2169,7 +2169,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = SIL_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2178,7 +2178,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = OCN_PCO2
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = uatm
 
@@ -2187,7 +2187,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = ALK_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2203,7 +2203,7 @@ component = land-use
 dimension = longitude latitude height2m landUse time
 expression = land_use_tile_mean(m01s03i328[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = K
 
@@ -2213,7 +2213,7 @@ dimension = longitude latitude typetree time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='tree')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2223,7 +2223,7 @@ dimension = longitude latitude typetreebd time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='broadLeafTreeDeciduous')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2233,7 +2233,7 @@ dimension = longitude latitude typetreebe time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='broadLeafTreeEvergreen')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2243,7 +2243,7 @@ dimension = longitude latitude typetreend time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='needleLeafTreeDeciduous')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2253,7 +2253,7 @@ dimension = longitude latitude typetreene time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='needleLeafTreeEvergreen')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2262,7 +2262,7 @@ component = land-use
 dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i316[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = K
 
@@ -2272,7 +2272,7 @@ dimension = longitude latitude typeveg time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='veg')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2282,7 +2282,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='veg')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2292,7 +2292,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='crop')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2302,7 +2302,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2312,7 +2312,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='pasture')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2322,7 +2322,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2332,7 +2332,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2346,7 +2346,7 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C,
     cube2d=(m01s38i906[lbproc=128] + m01s38i912[lbproc=128]
     + m01s38i921[lbproc=128]), sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -2361,7 +2361,7 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C * CONV_C_ORGM,
     cube2d=(m01s38i907[lbproc=128] + m01s38i913[lbproc=128]
     + m01s38i922[lbproc=128]), sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -2371,7 +2371,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO2,
     m01s50i155[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -2387,7 +2387,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -2400,7 +2400,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL,
     cube2d=(m01s38i914[lbproc=128] + m01s38i923[lbproc=128]),
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -2409,7 +2409,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = ZME_E3T * C_TO_N_RATIO_ZOO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2425,7 +2425,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = ZMI_E3T * C_TO_N_RATIO_ZOO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2449,7 +2449,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (ZMI_E3T + ZME_E3T) * C_TO_N_RATIO_ZOO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2465,7 +2465,7 @@ component = obgc
 dimension = longitude latitude time
 expression = ARG_CCD
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = m
 
@@ -2474,6 +2474,6 @@ component = obgc
 dimension = longitude latitude time
 expression = CAL_CCD
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = m

--- a/mip_convert/mip_convert/process/common_mappings.cfg
+++ b/mip_convert/mip_convert/process/common_mappings.cfg
@@ -51,7 +51,7 @@ expression = m01s02i240[lbplev=3, lbproc=128]
     + m01s02i243[lbplev=3, lbproc=128] + m01s02i585[lbplev=3, lbproc=128]
 mip_table_id = AERmon AEmon
 notes = Assuming CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -63,7 +63,7 @@ expression = combine_sw_lw(m01s01i508[lbproc=0] / m01s01i507[lbproc=0],
     m01s02i508[lbproc=0] / m01s02i507[lbproc=0],
     minval= '-1.0', maxval= '1.0')
 mip_table_id = E3hrPt AP3hrPtLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -74,7 +74,7 @@ dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i506[lbproc=0], m01s02i506[lbproc=0],
     swmask= m01s01i200[lbproc=0], minval= '0', maxval= '10')
 mip_table_id = E3hrPt AP3hrPtLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -85,7 +85,7 @@ dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i507[lbproc=0] / m01s01i506[lbproc=0],
     m01s02i507[lbproc=0] / m01s02i506[lbproc=0], minval='0.0', maxval='1.0')
 mip_table_id = E3hrPt AP3hrPtLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -95,7 +95,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = agessc
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = yr
 
@@ -104,7 +104,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = div_by_area(m01s50i063[lbproc=128])
 mip_table_id = AERmon AEmonLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = kg m-2
 
@@ -128,7 +128,7 @@ dimension = longitude latitude time
 expression = fix_packing_division(m01s02i331[lbproc=128],
                                   m01s02i334[lbproc=128])
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -137,7 +137,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = areacella(m01s00i505)
 mip_table_id = fx APfx mon day 6hr 3hr 1hr
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok
 units = m2
 
@@ -146,7 +146,7 @@ component = ocean
 dimension = longitude latitude
 expression = areacello
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -155,7 +155,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i054[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = s m-1
 
@@ -167,7 +167,7 @@ component = ocean
 dimension = longitude latitude
 expression = basin
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1
 
@@ -176,7 +176,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = 6hrPlev AERmon AE6hr AEmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -192,7 +192,7 @@ expression = MOLECULAR_MASS_OF_AIR
     + (m01s51i994[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRO))
     / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -203,7 +203,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C2H6)
     * m01s34i014[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -214,7 +214,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C3H8)
     * m01s34i018[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -226,7 +226,7 @@ dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128],
     m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -236,7 +236,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s01i241[lbproc=128] / m01s01i223[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -245,7 +245,7 @@ component = cloud
 dimension = longitude latitude alt40 dbze time
 expression = m01s02i372[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -254,7 +254,7 @@ component = cloud
 dimension = longitude latitude alt40 scatratio time
 expression = m01s02i370[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -264,7 +264,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i055[lbproc=128],
     MOLECULAR_MASS_OF_CFC11)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -274,7 +274,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i056[lbproc=128],
     MOLECULAR_MASS_OF_CFC12)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -284,7 +284,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH3COCH3)
     * m01s34i022[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -295,7 +295,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
     * m01s51i009[blev=PLEV19, lbproc=128]
     / m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -305,7 +305,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i009[lbproc=128],
     MOLECULAR_MASS_OF_CH4)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -321,7 +321,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
     + m01s38i289[lbproc=128]), areadiv='True')
 mip_table_id = AERmon AEmonLev
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -332,7 +332,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
     m01s50i150[lbproc=128], areadiv='True')
 mip_table_id = AERmon AEmonLev
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -341,7 +341,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i269[lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Mark Webb <mark.webb@metoffice.gov.uk>
+reviewer = Mark Webb (Met Office)
 status = ok
 units = 1
 
@@ -350,7 +350,7 @@ component = cftables cloud
 dimension = longitude latitude alevel time
 expression = m01s02i261[lbproc=128]
 mip_table_id = Amon CFday APmonLev APdayLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -360,7 +360,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i317[lbproc=128]
 mip_table_id = CFmon APmonLev
 notes = Using convective cores in this model configuration.
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -369,7 +369,7 @@ component = cftables
 dimension = longitude latitude alt40 time
 expression = m01s02i371[lbproc=128] / m01s02i325[lbproc=128]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -378,7 +378,7 @@ component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i374[lbproc=0] / m01s02i325[lbproc=0]
 mip_table_id = E3hrPt AP3hrPt
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -409,7 +409,7 @@ dimension = longitude latitude time
 expression = m01s01i280[lbproc=128] / m01s01i281[lbproc=128]
 mip_table_id = Eday Emon APmon APday
 notes = Calculated at daylight grids only.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-2
 
@@ -419,7 +419,7 @@ dimension = longitude latitude p220 time
 expression = m01s02i346[lbproc=128, blev=P220]
     / m01s02i323[lbproc=128, blev=P220]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -429,7 +429,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i309[lbproc=128]
 mip_table_id = Amon CFday APmonLev APdayLev
 notes = ${COMMON:convective_notes}
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -438,7 +438,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i319[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -447,7 +447,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i453[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -465,7 +465,7 @@ dimension = longitude latitude plev7c tau time
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=128],
     m01s02i330[lbproc=128])
 mip_table_id = CFmon CFday APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -474,7 +474,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i392[lbproc=128]
 mip_table_id = Amon CFday APmon APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -483,7 +483,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i396[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -493,7 +493,7 @@ dimension = longitude latitude p840 time
 expression = m01s02i344[lbproc=128, blev=P840]
     / m01s02i321[lbproc=128, blev=P840]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -503,7 +503,7 @@ dimension = longitude latitude p560 time
 expression = m01s02i345[lbproc=128, blev=P560]
     / m01s02i322[lbproc=128, blev=P560]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -512,7 +512,7 @@ component = cloud
 dimension = longitude latitude alt16 tau time
 expression = fix_clmisr_height(m01s02i360[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -522,7 +522,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i312[lbproc=128] + m01s02i313[lbproc=128]
     - m01s02i317[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -531,7 +531,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i204[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -540,7 +540,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i347[lbproc=128] / m01s02i324[lbproc=128]
 mip_table_id = CFday CFmon APmon APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -549,7 +549,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i334[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -558,7 +558,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i451[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -568,7 +568,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i308[lbproc=128]
 mip_table_id = Amon CFday APdayLev APmonLev
 notes = ${COMMON:convective_notes}
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -577,7 +577,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i318[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -586,7 +586,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i452[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -603,7 +603,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128] + m01s02i392[lbproc=128]
 mip_table_id = Amon CFday APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -612,7 +612,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i395[lbproc=128] + m01s02i396[lbproc=128]
 mip_table_id = Eday Emon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -630,7 +630,7 @@ expression = MOLECULAR_MASS_OF_AIR
     + (m01s51i992[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HCL))
     / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -640,7 +640,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO)
     * m01s34i010[lbproc=128]
 mip_table_id = AERmon CresAERday AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -650,7 +650,7 @@ component = carbon
 dimension = time
 expression = m01s30i465[lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg
 
@@ -659,7 +659,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i332[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = AERday AERmon AEday AEmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -668,7 +668,7 @@ component = dust
 dimension = longitude latitude alevel time
 expression = m01s17i257[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -677,7 +677,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i209[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -687,7 +687,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s03i440[lbproc=128]
 mip_table_id = Emon AEmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -696,7 +696,7 @@ component = ocean
 dimension = longitude latitude
 expression = deptho
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -729,7 +729,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i071[lbproc=128]
     * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_DMS)
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -744,7 +744,7 @@ expression = m01s03i441[lbproc=128] + m01s03i442[lbproc=128]
     + m01s03i456[lbproc=128]
 mip_table_id = AERmon CresAERday AEmon
 notes = Assumes CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -754,7 +754,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_O3,
     m01s50i131[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -763,7 +763,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -773,7 +773,7 @@ dimension = longitude latitude alevel lambda550nm time
 expression = m01s02i530[lbplev=3, lbproc=128]
     + m01s02i540[lbplev=3, lbproc=128]
 mip_table_id = Emon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-1
 
@@ -783,7 +783,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C,
     m01s38i207[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -796,8 +796,8 @@ dimension = longitude latitude time
 expression = (m01s03i495[lbproc=128] + m01s03i496[lbproc=128]) *
     m01s00i505
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-    Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (NIWA),
+    Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -806,7 +806,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i158[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -815,7 +815,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i214[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -828,7 +828,7 @@ expression = m01s03i401[lbproc=128] + m01s03i402[lbproc=128]
     + m01s03i406[lbproc=128]
 mip_table_id = AERmon AEmon
 notes = Assumes CLASSIC dust.
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -839,8 +839,8 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_ISOPRENE / (5.0 * ATOMIC_MASS_OF_C))
     * (m01s03i495[lbproc=128] * m01s00i505)
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-    Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (NIWA),
+    Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -849,7 +849,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i081[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol s-1
 
@@ -861,7 +861,7 @@ expression = achem_emdrywet(1.0,
     m01s50i172[lbproc=128], cube2d=m01s50i156[lbproc=128],
     sumlev='True')
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -872,7 +872,7 @@ expression = achem_emdrywet(1.0,
     m01s50i217[lbproc=128], cube2d=(m01s50i215[lbproc=128]
     + m01s50i216[lbproc=128]), sumlev='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = kg m-2 s-1
 
@@ -884,7 +884,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
     sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -895,7 +895,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL,
     m01s38i204[lbproc=128] + m01s38i205[lbproc=128],
     sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -912,7 +912,7 @@ expression = ((m01s50i159[lbproc=128] / MOLECULAR_MASS_OF_HCHO)
     + (m01s50i301[lbproc=128] * (10.0 / MOLECULAR_MASS_OF_MONOTERPENE)))
     * ATOMIC_MASS_OF_C
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -929,7 +929,7 @@ dimension = latitude plev39 time
 expression = scale_epflux(m01s30i312[blev=PLEV39, lbproc=192],
     m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APdayZ APmonZ
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -940,7 +940,7 @@ expression = scale_epflux(m01s30i313[blev=PLEV39, lbproc=192],
     m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APdayZ APmonZ
 positive = up
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -949,7 +949,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i296[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -967,7 +967,7 @@ expression = correct_evaporation(evs, sowaflup - (evs - (ficeberg
     + friver + prsn + pr + fsitherm) ), areacello)
 mip_table_id = Omon OPmon
 positive = None
-reviewer = Dave Storkey <dave.storkey@metoffice.gov.uk>
+reviewer = Dave Storkey (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -976,8 +976,8 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i223[lbproc=128]
 mip_table_id = Amon Eday APmon LPday
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>,
-    Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office),
+    Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -986,7 +986,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i334[lbproc=128]
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -996,7 +996,7 @@ dimension = longitude latitude time
 expression = m01s03i296[lbproc=128] + m01s03i298[lbproc=128]
     - m01s03i539[lbproc=128]
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1005,7 +1005,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1018,7 +1018,7 @@ expression = calc_fgdms(m01s00i505, m01s50i214[lbproc=128]
     / MOLECULAR_MASS_OF_DMS )
 mip_table_id = Omon OBmon
 positive = up
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = kmol m-2 s-1
 
@@ -1028,7 +1028,7 @@ component = ocean
 dimension = longitude latitude olevel time
 mip_table_id = Omon OPmonLev
 expression = sum_2d_and_3d(ficeberg, -1*vowflisf)
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1044,8 +1044,8 @@ component = chemistry
 dimension = longitude latitude time
 expression = div_by_area(m01s50i082[lbproc=128])
 mip_table_id = Emon ACmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>,
-    Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (University of Cambridge),
+    Mohit Dalvi (Met Office)
 status = ok
 units = m-2 min-1
 
@@ -1054,7 +1054,7 @@ component = ocean
 dimension = longitude latitude time
 expression = friver
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1063,7 +1063,7 @@ component = seaice
 dimension = longitude latitude time
 expression = fsitherm
 mip_table_id = Omon OPmon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1072,7 +1072,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s03i261[lbproc=128]
 mip_table_id = E3hr LP3hr
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1090,7 +1090,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCHO)
     * m01s34i011[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1100,7 +1100,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL)
     * m01s34i992[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1112,7 +1112,7 @@ expression = combine_cubes_to_basin_coord(hfbasin_global, hfbasin_atlantic,
     hfbasin_indopacific, mask_global=global_ocean_1D_V,
     mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1125,7 +1125,7 @@ expression = combine_cubes_to_basin_coord(hfbasinpadv_global,
     mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V,
     mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1138,7 +1138,7 @@ expression = combine_cubes_to_basin_coord(hfbasinpmadv_global,
     mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V,
     mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1151,7 +1151,7 @@ expression = combine_cubes_to_basin_coord(hfbasinpmdiff_global,
     mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V,
     mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1161,7 +1161,7 @@ dimension = longitude latitude time
 expression = hfds
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1179,7 +1179,7 @@ dimension = longitude latitude time
 expression = hfevapds
 mip_table_id = Omon OPmon
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1189,7 +1189,7 @@ dimension = longitude latitude
 expression = hfgeou
 mip_table_id = Ofx OPfx
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1199,7 +1199,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(-1*berg_latent_heat_flux, vohflisf)
 mip_table_id = Omon OPmonLev
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -1209,7 +1209,7 @@ dimension = longitude latitude time
 expression = m01s03i234[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -1219,7 +1219,7 @@ dimension = longitude latitude time
 expression = hfrainds
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1230,7 +1230,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(hflx_rnf, -1*vohfcisf)
 mip_table_id = Omon OPmonLev
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -1248,7 +1248,7 @@ dimension = longitude latitude time
 expression = m01s03i217[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -1257,7 +1257,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfx, mask_2D_U)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -1266,7 +1266,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfy, mask_2D_V)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -1276,7 +1276,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3)
     * m01s34i007[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1287,7 +1287,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HO2)
     * m01s51i082[blev=PLEV39, lbproc=192]
     / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 
@@ -1299,7 +1299,7 @@ expression = combine_cubes_to_basin_coord(hfovgyre_global, hfovgyre_atlantic,
     hfovgyre_indopacific, mask_global=global_ocean_1D_V,
     mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1311,7 +1311,7 @@ expression = combine_cubes_to_basin_coord(hfovovrt_global, hfovovrt_atlantic,
     hfovovrt_indopacific, mask_global=global_ocean_1D_V,
     mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1320,7 +1320,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i113[lbproc=128]
 mip_table_id = CFday CFmon APdayLev APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = %
 
@@ -1448,7 +1448,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i245[lbproc=128]
 mip_table_id = 6hrPlev Amon day AP6hr APday APmon
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = %
 
@@ -1483,7 +1483,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128]
     / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1501,7 +1501,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i295[blev=PLEV7H, lbproc=0]
     / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt AP6hrPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1518,7 +1518,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128]
     / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1535,7 +1535,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i295[blev=PLEV27, lbproc=128]
     / m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1629,7 +1629,7 @@ dimension = longitude latitude p850 time
 expression = m01s30i295[blev=P850, lbproc=128]
     / m01s30i304[blev=P850, lbproc=128]
 mip_table_id = Eday GCAmon GCday APday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1652,7 +1652,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i237[lbproc=128]
 mip_table_id = Amon day APday APmon
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = 1
 
@@ -1669,7 +1669,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i462[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -1686,7 +1686,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i463[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -1696,7 +1696,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_ISOPRENE)
     * m01s34i027[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1705,7 +1705,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i229[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1715,7 +1715,7 @@ dimension = latitude plev39 time
 expression = m01s52i245[blev=PLEV39, lbproc=192]
     / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ APmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1725,7 +1725,7 @@ dimension = latitude plev39 time
 expression = m01s52i246[blev=PLEV39, lbproc=192]
     / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ APmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1734,7 +1734,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadIc tau time
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -1743,7 +1743,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadLi tau time
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday APmon APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -1752,7 +1752,7 @@ component = dust
 dimension = longitude latitude time
 expression = calc_loaddust(m01s17i257[lbproc=128], m01s50i255[lbproc=128])
 mip_table_id = Emon Eday APday APmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1763,7 +1763,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i247[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -1773,7 +1773,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i071[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -1782,7 +1782,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -1792,7 +1792,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = masscello
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2
 
@@ -1801,7 +1801,7 @@ component = ocean
 dimension = time
 expression = scvoltot * SEAWATER_DENSITY
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg
 
@@ -1810,7 +1810,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=8192]
 mip_table_id = AERday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -1819,7 +1819,7 @@ dimension = longitude latitude alevhalf time
 expression = (m01s05i250[lbproc=128] - m01s05i251[lbproc=128]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = Amon CFday APdayLev APmonLev
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1828,7 +1828,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i251[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1837,7 +1837,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i250[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1850,7 +1850,7 @@ expression = (m01s51i150[blev=PLEV39, lbproc=192]
     / m01s51i999[blev=PLEV39, lbproc=192])
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = AERmonZ AEmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = yr
 
@@ -1859,7 +1859,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=4096]
 mip_table_id = AERday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -1868,7 +1868,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotst
 mip_table_id = Eday Omon OPday OPmon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -1877,7 +1877,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmax
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -1886,7 +1886,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmin
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -1895,7 +1895,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstsq
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -2062,7 +2062,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i105[lbproc=128] + m01s34i109[lbproc=128]
     + m01s34i115[lbproc=128] + m01s34i120[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2073,7 +2073,7 @@ expression = m01s00i431[lbproc=128] + m01s00i432[lbproc=128]
     + m01s00i433[lbproc=128] + m01s00i434[lbproc=128] + m01s00i435[lbproc=128]
     + m01s00i436[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2084,7 +2084,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i106[lbproc=128] + m01s34i110[lbproc=128]
     + m01s34i116[lbproc=128] + m01s34i121[lbproc=128] + m01s34i126[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2097,7 +2097,7 @@ expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4)
     + m01s34i108[lbproc=128]
     + m01s34i114[lbproc=128])
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2106,7 +2106,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i111[lbproc=128] + m01s34i117[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2117,7 +2117,7 @@ expression = level_sum(m01s08i223[lbproc=128]
     * m01s08i230[lbproc=128]
     / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Lmon LPmon
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -2144,7 +2144,7 @@ expression = level_sum(m01s08i223[lbproc=128]
     * m01s08i229[lbproc=128]
     / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2153,7 +2153,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128] + m01s08i235[lbproc=128]
 mip_table_id = 3hr Lmon day LP3hr LPday LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2162,7 +2162,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i235[lbproc=128]
 mip_table_id = Eday GCLmon LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2171,7 +2171,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2181,7 +2181,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i230[lbproc=128]
     / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Eday Emon LPday LPmon mon day 6hr
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2191,7 +2191,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i229[lbproc=128]
     / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Eday Emon LPday LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2200,7 +2200,7 @@ component = land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128])
 mip_table_id = Lmon day LPmon LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2211,7 +2211,7 @@ component = land
 dimension = longitude latitude
 expression = mask_zeros(m01s00i041 * FRESHWATER_DENSITY)
 mip_table_id = fx LPfx
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = kg m-2
 
@@ -2220,7 +2220,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Eday Emon LPday LPmon mon day
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>,
+reviewer = Ron Kahana (Met Office),
     Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = kg m-2
@@ -2230,7 +2230,7 @@ component = land
 dimension = longitude latitude sdepth1 time
 expression = m01s08i223[blev=0.05, lbproc=128]
 mip_table_id = day Lmon LPmon LPday mon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2242,7 +2242,7 @@ dimension = longitude latitude time
 expression = ocean_quasi_barotropic_streamfunc(umo_vint, areacello,
                                                cube_mask=mask_2D_T)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -2254,7 +2254,7 @@ expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfglo,
     zomsfatl, zomsfipc, mask_global=global_ocean_2D_V,
     mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -2266,7 +2266,7 @@ expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfeivglo,
     zomsfeivatl, zomsfeivipc, mask_global=global_ocean_2D_V,
     mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -2277,7 +2277,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
     * m01s51i049[blev=PLEV19, lbproc=128]
     / m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2287,7 +2287,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i049[lbproc=128],
     MOLECULAR_MASS_OF_N2O)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -2297,7 +2297,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO)
     * m01s34i002[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2307,7 +2307,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2)
     * m01s34i996[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2328,7 +2328,7 @@ expression = MOLECULAR_MASS_OF_AIR
     + (m01s51i996[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO2))
     / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2339,7 +2339,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
     * m01s51i001[blev=PLEV19, lbproc=128]
     / m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2350,7 +2350,7 @@ expression = (m01s50i011[lbproc=128] + m01s50i013[lbproc=128]
     + m01s50i014[lbproc=128] + m01s50i015[lbproc=128])
     / m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -2361,7 +2361,7 @@ expression = (m01s50i001[lbproc=128] + m01s50i003[lbproc=128]
     + m01s50i103[lbproc=128])
     / m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -2371,7 +2371,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(obvfsq, mask_3D_T)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = s-2
 
@@ -2383,7 +2383,7 @@ expression = m01s02i285[lbplev=2, lbproc=128]
     + m01s02i300[lbplev=2, lbproc=128] + m01s02i301[lbplev=2, lbproc=128]
     + m01s02i302[lbplev=2, lbproc=128] + m01s02i303[lbplev=2, lbproc=128]
 mip_table_id = AERmon CresAERday Cres1HrMn AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2393,7 +2393,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=2, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2404,7 +2404,7 @@ expression = m01s02i285[lbplev=3, lbproc=128]
     + m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128]
     + m01s02i302[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERday AERmon CresAERday Cres1HrMn AEday AEmon mon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2416,7 +2416,7 @@ expression = m01s02i251[lbplev=3, lbproc=128]
     + m01s02i252[lbplev=3, lbproc=128] + m01s02i253[lbplev=3, lbproc=128]
     + m01s02i254[lbplev=3, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2425,7 +2425,7 @@ component = dust
 dimension = longitude latitude lambda550nm time
 expression = m01s02i285[lbplev=3, lbproc=128]
 mip_table_id = AERmon CresAERday AEmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2436,7 +2436,7 @@ dimension = longitude latitude lambda550nm time
 expression = m01s02i300[lbplev=3, lbproc=128]
     + m01s02i301[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2446,7 +2446,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=5, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2458,7 +2458,7 @@ expression = m01s02i285[lbplev=5, lbproc=128]
     + m01s02i300[lbplev=5, lbproc=128] + m01s02i301[lbplev=5, lbproc=128]
     + m01s02i302[lbplev=5, lbproc=128] + m01s02i303[lbplev=5, lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2468,7 +2468,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH)
     * m01s34i081[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2478,7 +2478,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2490,7 +2490,7 @@ component = ocean
 dimension = longitude latitude time
 expression = opottempmint
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC kg m-2
 
@@ -2500,7 +2500,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemppmdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2510,7 +2510,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempadvect
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2520,7 +2520,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemptend
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2529,7 +2529,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = m01s00i033
 mip_table_id = fx LPfx mon day 6hr 3hr 1hr
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -2539,7 +2539,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2549,7 +2549,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltpmdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2559,7 +2559,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltadvect
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2569,7 +2569,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osalttend
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2579,7 +2579,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_PAN)
     * m01s34i017[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2588,7 +2588,7 @@ component = cftables
 dimension = longitude latitude sza5 time
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=128])
 mip_table_id = Eday Emon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -2597,7 +2597,7 @@ component = ocean
 dimension = longitude latitude time
 expression = pbo
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = dbar
 
@@ -2606,7 +2606,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i333[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -2615,7 +2615,7 @@ component = atmos-physics cftables
 dimension = longitude latitude alevel time
 expression = m01s00i408[lbproc=128]
 mip_table_id = AERmon CFday AEmonLev APdayLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2626,7 +2626,7 @@ component = aerosol cftables
 dimension = longitude latitude alevhalf time
 expression = m01s00i407[lbproc=128]
 mip_table_id = AERmon CFday APdayLev AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = Pa
 
@@ -2635,7 +2635,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i228[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -2651,7 +2651,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128]
 mip_table_id = 3hr 6hrPlev Amon E1hr day CresAERday AP1hr AP3hr AP6hr APday APmon mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2661,7 +2661,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128] + m01s05i206[lbproc=128]
 mip_table_id = 3hr Amon E1hr day AP1hr AP3hr APday APmon mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2671,7 +2671,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i227[lbproc=0]
 mip_table_id = CF3hr AP3hrPtLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2680,7 +2680,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i223[lbproc=0]
 mip_table_id = CF3hr AP3hrPtLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2689,7 +2689,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i222[lbproc=0]
 mip_table_id = CF3hr AP3hrPtLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2698,7 +2698,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i214[lbproc=128]
 mip_table_id = E3hr AP3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2707,7 +2707,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128]
 mip_table_id = E3hr Eday AP3hr APday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2716,7 +2716,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i215[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2726,7 +2726,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i206[lbproc=128]
 mip_table_id = E3hr GCAmon AP3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2735,7 +2735,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i461[lbproc=128]
 mip_table_id = Amon Eday APday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2
 
@@ -2744,7 +2744,7 @@ component = atmos-physics cftables
 dimension = longitude latitude time
 expression = m01s00i409[lbproc=128]
 mip_table_id = AERhr AERmon Amon CFday CFmon Emon CresAERday Cres1HrMn AP1hr APday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2753,7 +2753,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s16i222[lbproc=128]
 mip_table_id = 6hrPlev Amon day APmon AP6hr APday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2762,7 +2762,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i451[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2774,7 +2774,7 @@ dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128],
     m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2783,7 +2783,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2792,7 +2792,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2801,7 +2801,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2810,7 +2810,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2819,7 +2819,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s01i245[lbproc=128] / m01s01i246[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2832,7 +2832,7 @@ expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128],
     m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128]
     + m01s02i396[lbproc=128]))
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2843,7 +2843,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i218[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2853,7 +2853,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i522[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2864,7 +2864,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i220[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2874,7 +2874,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i524[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2885,7 +2885,7 @@ dimension = longitude latitude time
 expression = m01s02i207[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2896,7 +2896,7 @@ dimension = longitude latitude time
 expression = m01s02i208[lbproc=128]
 mip_table_id = 3hr Amon CFday AP3hr APday APmon mon day 6hr
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2907,7 +2907,7 @@ expression = m01s02i201[lbproc=128] - (m01s03i332[lbproc=128]
     - m01s02i205[lbproc=128])
 mip_table_id = Eday Emon APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2918,7 +2918,7 @@ expression = hotspot(m01s02i217[lbproc=128], m01s03i332[lbproc=128],
     m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2929,7 +2929,7 @@ expression = hotspot(m01s02i521[lbproc=128], m01s03i332[lbproc=128],
     m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2940,7 +2940,7 @@ expression = hotspot(m01s02i219[lbproc=128], m01s03i332[lbproc=128],
     m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2951,7 +2951,7 @@ expression = hotspot(m01s02i523[lbproc=128], m01s03i332[lbproc=128],
     m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2963,7 +2963,7 @@ expression = m01s02i207[lbproc=128] - m01s02i201[lbproc=128]
     + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2973,7 +2973,7 @@ dimension = longitude latitude time
 expression = m01s03i332[lbproc=128]
 mip_table_id = Amon day APmon APday
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2984,7 +2984,7 @@ expression = remove_altitude_coords(m01s02i521[lblev=86, lbproc=128])
     + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2995,7 +2995,7 @@ expression = remove_altitude_coords(m01s02i517[lblev=86, lbproc=128])
     + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -3006,7 +3006,7 @@ expression = m01s02i206[lbproc=128] + m01s03i332[lbproc=128]
     - m01s02i205[lbproc=128]
 mip_table_id = Amon CFday APday APmon mon day 6hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3017,7 +3017,7 @@ expression = remove_altitude_coords(m01s02i523[lblev=86, lbproc=128])
     + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3028,7 +3028,7 @@ expression = remove_altitude_coords(m01s02i519[lblev=86, lbproc=128])
     + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -3039,7 +3039,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i218[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3049,7 +3049,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i522[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3060,7 +3060,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i220[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3070,7 +3070,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i524[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3105,7 +3105,7 @@ dimension = longitude latitude olevel time
 expression = rsdo
 mip_table_id = Omon OPmonLev
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -3115,7 +3115,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = rsdoabsorb
 mip_table_id = Emon OPmonLev
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = W m-2
 
@@ -3126,7 +3126,7 @@ dimension = longitude latitude time
 expression = m01s01i235[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3137,7 +3137,7 @@ dimension = longitude latitude time
 expression = m01s01i210[lbproc=128]
 mip_table_id = 3hr Amon CFday APmon AP3hr APday mon day 6hr
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3171,7 +3171,7 @@ dimension = longitude latitude time
 expression = m01s01i216[lbproc=128]
 mip_table_id = 3hr Eday Emon AP3hr APday APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3181,7 +3181,7 @@ dimension = longitude latitude time
 expression = m01s01i207[lbproc=128]
 mip_table_id = Amon CFday APmon APday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3191,7 +3191,7 @@ dimension = longitude latitude time
 expression = m01s01i201[lbproc=128]
 mip_table_id = Emon APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3202,7 +3202,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i217[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3212,7 +3212,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i521[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3223,7 +3223,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i219[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3233,7 +3233,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i523[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3268,7 +3268,7 @@ dimension = longitude latitude time
 expression = m01s01i235[lbproc=128] - m01s01i201[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3278,7 +3278,7 @@ dimension = longitude latitude time
 expression = m01s01i211[lbproc=128]
 mip_table_id = 3hr Amon CFday AP3hr APday APmon mon day 6hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3313,7 +3313,7 @@ dimension = longitude latitude time
 expression = m01s01i208[lbproc=128]
 mip_table_id = Amon CFday APday APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3323,7 +3323,7 @@ dimension = longitude latitude time
 expression = m01s01i521[lblev=86, lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3333,7 +3333,7 @@ dimension = longitude latitude time
 expression = m01s01i517[lblev=86, lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3343,7 +3343,7 @@ dimension = longitude latitude time
 expression = m01s01i209[lbproc=128]
 mip_table_id = Amon CFday E3hr AP3hr APday APmon mon day 6hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3353,7 +3353,7 @@ dimension = longitude latitude time
 expression = m01s01i523[lblev=86, lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3363,7 +3363,7 @@ dimension = longitude latitude time
 expression = m01s01i519[lblev=86, lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3390,7 +3390,7 @@ expression = m01s01i207[lbproc=128] - m01s01i208[lbproc=128]
     - m01s03i332[lbproc=128]
 mip_table_id = Amon APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3407,7 +3407,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i331[lbproc=128], m01s03i317[lbproc=128],
     land_class='all')
 mip_table_id = LImon Eday LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3416,7 +3416,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i270[lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Rachel Stratton <rachel.stratton@metoffice.gov.uk>
+reviewer = Rachel Stratton (Met Office)
 status = ok
 units = 1
 
@@ -3429,7 +3429,7 @@ expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128],
     m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128]
     + m01s02i396[lbproc=128]))
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -3438,7 +3438,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s17i257[lblev=1, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -3449,7 +3449,7 @@ expression = m01s03i230[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr Prim3hr day AP3hr AP6hr APday APmon
 notes = An arbitrary choice between 'B-grid' or 'C-grid' but it would seem
     sensible to use the same throughout.
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -3725,7 +3725,7 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2)
     * m01s34i996[lblev=1, lbproc=128]
 mip_table_id = AERhr AE1hr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -3735,7 +3735,7 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
     * m01s34i001[lblev=1, lbproc=128]
 mip_table_id = AERhr AE1hr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -3745,7 +3745,7 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
     * m01s34i001[lblev=1, lbproc=8192]
 mip_table_id = AERday AEday
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3763,7 +3763,7 @@ component = land
 dimension = longitude latitude typeland
 expression = m01s00i505
 mip_table_id = fx APfx mon day 6hr 3hr 1hr
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = 1
 
@@ -3772,7 +3772,7 @@ component = ocean
 dimension = longitude latitude typesea
 expression = sftof
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = %
 
@@ -3781,7 +3781,7 @@ component = seaice
 dimension = longitude latitude time
 expression = iage * SECONDS_IN_DAY * DAYS_IN_YEAR
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s
 
@@ -3797,7 +3797,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sicompstren
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-1
 
@@ -3806,7 +3806,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3815,7 +3815,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = m01s00i031[lbproc=128]
 mip_table_id = SIday SImon mon day
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3824,7 +3824,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcdyn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -3833,7 +3833,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcth
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -3842,7 +3842,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtd * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3852,7 +3852,7 @@ dimension = longitude latitude time
 expression = -1 * evap_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3861,7 +3861,7 @@ component = seaice
 dimension = longitude latitude time
 expression = congel * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3870,7 +3870,7 @@ component = seaice
 dimension = longitude latitude time
 expression = frazil * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3879,7 +3879,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltl * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3888,7 +3888,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltb * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3897,7 +3897,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3906,7 +3906,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3915,7 +3915,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3924,7 +3924,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstranx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -3933,7 +3933,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstrany
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -3942,7 +3942,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i538[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3951,7 +3951,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sifb
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3961,7 +3961,7 @@ dimension = longitude latitude time
 expression = siflcondbot
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -3971,7 +3971,7 @@ dimension = longitude latitude time
 expression = siflcondtop
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -3981,7 +3981,7 @@ dimension = longitude latitude time
 expression = ((meltt + meltb + meltl - congel - frazil) * ICE_DENSITY + melts
     * SNOW_DENSITY) / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [siflfwdrain]
@@ -3990,7 +3990,7 @@ dimension = longitude latitude time
 expression = (meltt * ICE_DENSITY + melts * SNOW_DENSITY)
     / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sifllatstop]
@@ -4007,7 +4007,7 @@ dimension = longitude latitude time
 expression = m01s02i501[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4017,7 +4017,7 @@ dimension = longitude latitude time
 expression = m01s03i531[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4066,7 +4066,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecoriolx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4075,7 +4075,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecorioly
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4084,7 +4084,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstrx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4093,7 +4093,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstry
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4102,7 +4102,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetiltx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4111,7 +4111,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetilty
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4120,7 +4120,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sihc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -4129,7 +4129,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4138,7 +4138,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = snowfracn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4147,7 +4147,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vsnon / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4156,7 +4156,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vicen / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4165,7 +4165,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi * ICE_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -4177,7 +4177,7 @@ component = seaice
 dimension = longitude latitude typemp time
 expression = apond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4188,7 +4188,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hpond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4201,7 +4201,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ipond_ai / apond_ai
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4210,7 +4210,7 @@ component = seaice
 dimension = longitude latitude time
 expression = rain_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sirdgconc]
@@ -4218,7 +4218,7 @@ component = seaice
 dimension = longitude latitude typesirdg time
 expression = ardg
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4237,7 +4237,7 @@ mip_table_id = SImon
 notes = The interpretation of this variable in CICE is not obvious as CICE has
     two simultaneous salinity profiles (when prognostic salinity is not being
     used).
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -4246,7 +4246,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snowfrac / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4255,7 +4255,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnhc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -4264,7 +4264,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hs * SNOW_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -4273,7 +4273,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnthick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4282,7 +4282,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sispeed
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -4323,7 +4323,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sitempbot
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -4332,7 +4332,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i535[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SIday SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -4341,7 +4341,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sithick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4350,7 +4350,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ice_present
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4359,7 +4359,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siu
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -4368,7 +4368,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siv
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -4377,7 +4377,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4389,7 +4389,7 @@ expression = 1.026 * combine_cubes_to_basin_coord(sltbasin_global,
     sltbasin_atlantic, sltbasin_indopacific, mask_global=global_ocean_1D_V,
     mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = EmonZ OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -4401,7 +4401,7 @@ expression = 1.026 * combine_cubes_to_basin_coord(sltovgyre_global,
     sltovgyre_atlantic, sltovgyre_indopacific, mask_global=global_ocean_1D_V,
     mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -4413,7 +4413,7 @@ expression = 1.026 * combine_cubes_to_basin_coord(sltovovrt_global,
     sltovovrt_atlantic, sltovovrt_indopacific, mask_global=global_ocean_1D_V,
     mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -4430,7 +4430,7 @@ expression = snc_calc(m01s08i236[lbproc=128],
     m01s03i317[lbproc=128],
     m01s03i395[lbproc=128])
 mip_table_id = day LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = %
 
@@ -4442,7 +4442,7 @@ expression = land_class_mean(m01s08i376[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='all')
 mip_table_id = Eday LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = m
 
@@ -4451,7 +4451,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvsdtd * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4460,7 +4460,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * melts * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4469,7 +4469,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4478,7 +4478,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snow_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4488,7 +4488,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i237[lbproc=128], m01s03i317[lbproc=128],
     land_class='all')
 mip_table_id = Eday LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4499,7 +4499,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i236[lbproc=128], m01s03i317[lbproc=128],
     land_class='all')
 mip_table_id = day LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -4509,7 +4509,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = so
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4519,7 +4519,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i072[lbproc=128] * (MOLECULAR_MASS_OF_AIR
     / MOLECULAR_MASS_OF_SO2)
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -4528,7 +4528,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sob
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4537,7 +4537,7 @@ component = ocean
 dimension = time
 expression = soga
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4556,7 +4556,7 @@ component = ocean
 dimension = longitude latitude time
 expression = somint
 mip_table_id = Emon OPmon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = 1e-3 kg m-2
 
@@ -4565,7 +4565,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sos
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4574,7 +4574,7 @@ component = ocean
 dimension = time
 expression = area_mean(sos, areacello)
 mip_table_id = Oday Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4583,7 +4583,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sossq
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-6
 
@@ -4593,7 +4593,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(
     m01s08i236[lbproc=128] / FRESHWATER_DENSITY, m01s03i317[lbproc=128])
 mip_table_id = Emon LPmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = m
 
@@ -4602,7 +4602,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i044[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1e5 K2
 
@@ -4613,7 +4613,7 @@ expression = t20d
 mip_table_id = Eday Emon OPday OPmon
 notes = PMIP variables: Variable will be output with a time dimension and with
     cell_methods for time.
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -4623,7 +4623,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=128]
     / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday APday APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4633,7 +4633,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i294[blev=PLEV7H, lbproc=0]
     / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt E3hrPt AP6hrPt AP3hrPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
@@ -4657,7 +4657,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i294[blev=PLEV27, lbproc=128]
     / m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4730,7 +4730,7 @@ dimension = longitude latitude p500 time
 expression = m01s30i294[blev=P500, lbproc=128]
     / m01s30i304[blev=P500, lbproc=128]
 mip_table_id = Eday GCAmon GCday APday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4747,7 +4747,7 @@ dimension = longitude latitude p700 time
 expression = m01s30i294[blev=P700, lbproc=128]
     / m01s30i304[blev=P700, lbproc=128]
 mip_table_id = CFday GCAmon GCday APday mon day 6hr
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
@@ -4757,7 +4757,7 @@ dimension = longitude latitude p850 time
 expression = m01s30i294[blev=P850, lbproc=128]
     / m01s30i304[blev=P850, lbproc=128]
 mip_table_id = Eday GCAmon GCday APday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4780,7 +4780,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=128]
 mip_table_id = 6hrPlev Amon day CresAERday Cres1HrMn AP6hr APday APmon mon 1hr
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = K
 
@@ -4789,7 +4789,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=8192])
 mip_table_id = Amon CresAERday APmon mon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4798,7 +4798,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=4096])
 mip_table_id = Amon APmon mon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4818,7 +4818,7 @@ dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Amon Eday APday APmon
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -4828,7 +4828,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauuo, mask_2D_U)
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -4837,7 +4837,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -4850,7 +4850,7 @@ dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Amon Eday APday APmon
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -4860,7 +4860,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauvo, mask_2D_V)
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -4869,7 +4869,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -4885,7 +4885,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i316[lbplev=8, lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = K
 
@@ -4895,7 +4895,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thetao
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4904,7 +4904,7 @@ component = ocean
 dimension = time
 expression = thetaoga
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4913,7 +4913,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao, thkcello)
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4922,7 +4922,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<300], thkcello[depth<300])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4931,7 +4931,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<735], thkcello[depth<735])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4940,7 +4940,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<2025], thkcello[depth<2025])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4950,7 +4950,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thkcello
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -4959,7 +4959,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i182[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4969,7 +4969,7 @@ dimension = longitude latitude alevel time
 expression = (m01s12i182[lbproc=128] + m01s12i382[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
 notes = Obtained by advection plus solver
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4978,7 +4978,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i162[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4991,7 +4991,7 @@ expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128]
     + m01s16i182[lbproc=128] + m01s35i025[lbproc=128] ) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
 notes = Methane Oxidation added.
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5000,7 +5000,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i190[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5012,7 +5012,7 @@ expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128]
     + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128]
     + m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5027,7 +5027,7 @@ expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128]
     + m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128]
     + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5050,7 +5050,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i181[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5061,7 +5061,7 @@ expression = (m01s10i181[lbproc=128] + m01s12i181[lbproc=128]
     + m01s12i381[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
 notes = Obtained by Solver plus Advection plus Conservations Corrections
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5070,7 +5070,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5083,7 +5083,7 @@ expression = (m01s14i181[lbproc=128] + m01s01i181[lbproc=128]
     + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s35i029[lbproc=128])
     / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5092,7 +5092,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i189[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5101,7 +5101,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s01i161[lbproc=128] + m01s02i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5111,7 +5111,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon AEmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5120,7 +5120,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i233[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5130,7 +5130,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon AEmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5139,7 +5139,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i233[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5152,7 +5152,7 @@ expression = (m01s03i181[lbproc=128] - m01s03i189[lbproc=128]
     + m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128]
     - m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5168,7 +5168,7 @@ expression = (m01s03i181[lbproc=128] + m01s04i141[lbproc=128]
     - m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128])
     / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5177,7 +5177,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tob
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -5186,7 +5186,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tos
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -5195,7 +5195,7 @@ component = ocean
 dimension = time
 expression = area_mean(tos, areacello)
 mip_table_id = Oday Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -5204,7 +5204,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tossq
 mip_table_id = Oday Omon OPday OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC2
 
@@ -5213,7 +5213,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i219[lblev=1, lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = 1e-5 m
 
@@ -5223,7 +5223,7 @@ dimension = longitude latitude time
 expression = m01s03i539[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon
 positive = up
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5232,8 +5232,8 @@ component = chemistry
 dimension = longitude latitude time
 expression = trop_o3col(m01s34i001[lbproc=128]
     * m01s50i063[lbproc=128] * m01s50i062[lbproc=128])
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>,
-    Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (University of Cambridge),
+    Mohit Dalvi (Met Office)
 status = ok
 mip_table_id = AERmon AEmon
 units = 1.0e-5 m
@@ -5243,7 +5243,7 @@ component = atmos-physics boundary-layer
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128]
 mip_table_id = Amon Eday APday APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -5252,7 +5252,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon mon day 6hr
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>,
+reviewer = Ron Kahana (Met Office),
     Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = K
@@ -5269,7 +5269,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i011[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -5279,7 +5279,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128]
     / m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5297,7 +5297,7 @@ dimension = longitude latitude p10 time
 expression = m01s30i201[blev=P10, lbproc=128]
     / m01s30i301[blev=P10, lbproc=128]
 mip_table_id = AERday GCAmon AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5307,7 +5307,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128]
     / m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5324,7 +5324,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i201[blev=PLEV27, lbproc=128]
     / m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -5454,7 +5454,7 @@ component = boundary-layer
 dimension = longitude latitude height10m time
 expression = m01s03i209[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr day AP6hr APday APmon AP3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5464,7 +5464,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(umo, mask_3D_U)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -5474,7 +5474,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(uo, mask_3D_U)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -5487,7 +5487,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i428[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -5496,7 +5496,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i014[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -5507,7 +5507,7 @@ dimension = latitude plev39 time
 expression = zonal_apply_heaviside(m01s30i314[blev=PLEV39, lbproc=192],
     m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APmonZ APdayZ
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-2
 
@@ -5523,7 +5523,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s06i247[blev=PLEV19, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 
@@ -5532,7 +5532,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i012[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -5541,7 +5541,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i022[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -5551,7 +5551,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128]
     / m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5576,7 +5576,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128]
     / m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5593,7 +5593,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i202[blev=PLEV27, lbproc=128]
     / m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -5723,7 +5723,7 @@ component = boundary-layer
 dimension = longitude latitude height10m time
 expression = m01s03i210[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr day AP3hr AP6hr APday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5733,7 +5733,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vmo, mask_3D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -5747,7 +5747,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
     + m01s51i059[blev=PLEV39, lbproc=192])
     / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ ACmonZ
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -5757,7 +5757,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vo, mask_3D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -5767,7 +5767,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = volcello(thkcello, areacello)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -5776,7 +5776,7 @@ component = ocean
 dimension = time
 expression = scvoltot
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -5785,7 +5785,7 @@ component = atmos-physics
 dimension = longitude latitude pl700 time1
 expression = vortmean(m01s30i457[blev=600 700 850, lbproc=0])
 mip_table_id = 6hrPlevPt AP6hrPt
-reviewer = Malcolm Roberts <malcolm.roberts@metoffice.gov.uk>
+reviewer = Malcolm Roberts (Met Office)
 status = ok
 units = s-1
 
@@ -5798,7 +5798,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i429[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -5807,7 +5807,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i024[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -5818,7 +5818,7 @@ dimension = latitude plev39 time
 expression = mask_vtem(m01s30i310[blev=PLEV39, lbproc=192],
     m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APmonZ APdayZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -5827,7 +5827,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s00i150[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5963,7 +5963,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i298[blev=PLEV19, lbproc=128]
     / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -5973,7 +5973,7 @@ dimension = longitude latitude plev4 time
 expression = m01s30i298[blev=PLEV4, lbproc=128]
     / m01s30i304[blev=PLEV4, lbproc=128]
 mip_table_id = 6hrPlev AP6hr
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -5983,7 +5983,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i298[blev=PLEV7H, lbproc=0]
     / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = E3hrPt AP3hrPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6070,7 +6070,7 @@ dimension = longitude latitude p500 time
 expression = m01s30i298[blev=P500, lbproc=128]
     / m01s30i304[blev=P500, lbproc=128]
 mip_table_id = CFday GCAmon APday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6133,7 +6133,7 @@ expression = m01s04i231[lbproc=128] + m01s04i232[lbproc=128]
     + m01s05i283[lbproc=128] + m01s05i284[lbproc=128] + m01s05i285[lbproc=128]
     + m01s05i286[lbproc=128]
 mip_table_id = AERmon CresAERday AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -6142,7 +6142,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s08i242[lbproc=128] * MOLECULAR_MASS_OF_CH4 / ATOMIC_MASS_OF_C
 mip_table_id = Emon LPmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = ug m-2 s-1
 
@@ -6151,7 +6151,7 @@ component = carbon
 dimension = longitude latitude typewetla time
 expression = m01s08i248[lbproc=128] * m01s03i395[lbproc=128]
 mip_table_id = Emon LPmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = 1
 
@@ -6160,7 +6160,7 @@ component = ocean
 dimension = longitude latitude time
 expression = -1 * (sowaflup + sowflisf)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -6170,7 +6170,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wmo, mask_3D_T)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -6180,7 +6180,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wo, mask_3D_T)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -6196,8 +6196,8 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i249[lbproc=128]
 mip_table_id = Eday Emon LPday LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -6207,7 +6207,7 @@ dimension = latitude plev39 time
 expression = mask_polar_column_zonal_means(
     m01s30i311[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APdayZ APmonZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -6224,7 +6224,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = zfull
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6234,7 +6234,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=128]
     / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6244,7 +6244,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i297[blev=PLEV7H, lbproc=0]
     / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt Prim3hrPt AP6hrPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -6254,7 +6254,7 @@ dimension = longitude latitude p10 time
 expression = m01s30i297[blev=P10, lbproc=128]
     / m01s30i304[blev=P10, lbproc=128]
 mip_table_id = AERday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6264,7 +6264,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i297[blev=PLEV27, lbproc=128]
     / m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -6274,7 +6274,7 @@ dimension = longitude latitude p100 time
 expression = m01s30i297[blev=P100, lbproc=128]
     / m01s30i304[blev=P100, lbproc=128]
 mip_table_id = AERday AEday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -6315,7 +6315,7 @@ dimension = longitude latitude p500 time
 expression = m01s30i297[blev=P500, lbproc=128]
     / m01s30i304[blev=P500, lbproc=128]
 mip_table_id = AERday GCAmon GCday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6355,7 +6355,7 @@ dimension = longitude latitude p1000 time
 expression = m01s30i297[blev=P1000, lbproc=128]
     / m01s30i304[blev=P1000, lbproc=128]
 mip_table_id = GCAmon GCday 6hrPlev AERday AP6hr APday mon day 6hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6372,7 +6372,7 @@ component = ocean
 dimension = longitude latitude olevhalf time
 expression = zhalf
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6381,7 +6381,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6390,7 +6390,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zos
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6399,7 +6399,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zossq
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -6411,7 +6411,7 @@ dimension = time
 expression = calc_zostoga(thetao, thkcello, areacello,
                           zfullo_0, so_0, rho_0_mean, deptho_0_mean)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6420,6 +6420,6 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i453[lbproc=128] + m01s00i033[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m

--- a/mip_convert/mip_convert/process/common_mappings.cfg
+++ b/mip_convert/mip_convert/process/common_mappings.cfg
@@ -2221,7 +2221,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Eday Emon LPday LPmon mon day
 reviewer = Ron Kahana (Met Office),
-    Eleanor Burke <eleanor.burke@metoffice.gov.uk
+    Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -5253,7 +5253,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon mon day 6hr
 reviewer = Ron Kahana (Met Office),
-    Eleanor Burke <eleanor.burke@metoffice.gov.uk
+    Eleanor Burke (Met Office)
 status = ok
 units = K
 

--- a/mip_convert/mip_convert/process/day_mappings.cfg
+++ b/mip_convert/mip_convert/process/day_mappings.cfg
@@ -16,62 +16,62 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [hus]
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [ta]
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [sfcWindmax]
 expression = m01s03i230[lbproc=8192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [tasmax]
 expression = m01s03i236[lbproc=8192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [tasmin]
 expression = m01s03i236[lbproc=4096]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [ua]
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
     / m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [va]
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
     / m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [wap]
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [zg]
 dimension = longitude latitude plev8 time
 expression = m01s30i297[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok

--- a/mip_convert/mip_convert/process/eUKESM1_E3hr_mappings.cfg
+++ b/mip_convert/mip_convert/process/eUKESM1_E3hr_mappings.cfg
@@ -15,6 +15,6 @@ status = embargoed
 component = carbon
 dimension = longitude latitude time
 expression = m01s03i261[lbproc=128]
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1

--- a/mip_convert/mip_convert/process/eUKESM1_LImon_mappings.cfg
+++ b/mip_convert/mip_convert/process/eUKESM1_LImon_mappings.cfg
@@ -14,7 +14,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i578[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [hflsIs]
@@ -26,7 +26,7 @@ expression = land_class_mean(m01s03i330[lbproc=128],
     land_class='iceElev')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [hfssIs]
@@ -38,7 +38,7 @@ expression = land_class_mean(m01s03i290[lbproc=128],
     land_class='iceElev')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [litemptopIs]
@@ -49,7 +49,7 @@ expression = land_class_mean(m01s08i576[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = HadGEM3_variable_mapping:m01s08i225: UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [mrroIs]
@@ -60,7 +60,7 @@ expression = land_class_mean(m01s08i583[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM: ISMIP snowpack runoff definition not necessarily the same as UM.
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [rldsIs]
@@ -72,7 +72,7 @@ expression = land_class_mean(m01s03i384[lbproc=128],
     land_class='iceElev')
 notes = UM
 positive = down
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [rlusIs]
@@ -83,7 +83,7 @@ expression = land_class_mean(m01s03i383[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [sblIs]
@@ -94,7 +94,7 @@ expression = land_class_mean(m01s03i331[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [sftgif]
@@ -104,7 +104,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
     land_class='iceElev')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = %
 
 [snicefreezIs]
@@ -115,7 +115,7 @@ expression = land_class_mean(m01s08i580[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snicemIs]
@@ -126,7 +126,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snmIs]
@@ -137,7 +137,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [tasIs]
@@ -148,7 +148,7 @@ expression = land_class_mean(m01s03i328[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [tsIs]
@@ -159,5 +159,5 @@ expression = land_class_mean(m01s03i316[lbproc=128],
     m01s03i317[lbproc=128],
     land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K

--- a/mip_convert/mip_convert/process/eUKESM1_mappings.cfg
+++ b/mip_convert/mip_convert/process/eUKESM1_mappings.cfg
@@ -34,7 +34,7 @@ dimension = longitude latitude typebare time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='bareSoil')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -44,7 +44,7 @@ dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T + ZMI_E3T + ZME_E3T + DET_E3T)
     * FE_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -55,7 +55,7 @@ expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]
     + ZMI_E3T[depth=0] + ZME_E3T[depth=0]
     + DET_E3T[depth=0]) * FE_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -65,7 +65,7 @@ dimension = longitude latitude olevel time
 expression = PDS_E3T / thkcello
 mip_table_id = Omon
 notes = AXY: mostly a units thing; overlooking fast detritus Si
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -74,7 +74,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = PDS_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -84,7 +84,7 @@ dimension = longitude latitude typec3pft time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='c3')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -94,7 +94,7 @@ dimension = longitude latitude typec4pft time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='c4')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -104,7 +104,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CFC11_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = umol m-3
 
@@ -114,7 +114,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CFC12_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = umol m-3
 
@@ -123,7 +123,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (CHN_E3T + CHD_E3T) / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -132,7 +132,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CHD_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -141,7 +141,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = CHD_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -154,7 +154,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (CHN_E3T[depth=0] + CHD_E3T[depth=0]) / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -163,7 +163,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CHN_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -172,7 +172,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = CHN_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -183,8 +183,8 @@ expression = m01s19i002[lbtim_ia=240,lbproc=128] + m01s19i016[lbtim_ia=240,lbpro
     + m01s19i032[lbtim_ia=240,lbproc=128] + m01s19i033[lbtim_ia=240,lbproc=128]
     + m01s19i034[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -193,8 +193,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i026[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -204,7 +204,7 @@ dimension = longitude latitude alevel time
 expression = m01s00i252[lbproc=128]
     * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO2)
 mip_table_id = AERmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = mol mol-1
 
@@ -214,7 +214,7 @@ dimension = longitude latitude alevel time
 expression = m01s00i252[lbproc=128]
 mip_table_id = Emon
 notes = Available from emissions-driven runs only.
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg kg-1
 
@@ -225,7 +225,7 @@ expression = m01s00i252[lblev=1, lbproc=128]
     * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO2)
 mip_table_id = Emon
 notes = Available from emissions-driven runs only.
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = mol mol-1
 
@@ -236,7 +236,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CO33
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -249,7 +249,7 @@ expression = CO33 / CO3SATARAG3
 mip_table_id = Omon
 notes = AXY: think this needs calculating; but should it be?;
     MEDUSA ignores aragonite.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -267,7 +267,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CO33 / CO3SATCALC3
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -287,7 +287,7 @@ expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP
     * (m01s38i507[lbproc=128] + m01s38i510[lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-3
 
@@ -300,7 +300,7 @@ expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP
     + m01s38i506[lbproc=128] + m01s38i507[lbproc=128] + m01s38i508[lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-3
 
@@ -311,7 +311,7 @@ dimension = longitude latitude alevel time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i504[lbproc=128]
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-3
 
@@ -321,8 +321,8 @@ dimension = longitude latitude time
 expression = m01s19i032[lbtim_ia=240,lbproc=128] + m01s19i033[lbtim_ia=240,lbproc=128]
     + m01s19i034[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -331,8 +331,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i030[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -342,8 +342,8 @@ dimension = longitude latitude time typecrop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='crop')
 mip_table_id = Lmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -353,7 +353,7 @@ dimension = longitude latitude time typec3crop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='c3Crop')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -363,7 +363,7 @@ dimension = longitude latitude time typec4crop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='c4Crop')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -372,8 +372,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i016[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -383,7 +383,7 @@ dimension = longitude latitude time
 expression = m01s19i021[lbtim_ia=240,lbproc=128] + m01s19i022[lbtim_ia=240,lbproc=128]
     + m01s19i023[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2
 
@@ -392,7 +392,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i024[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2
 
@@ -401,8 +401,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i028[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -411,8 +411,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i002[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -422,8 +422,8 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='grass')
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -433,7 +433,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -443,7 +443,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -454,7 +454,7 @@ expression = DTC_E3T / thkcello
 mip_table_id = Omon
 notes = AXY: partly a units thing, but need to modify code to produce
     combined slow- and fast-sinking detritus.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -470,7 +470,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = FER_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -479,7 +479,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = FER_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -488,7 +488,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = DIC_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -504,7 +504,7 @@ component = obgc
 dimension = longitude latitude time
 expression = DMS_SURF
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = nmol L-1
 
@@ -513,7 +513,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = OCN_PCO2 - ATM_PCO2
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = uatm
 
@@ -525,8 +525,8 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C,
     + m01s38i222[lbproc=128] + m01s38i223[lbproc=128],
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>,
-    Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Nicolas Bellouin (University of Reading),
+    Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -539,7 +539,7 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C * CONV_C_ORGM,
     + m01s38i227[lbproc=128] + m01s38i228[lbproc=128],
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -549,7 +549,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO2,
     m01s50i154[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -561,7 +561,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
     + m01s38i217[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -572,7 +572,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL,
     m01s38i218[lbproc=128] + m01s38i219[lbproc=128],
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -585,7 +585,7 @@ expression = achem_emdrywet( ATOMIC_MASS_OF_C * CONV_C_ORGM,
     + m01s38i302[lbproc=128] + m01s38i303[lbproc=128] + m01s38i304[lbproc=128]
     + m01s38i305[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -595,7 +595,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epC100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -605,7 +605,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epCALC100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -615,7 +615,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epN100 * FE_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -625,7 +625,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epN100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -636,7 +636,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epN100 * P_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -646,7 +646,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epSI100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -658,7 +658,7 @@ dimension = longitude latitude olevel time
 expression = EXPC3
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -670,7 +670,7 @@ dimension = longitude latitude olevel time
 expression = FD_CAL3
 mip_table_id = Emon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -684,7 +684,7 @@ mip_table_id = Emon
 notes = AXY: already post-processable, but would be better if sinking fluxes
     are done more systematically; see earlier remarks.
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -698,7 +698,7 @@ mip_table_id = Emon
 notes = AXY: already post-processable, but would be better if sinking fluxes
     are done more systematically; see earlier remarks.
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -712,7 +712,7 @@ dimension = longitude latitude olevel time
 expression = EXPN3 * P_TO_N_RATIO
 mip_table_id = Emon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -724,7 +724,7 @@ dimension = longitude latitude olevel time
 expression = FD_SIL3
 mip_table_id = Emon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -733,7 +733,7 @@ component = land-use
 dimension = longitude latitude time
 expression = (m01s19i044[lbtim_ia=240,lbproc=128])/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -743,7 +743,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_ALK_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdic]
@@ -752,7 +752,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_DiC_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdife]
@@ -761,7 +761,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_FER_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdin]
@@ -770,7 +770,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_DIN_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdip]
@@ -782,7 +782,7 @@ expression = sum_over_upper_100m(SMS_DIN_E3T, thkcello)
     * P_TO_N_RATIO
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fbddtdisi]
@@ -793,7 +793,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_SIL_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fBNF]
@@ -802,8 +802,8 @@ dimension = longitude latitude time
 expression = m01s19i113[lbtim_ia=240,lbproc=128]
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -817,7 +817,7 @@ expression = m01s00i251[lbproc=128]
     + mdi_to_zero(m01s19i044[lbtim_ia=240,lbproc=128])) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Amon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -828,7 +828,7 @@ expression = m01s00i251[lbproc=128]
     * (ATOMIC_MASS_OF_C / MOLECULAR_MASS_OF_CO2)
 mip_table_id = Amon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -849,7 +849,7 @@ notes = For emissions driven runs. The land fraction use here is being sampled
     every 6 hours rather than being a true time average. However, this appears
     to be a constant field so there is no impact for current model configurations.
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -884,7 +884,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(TOT_DIN_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fddtdip]
@@ -896,7 +896,7 @@ expression = sum_over_upper_100m(TOT_DIN_E3T, thkcello)
     * P_TO_N_RATIO
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fddtdisi]
@@ -907,7 +907,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(TOT_SIL_E3T, thkcello)
 mip_table_id = Omon
 units = mmol m-2 s-1
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 
 [fDeforestToProduct]
@@ -918,8 +918,8 @@ expression = (m01s19i036[lbtim_ia=240,lbproc=128]
     + m01s19i038[lbtim_ia=240,lbproc=128])
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -930,7 +930,7 @@ dimension = longitude latitude time
 expression = qtrCFC11
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mol m-2 s-1
 
@@ -941,7 +941,7 @@ dimension = longitude latitude time
 expression = qtrCFC12
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mol m-2 s-1
 
@@ -951,8 +951,8 @@ dimension = longitude latitude time depth0m
 expression = CO2FLUX * ATOMIC_MASS_OF_C
 mip_table_id = Omon
 positive = down
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andrew Yool <axy@noc.ac.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andrew Yool (NOC)
 status = ok
 units = mg m-2 d-1
 
@@ -962,7 +962,7 @@ dimension = longitude latitude time depth0m
 expression = O2FLUX
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -973,7 +973,7 @@ dimension = longitude latitude time
 expression = qtrSF6
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mol m-2 s-1
 
@@ -983,7 +983,7 @@ dimension = longitude latitude time
 expression = m01s19i044[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -993,8 +993,8 @@ dimension = longitude latitude time
 expression = m01s19i044[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1006,7 +1006,7 @@ expression = (m01s19i039[lbtim_ia=240,lbproc=128]
     + m01s19i041[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1016,8 +1016,8 @@ dimension = longitude latitude time
 expression = (m01s19i120[lbtim_ia=240,lbproc=128] + m01s19i122[lbtim_ia=240,lbproc=128])
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1026,8 +1026,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i126[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1036,8 +1036,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i117[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1046,8 +1046,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i117[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1056,8 +1056,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i114[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1066,8 +1066,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i118[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1077,8 +1077,8 @@ dimension = longitude latitude time
 expression = (m01s19i181[lbtim_ia=240,lbproc=128] - m01s19i171[lbtim_ia=240,lbproc=128])
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1087,7 +1087,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i122[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1097,7 +1097,7 @@ dimension = longitude latitude time
 expression = (m01s19i160[lbtim_ia=240,lbproc=128] - m01s19i113[lbtim_ia=240,lbproc=128])
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1106,8 +1106,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i124[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1116,7 +1116,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i042[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1125,7 +1125,7 @@ component = land-use
 dimension = longitude latitude landUse time
 expression = land_use_tile_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = %
 
@@ -1134,7 +1134,7 @@ component = obgc
 dimension = longitude latitude time
 expression = IBEN_CA
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1143,7 +1143,7 @@ component = obgc
 dimension = longitude latitude time
 expression = IBEN_C
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1153,7 +1153,7 @@ dimension = longitude latitude time depth0m
 expression = AEOLIAN + BENTHIC
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1162,8 +1162,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i005[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1172,7 +1172,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i183[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1183,8 +1183,8 @@ expression = land_class_mean(
     m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1195,7 +1195,7 @@ expression = land_use_tile_mean(
      m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
      m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1206,8 +1206,8 @@ expression = land_class_mean(
     m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1218,8 +1218,8 @@ expression = land_class_mean(
     m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1229,7 +1229,7 @@ dimension = longitude latitude typenatgr time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='grass')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1239,7 +1239,7 @@ dimension = longitude latitude typec3pft typenatgr time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='c3Grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1249,7 +1249,7 @@ dimension = longitude latitude typec4pft typenatgr time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='c4Grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1260,7 +1260,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (MIGRAZP3 + MEGRAZP3) * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -1270,7 +1270,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i330[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -1280,7 +1280,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i290[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -1289,7 +1289,7 @@ component = land-use
 dimension = longitude latitude height2m landUse time
 expression = land_use_tile_mean(m01s03i329[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = 1
 
@@ -1298,7 +1298,7 @@ component = obgc
 dimension = longitude latitude time
 expression = INTDISSIC * ATOMIC_MASS_OF_C
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-2
 
@@ -1307,7 +1307,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (PRN + PRD) * FE_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1316,7 +1316,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PRN + PRD
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1327,7 +1327,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (PRN + PRD) * P_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1336,7 +1336,7 @@ component = obgc
 dimension = longitude latitude time
 expression = OPAL
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1345,7 +1345,7 @@ component = obgc
 dimension = longitude latitude time
 expression = FASTCA
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1356,7 +1356,7 @@ expression = (((INT_PN + INT_PD) * C_TO_N_RATIO)
     + ((INT_ZMI + INT_ZME) * C_TO_N_RATIO_ZOO)
     + INT_DTC) * ATOMIC_MASS_OF_C
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-2
 
@@ -1365,7 +1365,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (PRN + PRD) * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1374,7 +1374,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PRD * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1383,7 +1383,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PRN * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1394,7 +1394,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i014[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
    land_class='veg')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = 1
 
@@ -1403,7 +1403,7 @@ component = land-use
 dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s19i014[lbtim_ia=240,lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = 1
 
@@ -1412,7 +1412,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PD_FELIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1421,7 +1421,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PN_FELIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1430,7 +1430,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PD_JLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1439,7 +1439,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PN_JLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1448,7 +1448,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PD_NLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1457,7 +1457,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PN_NLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1467,7 +1467,7 @@ dimension = longitude latitude time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i525[lbproc=128]
 mip_table_id = Eday
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1477,7 +1477,7 @@ dimension = longitude latitude time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i531[lbproc=128]
 mip_table_id = Eday
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1489,7 +1489,7 @@ expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4)
     * m01s38i520[lbproc=128]
 mip_table_id = Eday Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1499,7 +1499,7 @@ dimension = longitude latitude time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i539[lbproc=128]
 mip_table_id = Eday Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1509,7 +1509,7 @@ dimension = longitude latitude alevel time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i545[lbproc=128]
 mip_table_id = AERmon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -1523,8 +1523,8 @@ expression = (m01s19i102[lbtim_ia=240,lbproc=128]
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = down
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1536,7 +1536,7 @@ expression = (m01s19i102[lbtim_ia=240,lbproc=128] - m01s19i053[lbtim_ia=240,lbpr
     / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
 positive = down
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1545,8 +1545,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i147[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1557,7 +1557,7 @@ expression = land_class_mean(m01s19i132[lbtim_ia=240,lbproc=128], m01s19i013[lbt
     land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1566,8 +1566,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i146[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1578,7 +1578,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = DIN_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1589,7 +1589,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = DIN_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1599,7 +1599,7 @@ dimension = longitude latitude time
 expression = m01s19i102[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = down
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1610,7 +1610,7 @@ expression = land_class_mean(
     m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1621,7 +1621,7 @@ expression = land_use_tile_mean(
     m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1632,7 +1632,7 @@ expression = land_class_mean(
     m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1643,7 +1643,7 @@ expression = land_class_mean(
     m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1654,7 +1654,7 @@ expression = land_class_mean(m01s19i133[lbtim_ia=240,lbproc=128], m01s19i013[lbt
     land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1663,8 +1663,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i145[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1675,7 +1675,7 @@ expression = land_class_mean(m01s19i131[lbtim_ia=240,lbproc=128], m01s19i013[lbt
     land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
     m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1684,8 +1684,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i137[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -1694,7 +1694,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = OXY_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1711,7 +1711,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = OXY_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1722,7 +1722,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = O2SAT3
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1733,7 +1733,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = O2SAT3[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1744,8 +1744,8 @@ dimension = longitude latitude time typepasture
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='pasture')
 mip_table_id = Lmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1755,7 +1755,7 @@ dimension = longitude latitude time typec3pastures
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='c3Pasture')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1765,7 +1765,7 @@ dimension = longitude latitude time typec4pastures
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
     land_class='c4Pasture')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1776,7 +1776,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PH3
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -1785,7 +1785,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PH3[depth=0]
 mip_table_id = Omon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 
@@ -1794,7 +1794,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * C_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1807,7 +1807,7 @@ dimension = longitude latitude time
 expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0])
     * C_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1816,7 +1816,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PHD_E3T * C_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1832,7 +1832,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * FE_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1841,7 +1841,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1850,7 +1850,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]) / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1861,7 +1861,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * P_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1877,7 +1877,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PHN_E3T * C_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1889,7 +1889,7 @@ dimension = longitude latitude time depth0m
 expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0])
     * P_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1898,7 +1898,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PDS_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1919,7 +1919,7 @@ mip_table_id = Omon
 notes = AXY: phosphate not in model; and not a good idea to estimate it by
     converting DIN to DIP using fixed N:P ratio; though this is not a
     terrible idea.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1938,7 +1938,7 @@ expression = (PHN_E3T + PHD_E3T + ZMI_E3T + ZME_E3T + DET_E3T) / thkcello
 mip_table_id = Omon
 notes = AXY: partly a units thing, but need to modify code to produce
     combined slow- and fast-sinking detritus.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1949,7 +1949,7 @@ expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]
     + ZMI_E3T[depth=0] + ZME_E3T[depth=0]
     + DET_E3T[depth=0]) / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1961,7 +1961,7 @@ dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T + ZMI_E3T + ZME_E3T + DET_E3T)
     * P_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1974,7 +1974,7 @@ expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]
     + ZMI_E3T[depth=0] + ZME_E3T[depth=0] + DET_E3T[depth=0])
     * P_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1985,7 +1985,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = TPP3 * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -1996,7 +1996,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = TPPD3 * C_TO_N_RATIO
 mip_table_id = Emon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -2007,7 +2007,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (TPP3 - TPPD3) * C_TO_N_RATIO
 mip_table_id = Emon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -2017,8 +2017,8 @@ dimension = longitude latitude time
 expression = m01s19i185[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2029,7 +2029,7 @@ expression = land_class_mean(
     m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2040,7 +2040,7 @@ expression = land_use_tile_mean(
     m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2051,7 +2051,7 @@ expression = land_class_mean(
     m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2062,7 +2062,7 @@ expression = land_class_mean(
     m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
     m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2072,7 +2072,7 @@ dimension = longitude latitude typeresidual time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='residual')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2082,8 +2082,8 @@ dimension = longitude latitude time
 expression = m01s19i053[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-    Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+    Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2093,7 +2093,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i383[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -2104,7 +2104,7 @@ expression = land_use_tile_mean_difference(m01s01i235[lbproc=128],
     m01s03i382[lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -2119,7 +2119,7 @@ expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4)
     + m01s38i488[lblev=1, lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-3
 
@@ -2131,7 +2131,7 @@ expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP
     + m01s38i499[lblev=1, lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-3
 
@@ -2141,7 +2141,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = SF6_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = umol m-3
 
@@ -2151,7 +2151,7 @@ dimension = longitude latitude typeshrub time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='shrub')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2160,7 +2160,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = SIL_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2169,7 +2169,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = SIL_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2178,7 +2178,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = OCN_PCO2
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = uatm
 
@@ -2187,7 +2187,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = ALK_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2203,7 +2203,7 @@ component = land-use
 dimension = longitude latitude height2m landUse time
 expression = land_use_tile_mean(m01s03i328[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = K
 
@@ -2213,7 +2213,7 @@ dimension = longitude latitude typetree time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='tree')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2223,7 +2223,7 @@ dimension = longitude latitude typetreebd time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='broadLeafTreeDeciduous')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2233,7 +2233,7 @@ dimension = longitude latitude typetreebe time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='broadLeafTreeEvergreen')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2243,7 +2243,7 @@ dimension = longitude latitude typetreend time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='needleLeafTreeDeciduous')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2253,7 +2253,7 @@ dimension = longitude latitude typetreene time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='needleLeafTreeEvergreen')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2262,7 +2262,7 @@ component = land-use
 dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i316[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = K
 
@@ -2272,7 +2272,7 @@ dimension = longitude latitude typeveg time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
     land_class='veg')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2282,7 +2282,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='veg')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2292,7 +2292,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='crop')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2302,7 +2302,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2312,7 +2312,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='pasture')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2322,7 +2322,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2332,7 +2332,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
     land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -2346,7 +2346,7 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C,
     cube2d=(m01s38i906[lbproc=128] + m01s38i912[lbproc=128]
     + m01s38i921[lbproc=128]), sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -2361,7 +2361,7 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C * CONV_C_ORGM,
     cube2d=(m01s38i907[lbproc=128] + m01s38i913[lbproc=128]
     + m01s38i922[lbproc=128]), sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -2371,7 +2371,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO2,
     m01s50i155[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -2387,7 +2387,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -2400,7 +2400,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL,
     cube2d=(m01s38i914[lbproc=128] + m01s38i923[lbproc=128]),
     sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -2409,7 +2409,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = ZME_E3T * C_TO_N_RATIO_ZOO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2425,7 +2425,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = ZMI_E3T * C_TO_N_RATIO_ZOO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2449,7 +2449,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (ZMI_E3T + ZME_E3T) * C_TO_N_RATIO_ZOO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -2465,7 +2465,7 @@ component = obgc
 dimension = longitude latitude time
 expression = ARG_CCD
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = m
 
@@ -2474,6 +2474,6 @@ component = obgc
 dimension = longitude latitude time
 expression = CAL_CCD
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = m

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_eday_parasolrefl.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_eday_parasolrefl.py
@@ -29,7 +29,7 @@ class TestCmip6EdayParasolRefl(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                 },
                 request={
                     'ancil_files': os.path.join(ROOT_ANCIL_DIR, 'UKESM1-0-LL', 'qrparm.orog.pp'),

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_eday_parasolrefl.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_eday_parasolrefl.py
@@ -41,7 +41,7 @@ class TestCmip6EdayParasolRefl(AbstractFunctionalTests):
                     'ap6': {'CMIP6_Eday': 'parasolRefl'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['parasolRefl_Eday_UKESM1-0-LL_amip_r1i1p1f1_gn_19790101-19790130.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_soga.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_soga.py
@@ -28,7 +28,7 @@ class TestCmip6OmonSoga(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                 },
                 request={
                     'ancil_files': os.path.join(ROOT_ANCIL_DIR, 'UKESM1-0-LL', 'qrparm.orog.pp'),

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_soga.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_soga.py
@@ -40,7 +40,7 @@ class TestCmip6OmonSoga(AbstractFunctionalTests):
                     'onm': {'CMIP6_Omon': 'soga'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['soga_Omon_UKESM1-0-LL_amip_r1i1p1f1_gn_185105-185105.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thetao.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thetao.py
@@ -29,7 +29,7 @@ class TestCmip6OmonThetao(AbstractFunctionalTests):
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
                     'calendar': 'noleap',
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>',
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thetao.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thetao.py
@@ -42,7 +42,7 @@ class TestCmip6OmonThetao(AbstractFunctionalTests):
                     'onb': {'CMIP6_Omon': 'thetao'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['thetao_Omon_UKESM1-0-LL_amip_r1i1p1f1_197601-197601.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thkcello.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thkcello.py
@@ -45,7 +45,7 @@ class TestCmip6OmonThkcello(AbstractFunctionalTests):
                     'further_info_url': 'https://furtherinfo.es-doc.org/CMIP6.MOHC.HadGEM3-GC31-LL.amip.none.r1i1p1f1'
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['thkcello_Omon_HadGEM3-GC31-LL_amip_r1i1p1f1_198001-198001.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thkcello.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thkcello.py
@@ -28,7 +28,7 @@ class TestCmip6OmonThkcello(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>',
                     'model_id': 'HadGEM3-GC31-LL',
                 },

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_tos.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_tos.py
@@ -29,7 +29,7 @@ class TestCmip6OmonTos(AbstractFunctionalTests):
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
                     'calendar': 'noleap',
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>',
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_tos.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_tos.py
@@ -42,7 +42,7 @@ class TestCmip6OmonTos(AbstractFunctionalTests):
                     'onb': {'CMIP6_Omon': 'tos'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['tos_Omon_UKESM1-0-LL_amip_r1i1p1f1_197601-197601.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sifllwutop.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sifllwutop.py
@@ -40,7 +40,7 @@ class TestCmip6SImonSifllwutop(AbstractFunctionalTests):
                     'ap5': {'CMIP6_SImon': 'sifllwutop'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['sifllwutop_SImon_UKESM1-0-LL_amip_r1i1p1f1_185105-185105.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sifllwutop.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sifllwutop.py
@@ -28,7 +28,7 @@ class TestCmip6SImonSifllwutop(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>'
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_siitdsnthick.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_siitdsnthick.py
@@ -40,7 +40,7 @@ class TestCmip6SImonSiitdsnthick(AbstractFunctionalTests):
                     'inm': {'CMIP6_SImon': 'siitdsnthick'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['siitdsnthick_SImon_UKESM1-0-LL_amip_r1i1p1f1_185403-185403.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_siitdsnthick.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_siitdsnthick.py
@@ -28,7 +28,7 @@ class TestCmip6SImonSiitdsnthick(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>'
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sndmassmelt.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sndmassmelt.py
@@ -39,7 +39,7 @@ class TestCmip6SImonSndmassmelt(AbstractFunctionalTests):
                     'inm': {'CMIP6_SImon': 'sndmassmelt'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['sndmassmelt_SImon_UKESM1-0-LL_amip_r1i1p1f1_185403-185403.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sndmassmelt.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sndmassmelt.py
@@ -26,7 +26,7 @@ class TestCmip6SImonSndmassmelt(AbstractFunctionalTests):
                     'netcdf_file_action': 'CMOR_REPLACE_3'
                 },
                 cmor_dataset={
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_dir': get_output_dir(test_location),
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>'
                 },

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_no_mask.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_no_mask.py
@@ -42,7 +42,7 @@ class TestSeasonalOmonTosNoMask(AbstractFunctionalTests):
                     'onb': {'SEASONAL_Omon': 'tos'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['tos_Omon_UKESM1-0-LL_r1i1p1f1_197601-197601.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_no_mask.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_no_mask.py
@@ -29,7 +29,7 @@ class TestSeasonalOmonTosNoMask(AbstractFunctionalTests):
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
                     'calendar': 'noleap',
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><variant_label>',
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_with_mask.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_with_mask.py
@@ -47,7 +47,7 @@ class TestSeasonalOmonTosWithMask(AbstractFunctionalTests):
                     }
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['tos_Omon_UKESM1-0-LL_amip_197601-197601.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_with_mask.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_with_mask.py
@@ -29,7 +29,7 @@ class TestSeasonalOmonTosWithMask(AbstractFunctionalTests):
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
                     'calendar': 'noleap',
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id>',
                 },
                 request={


### PR DESCRIPTION
This change replaces the email addresses recorded against reviewer names in the mappings files with just their institutions. 
This information is only kept for audit trail purposes

Going forward we will change to including names and github handles.

Note that the changes here were scripted using the regular expression `'(([a-zA-Z0-9. ]+) \<.*@([a-zA-Z0-9\.]+)\>)'` to pick out reviewer name and email domain, which was translated via dictionary to an institution name.

No changes to tests necessary and all tests confirmed as passing.
