### PR TITLE
CDDSO-657: remove email addresses from main

### DIFF
--- a/cdds/bin/cdds_extract
+++ b/cdds/bin/cdds_extract
@@ -6,13 +6,7 @@
 Climate Data Dissemination System script to handle model data
 extractions from MASS
    - supports pp and nc file types
-   - optionally supports file filtering based on required variables mapping
-   - supports request extraction configuration from CREM or JSON data file
-   - optionally supports logging status to CREM
-   - optionally supports email notification of script start, exit and end.
-
-Author:
-    Mark Elkington (mark.elkington@metoffice.gov.uk)
+   - supports file filtering based on required variables mapping
 """
 
 import sys

--- a/docs/operational_procedure/cmip6.md
+++ b/docs/operational_procedure/cmip6.md
@@ -417,7 +417,7 @@ The conversion workflows run the following steps
             and contact the [CDDS Team](mailto:cdds@metoffice.gov.uk) for advice.
 
     !!! important "VERY IMPORTANT"
-        **Do not delete data from MASS without consultation with [Matt Mizielinski](mailto:matthew.mizielinski@metoffice.gov.uk).**
+        **Do not delete data from MASS without consultation with [CDDS support](mailto:cdds@metoffice.gov.uk).**
 
 - [x] `completion_<stream>`
 

--- a/docs/operational_procedure/gcmodeldev.md
+++ b/docs/operational_procedure/gcmodeldev.md
@@ -331,7 +331,7 @@ The conversion workflows run the following steps
             and contact the [CDDS Team](mailto:cdds@metoffice.gov.uk) for advice.
 
     !!! important "VERY IMPORTANT"
-        **Do not delete data from MASS without consultation with [Matt Mizielinski](mailto:matthew.mizielinski@metoffice.gov.uk).**
+        **Do not delete data from MASS without consultation with [CDDS support](mailto:cdds@metoffice.gov.uk).**
 
 - [x] `completion_<stream>`
 

--- a/docs/operational_procedure/sim_review.md
+++ b/docs/operational_procedure/sim_review.md
@@ -93,4 +93,4 @@ expected to do this part.
 
 - [x] Create a new file `~/.cdds_credentials`.
 
-- [x] Contact [Matt Mizielinski](mailto:matthew.mizielinski@metoffice.gov.uk) for the required settings.
+- [x] Contact Matt Mizielinski for the required settings.

--- a/docs/operational_procedure/sim_review.md
+++ b/docs/operational_procedure/sim_review.md
@@ -93,4 +93,4 @@ expected to do this part.
 
 - [x] Create a new file `~/.cdds_credentials`.
 
-- [x] Contact [Matt Mizielinski](mailto:matt.mizielinski@metoffice.gov.uk) for the required settings.
+- [x] Contact [Matt Mizielinski](mailto:matthew.mizielinski@metoffice.gov.uk) for the required settings.

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_3hr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_3hr_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [huss]
 dimension = longitude latitude height2m time1
 expression = m01s03i237[lbproc=0]
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = 1
 positive = None
@@ -22,7 +22,7 @@ positive = None
 [mrsos]
 dimension = longitude latitude sdepth1 time1
 expression = m01s08i223[blev=0.05, lbproc=0]
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -30,7 +30,7 @@ positive = None
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -39,8 +39,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = K
 positive = None
@@ -48,7 +48,7 @@ positive = None
 [uas]
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -56,7 +56,7 @@ positive = None
 [vas]
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_6hrLev_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_6hrLev_mappings.cfg
@@ -18,7 +18,7 @@ uva_native_levels = Note that the vertical levels for this variable correspond
 [ec550aer]
 dimension = longitude latitude alevel lambda550nm time1
 expression = m01s02i530[lbplev=3, lbproc=0] + m01s02i540[lbplev=3, lbproc=0]
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-1
 positive = None
@@ -27,8 +27,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = 1
 positive = None
@@ -37,8 +37,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i408[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -47,8 +47,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -57,8 +57,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s30i111[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = K
 positive = None
@@ -69,8 +69,8 @@ comment = Note that the vertical levels for this variable correspond
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i002[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -81,8 +81,8 @@ comment = Note that the vertical levels for this variable correspond
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i003[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = m s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_6hrPlevPt_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_6hrPlevPt_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [psl]
 dimension = longitude latitude time1
 expression = m01s16i222[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -29,7 +29,7 @@ positive = None
 dimension = longitude latitude plev3 time1
 expression = m01s30i294[blev=PLEV3, lbproc=0]
 	/ m01s30i304[blev=PLEV3, lbproc=0]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -44,7 +44,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -53,7 +53,7 @@ positive = None
 dimension = longitude latitude plev3 time1
 expression = m01s30i201[blev=PLEV3, lbproc=0]
 	/ m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -62,7 +62,7 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -71,7 +71,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -80,7 +80,7 @@ positive = None
 dimension = longitude latitude plev3 time1
 expression = m01s30i202[blev=PLEV3, lbproc=0]
 	/ m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -89,7 +89,7 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -97,7 +97,7 @@ positive = None
 [zg500]
 dimension = longitude latitude p500 time1
 expression = m01s30i297[blev=P500, lbproc=0] / m01s30i304[blev=P500, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_AERday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_AERday_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [toz]
 dimension = longitude latitude time
 expression = m01s50i219[lblev=1, lbproc=128]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = 1e-5 m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_AERmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_AERmonZ_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s51i009[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -23,8 +23,8 @@ positive = None
 [hcl]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL)
 	* m01s51i992[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-	Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Guang Zeng (NIWA),
+	Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 positive = None
@@ -32,7 +32,7 @@ positive = None
 [hno3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3)
 	* m01s51i007[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -40,7 +40,7 @@ positive = None
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s51i049[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -48,7 +48,7 @@ positive = None
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s51i001[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -56,7 +56,7 @@ positive = None
 [oh]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH)
 	* m01s51i081[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
@@ -64,7 +64,7 @@ positive = None
 [ta]
 expression = m01s30i294[blev=PLEV39, lbproc=192]
 	/ m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -72,7 +72,7 @@ positive = None
 [ua]
 expression = m01s30i201[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -80,7 +80,7 @@ positive = None
 [va]
 expression = m01s30i202[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -88,7 +88,7 @@ positive = None
 [zg]
 expression = m01s30i297[blev=PLEV39, lbproc=192]
 	/ m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_AERmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_AERmon_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s34i009[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
@@ -23,7 +23,7 @@ positive = None
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s34i049[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
@@ -31,28 +31,28 @@ positive = None
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s34i001[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_APday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_APday_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None
@@ -25,7 +25,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 positive = None
@@ -34,7 +34,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -42,7 +42,7 @@ positive = None
 [sfcWindmax]
 dimension = longitude latitude height10m time
 expression = m01s03i230[lbproc=8192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -50,7 +50,7 @@ positive = None
 [tasmax]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=8192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -58,7 +58,7 @@ positive = None
 [tasmin]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=4096]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -67,7 +67,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -76,7 +76,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -85,7 +85,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 positive = None
@@ -94,7 +94,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i297[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_APmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_APmon_mappings.cfg
@@ -17,7 +17,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_Amon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_Amon_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_CF3hr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_CF3hr_mappings.cfg
@@ -21,7 +21,7 @@ positive = None
 [clc]
 dimension = longitude latitude alevel time1
 expression = m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -29,7 +29,7 @@ positive = None
 [clic]
 dimension = longitude latitude alevel time1
 expression = m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -37,7 +37,7 @@ positive = None
 [clis]
 dimension = longitude latitude alevel time1
 expression = m01s02i309[lbproc=0] - m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -51,7 +51,7 @@ positive = None
 [cls]
 dimension = longitude latitude alevel time1
 expression = m01s02i312[lbproc=0] + m01s02i313[lbproc=0] - m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -66,7 +66,7 @@ positive = None
 [clwc]
 dimension = longitude latitude alevel time1
 expression = m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -74,7 +74,7 @@ positive = None
 [clws]
 dimension = longitude latitude alevel time1
 expression = m01s02i308[lbproc=0] - m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -149,7 +149,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i228[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -164,7 +164,7 @@ positive = None
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -180,7 +180,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -189,7 +189,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -198,7 +198,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -207,7 +207,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -337,7 +337,7 @@ units = Pa
 [ts]
 dimension = longitude latitude time1
 expression = m01s00i024[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_CFday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_CFday_mappings.cfg
@@ -15,42 +15,42 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 positive = None
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [wap]
 expression = m01s30i008[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = Pa s-1
 positive = None
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_CFmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_CFmon_mappings.cfg
@@ -15,14 +15,14 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 positive = None
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_CFsubhr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_CFsubhr_mappings.cfg
@@ -22,7 +22,7 @@ rld_rldcs = Physically, the radiation scheme used in this model ignores any
 [ci]
 dimension = site time1
 expression = m01s05i269[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -30,7 +30,7 @@ positive = None
 [cl]
 dimension = alevel site time1
 expression = m01s02i261[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -38,7 +38,7 @@ positive = None
 [cli]
 dimension = alevel site time1
 expression = m01s02i309[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg kg-1
 positive = None
@@ -46,7 +46,7 @@ positive = None
 [clivi]
 dimension = site time1
 expression = m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -54,7 +54,7 @@ positive = None
 [clt]
 dimension = site time1
 expression = m01s02i204[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -62,7 +62,7 @@ positive = None
 [clw]
 dimension = alevel site time1
 expression = m01s02i308[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg kg-1
 positive = None
@@ -70,7 +70,7 @@ positive = None
 [clwvi]
 dimension = site time1
 expression = m01s02i391[lbproc=0] + m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -78,7 +78,7 @@ positive = None
 [evspsbl]
 dimension = site time1
 expression = m01s03i223[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -88,7 +88,7 @@ comment = Includes both evaporation and sublimation.
 dimension = site time1
 expression = m01s03i234[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -96,14 +96,14 @@ units = W m-2
 dimension = site time1
 expression = m01s03i217[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
 [hur]
 dimension = alevel site time1
 expression = m01s30i113[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = %
 positive = None
@@ -111,7 +111,7 @@ positive = None
 [hurs]
 dimension = site height2m time1
 expression = m01s03i245[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = %
 positive = None
@@ -120,7 +120,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s00i010[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -128,7 +128,7 @@ positive = None
 [huss]
 dimension = site height2m time1
 expression = m01s03i237[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -140,14 +140,14 @@ component = cftables
 dimension = alevhalf site time1
 expression = (m01s05i250[lbproc=0] - m01s05i251[lbproc=0]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 positive = up
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>, William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [pfull]
 dimension = alevel site time1
 expression = m01s00i408[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -155,7 +155,7 @@ positive = None
 [phalf]
 dimension = alevhalf site time1
 expression = m01s00i407[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -163,7 +163,7 @@ positive = None
 [pr]
 dimension = site time1
 expression = m01s05i216[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -171,7 +171,7 @@ positive = None
 [prc]
 dimension = site time1
 expression = m01s05i205[lbproc=0] + m01s05i206[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -179,7 +179,7 @@ positive = None
 [prsn]
 dimension = site time1
 expression = m01s05i215[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -187,7 +187,7 @@ positive = None
 [prw]
 dimension = site time1
 expression = m01s30i461[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -195,7 +195,7 @@ positive = None
 [ps]
 dimension = site time1
 expression = m01s00i409[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -203,7 +203,7 @@ positive = None
 [psl]
 dimension = site time1
 expression = m01s16i222[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -218,7 +218,7 @@ comment = Physically, the radiation scheme used in this model ignores any
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i218[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -232,7 +232,7 @@ comment = Physically, the radiation scheme used in this model ignores any
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i220[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -240,7 +240,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i207[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -248,7 +248,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i208[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -256,7 +256,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i207[lbproc=0] - m01s02i201[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -265,7 +265,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i217[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -274,7 +274,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i219[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -283,7 +283,7 @@ component = cftables
 dimension = site time1
 expression = m01s02i205[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -291,7 +291,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i206[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -299,7 +299,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i218[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -307,7 +307,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i220[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -315,7 +315,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i235[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -323,7 +323,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i210[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -331,7 +331,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i207[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -339,7 +339,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i217[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -347,7 +347,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i219[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -356,7 +356,7 @@ component = cftables
 dimension = site time1
 expression = m01s01i235[lbproc=0] - m01s01i201[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -364,7 +364,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i211[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -372,7 +372,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i208[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -380,7 +380,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i209[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -395,14 +395,14 @@ component = boundary-layer
 dimension = site time1
 expression = m01s03i298[lbproc=0]
 positive = None
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [sci]
 dimension = site time1
 expression = m01s05i270[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -412,7 +412,7 @@ comment = This is the mean of the speed, not the speed computed from the mean u
 	and v components of wind.
 dimension = site height10m time1
 expression = m01s03i230[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -421,7 +421,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s30i111[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 positive = None
@@ -429,7 +429,7 @@ positive = None
 [tas]
 dimension = site height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 positive = None
@@ -438,7 +438,7 @@ positive = None
 dimension = site time1
 expression = m01s03i460[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
@@ -446,14 +446,14 @@ units = Pa
 dimension = site time1
 expression = m01s03i461[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
 [tnhus]
 dimension = alevel site time1
 expression = m01s30i182[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -462,7 +462,7 @@ positive = None
 dimension = alevel site time1
 expression = (m01s12i182[lbproc=0] + m01s12i382[lbproc=0])
 	/ ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -470,7 +470,7 @@ positive = None
 [tnhusc]
 dimension = alevel site time1
 expression = m01s05i162[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -481,7 +481,7 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
 	+ m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
 	+ m01s04i982[lbproc=0] + m01s05i182[lbproc=0] + m01s16i162[lbproc=0]
 	+ m01s16i182[lbproc=0] + m01s35i025[lbproc=0] ) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -492,7 +492,7 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
 	+ m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
 	+ m01s05i182[lbproc=0] - m01s05i162[lbproc=0] + m01s16i162[lbproc=0]
 	+ m01s16i182[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -500,7 +500,7 @@ positive = None
 [tnt]
 dimension = alevel site time1
 expression = m01s30i181[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -516,7 +516,7 @@ positive = None
 [tntc]
 dimension = alevel site time1
 expression = m01s05i161[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -535,7 +535,7 @@ positive = None
 [tntr]
 dimension = alevel site time1
 expression = (m01s01i161[lbproc=0] + m01s02i161[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -547,7 +547,7 @@ expression = (m01s03i181[lbproc=0] + m01s04i141[lbproc=0]
 	+ m01s01i181[lbproc=0] - m01s01i161[lbproc=0] + m01s02i181[lbproc=0]
 	- m01s02i161[lbproc=0] + m01s05i181[lbproc=0] - m01s05i161[lbproc=0])
 	/ ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -555,7 +555,7 @@ positive = None
 [ts]
 dimension = site time1
 expression = m01s00i024[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 positive = None
@@ -564,7 +564,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s00i002[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -572,7 +572,7 @@ positive = None
 [uas]
 dimension = site height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -581,7 +581,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s00i003[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -589,7 +589,7 @@ positive = None
 [vas]
 dimension = site height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -598,7 +598,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s30i008[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa s-1
 positive = None
@@ -607,7 +607,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s16i201[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_E3hrPt_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_E3hrPt_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [cfadDbze94]
 dimension = longitude latitude alt40 dbze time1
 expression = m01s02i372[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -22,7 +22,7 @@ positive = None
 [cfadLidarsr532]
 dimension = longitude latitude alt40 scatratio time1
 expression = m01s02i370[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -38,7 +38,7 @@ positive = None
 component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i371[lbproc=0] / m01s02i325[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -47,7 +47,7 @@ positive = None
 component = cloud
 dimension = longitude latitude p220 time1
 expression = m01s02i346[blev=P220, lbproc=0] / m01s02i323[blev=P220, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -55,7 +55,7 @@ positive = None
 [clisccp]
 dimension = longitude latitude plev7c tau time1
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -65,7 +65,7 @@ comment = CALIPSO Low Level Cloud Fraction
 component = cloud
 dimension = longitude latitude p840 time1
 expression = m01s02i344[blev=P840, lbproc=0] / m01s02i321[blev=P840, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -74,7 +74,7 @@ positive = None
 component = cloud
 dimension = longitude latitude p560 time1
 expression = m01s02i345[blev=P560, lbproc=0] / m01s02i322[blev=P560, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -82,7 +82,7 @@ positive = None
 [clmisr]
 dimension = longitude latitude alt16 tau time1
 expression = fix_clmisr_height(m01s02i360[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -91,7 +91,7 @@ positive = None
 component = cloud
 dimension = longitude latitude time1
 expression = m01s02i347[lbproc=0] / m01s02i324[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -99,7 +99,7 @@ positive = None
 [hus]
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 positive = None
@@ -114,7 +114,7 @@ positive = None
 [jpdftaureicemodis]
 dimension = longitude latitude plev7c effectRadIc tau time1
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -122,7 +122,7 @@ positive = None
 [jpdftaureliqmodis]
 dimension = longitude latitude plev7c effectRadLi tau time1
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -144,7 +144,7 @@ positive = None
 [parasolRefl]
 dimension = longitude latitude sza5 time1
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -152,7 +152,7 @@ positive = None
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -214,7 +214,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -223,7 +223,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_EdayZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_EdayZ_mappings.cfg
@@ -16,7 +16,7 @@ status = embargoed
 dimension = latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -24,7 +24,7 @@ units = 1
 dimension = latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -32,21 +32,21 @@ units = K
 dimension = latitude plev39 time
 expression = m01s30i201[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 
 [utendogw]
 dimension = latitude plev39 time
 expression = m01s06i247[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 
@@ -54,7 +54,7 @@ units = m s-2
 dimension = latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=192]
 	/ m01s30i301[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -62,7 +62,7 @@ units = m s-1
 dimension = latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_Eday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_Eday_mappings.cfg
@@ -16,7 +16,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i330[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -25,7 +25,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i290[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_EmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_EmonZ_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-2
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_Emon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_Emon_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 dimension = longitude latitude plev7h time
 expression = m01s30i295[blev=PLEV7H, lbproc=128]
 	/ m01s30i304[blev=PLEV7H, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 positive = None
@@ -25,7 +25,7 @@ comment = Monthly mean orography (needed if land ice has time varying
 	altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None
@@ -33,7 +33,7 @@ positive = None
 [wap]
 dimension = longitude latitude alevel time
 expression = m01s30i008[lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_GA7mon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_GA7mon_mappings.cfg
@@ -13,14 +13,14 @@ status = Internal
 [pr]
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = kg m-2 s-1
 positive = None
 
 [ts]
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = K
 positive = None
 
@@ -28,7 +28,7 @@ positive = None
 dimension = longitude latitude plev17 time
 expression = m01s30i201[blev=PLEV17, lbproc=128]
 	/ m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = m s-1
 positive = None
 
@@ -36,7 +36,7 @@ positive = None
 dimension = longitude latitude plev17 time
 expression = m01s30i202[blev=PLEV17, lbproc=128]
 	/ m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = m s-1
 positive = None
 

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_LImon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_LImon_mappings.cfg
@@ -14,7 +14,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i578[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [hflsIs]
@@ -26,7 +26,7 @@ expression = land_class_mean(m01s03i330[lbproc=128],
 	land_class='ice')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [hfssIs]
@@ -38,7 +38,7 @@ expression = land_class_mean(m01s03i290[lbproc=128],
 	land_class='ice')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [litemptopIs]
@@ -49,7 +49,7 @@ expression = land_class_mean(m01s08i225[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
 notes = mapping changed from the UKESM1 one
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [mrroIs]
@@ -60,7 +60,7 @@ expression = land_class_mean(m01s08i583[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
 notes = UM: ISMIP snowpack runoff definition not necessarily the same as UM.
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [rldsIs]
@@ -72,7 +72,7 @@ expression = land_class_mean(m01s03i384[lbproc=128],
 	land_class='ice')
 notes = UM
 positive = down
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [rlusIs]
@@ -83,7 +83,7 @@ expression = land_class_mean(m01s03i383[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [sblIs]
@@ -94,7 +94,7 @@ expression = land_class_mean(m01s03i331[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [sftgif]
@@ -104,7 +104,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='ice')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = %
 
 [snicefreezIs]
@@ -115,7 +115,7 @@ expression = land_class_mean(m01s08i580[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snicemIs]
@@ -126,7 +126,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snmIs]
@@ -137,7 +137,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [tasIs]
@@ -148,7 +148,7 @@ expression = land_class_mean(m01s03i328[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [tsIs]
@@ -159,6 +159,6 @@ expression = land_class_mean(m01s03i316[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='ice')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_LPmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_LPmon_mappings.cfg
@@ -16,7 +16,7 @@ comment = Monthly mean orography (needed if land ice has time varying
 	altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_Omon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_Omon_mappings.cfg
@@ -18,7 +18,7 @@ comment = Computed as the total mass of liquid water falling as liquid rain
 	portion of the grid cell.
 dimension = longitude latitude time
 expression = pr
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -26,7 +26,7 @@ positive = None
 [prsn]
 dimension = longitude latitude time
 expression = prsn
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_SIday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_SIday_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [siconc]
 dimension = longitude latitude typesi time
 expression = aice
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = 1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_day_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_day_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 
@@ -24,14 +24,14 @@ units = %
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
 [sfcWindmax]
 dimension = longitude latitude height10m time
 expression = m01s03i230[lbproc=8192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -40,14 +40,14 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
 [tasmax]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=8192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -55,7 +55,7 @@ positive = None
 [tasmin]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=4096]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -73,7 +73,7 @@ units = m s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
     / m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -81,7 +81,7 @@ units = m s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
     / m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -89,7 +89,7 @@ units = m s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
     / m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_mappings.cfg
@@ -37,7 +37,7 @@ dimension = longitude latitude lambda550nm time
 expression = m01s02i240[lbplev=3, lbproc=128] + m01s02i241[lbplev=3, lbproc=128] + m01s02i242[lbplev=3, lbproc=128] + m01s02i243[lbplev=3, lbproc=128] + m01s02i585[lbplev=3, lbproc=128]
 mip_table_id = AERmon
 notes = Assuming CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -47,7 +47,7 @@ component = aerosol
 dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i508[lbproc=0] / m01s01i507[lbproc=0], m01s02i508[lbproc=0] / m01s02i507[lbproc=0], minval= '-1.0', maxval= '1.0')
 mip_table_id = E3hrPt
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -57,7 +57,7 @@ component = aerosol
 dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i506[lbproc=0], m01s02i506[lbproc=0], swmask= m01s01i200[lbproc=0], minval= '0', maxval= '10')
 mip_table_id = E3hrPt
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -67,7 +67,7 @@ component = aerosol
 dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i507[lbproc=0] / m01s01i506[lbproc=0], m01s02i507[lbproc=0] / m01s02i506[lbproc=0], minval='0.0', maxval='1.0')
 mip_table_id = E3hrPt
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -77,7 +77,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = agessc
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = yr
 
@@ -86,7 +86,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = div_by_area(m01s50i063[lbproc=128])
 mip_table_id = AERmon
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = kg m-2
 
@@ -109,7 +109,7 @@ component = cftables
 dimension = longitude latitude time
 expression = fix_packing_division(m01s02i331[lbproc=128], m01s02i334[lbproc=128])
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -118,7 +118,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = areacella(m01s00i505)
 mip_table_id = fx
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok
 units = m2
 
@@ -127,7 +127,7 @@ component = ocean
 dimension = longitude latitude
 expression = areacello
 mip_table_id = Ofx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -136,7 +136,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i054[lbproc=128]
 mip_table_id = Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = s m-1
 
@@ -146,7 +146,7 @@ dimension = longitude latitude typebare time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='bareSoil')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -156,7 +156,7 @@ component = ocean
 dimension = longitude latitude
 expression = basin
 mip_table_id = Ofx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1
 
@@ -165,7 +165,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = AERmon 6hrPlev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -174,7 +174,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = MOLECULAR_MASS_OF_AIR * ((m01s51i045[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BROMINE) + (m01s51i047[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRCL) + (m01s51i048[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRONO2) + (m01s51i052[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HBR) + (m01s51i053[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HOBR) + (m01s51i994[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRO)) / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -184,7 +184,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C2H6) * m01s34i014[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -194,7 +194,7 @@ dimension = longitude latitude typec3pft time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='c3')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -204,7 +204,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C3H8) * m01s34i018[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -214,7 +214,7 @@ dimension = longitude latitude typec4pft time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='c4')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -224,7 +224,7 @@ component = cloud
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128], m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -234,7 +234,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s01i241[lbproc=128] / m01s01i223[lbproc=128]
 mip_table_id = AERmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -243,7 +243,7 @@ component = cloud
 dimension = longitude latitude alt40 dbze time
 expression = m01s02i372[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -252,7 +252,7 @@ component = cloud
 dimension = longitude latitude alt40 scatratio time
 expression = m01s02i370[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -261,7 +261,7 @@ component = chemistry
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i055[lbproc=128], MOLECULAR_MASS_OF_CFC11)
 mip_table_id = Amon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -270,7 +270,7 @@ component = chemistry
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i056[lbproc=128], MOLECULAR_MASS_OF_CFC12)
 mip_table_id = Amon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -279,7 +279,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH3COCH3) * m01s34i022[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -288,7 +288,7 @@ component = chemistry
 dimension = longitude latitude plev19 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4) * m01s51i009[blev=PLEV19, lbproc=128] / m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -297,7 +297,7 @@ component = chemistry
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i009[lbproc=128], MOLECULAR_MASS_OF_CH4)
 mip_table_id = Amon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -308,7 +308,7 @@ dimension = longitude latitude alevel time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, (m01s38i201[lbproc=128] + m01s38i202[lbproc=128] + m01s38i203[lbproc=128] + m01s38i285[lbproc=128] + m01s38i286[lbproc=128] + m01s38i288[lbproc=128] + m01s38i289[lbproc=128]), areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -318,7 +318,7 @@ dimension = longitude latitude alevel time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s50i150[lbproc=128], areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -327,7 +327,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i269[lbproc=128]
 mip_table_id = Amon
-reviewer = Mark Webb <mark.webb@metoffice.gov.uk>
+reviewer = Mark Webb (Met Office)
 status = ok
 units = 1
 
@@ -336,7 +336,7 @@ component = cftables cloud
 dimension = longitude latitude alevel time
 expression = m01s02i261[lbproc=128]
 mip_table_id = Amon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -346,7 +346,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i317[lbproc=128]
 mip_table_id = CFmon
 notes = Using convective cores in this model configuration.
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -355,7 +355,7 @@ component = cftables
 dimension = longitude latitude alt40 time
 expression = m01s02i371[lbproc=128] / m01s02i325[lbproc=128]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -364,7 +364,7 @@ component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i374[lbproc=0] / m01s02i325[lbproc=0]
 mip_table_id = E3hrPt
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -395,7 +395,7 @@ dimension = longitude latitude time
 expression = m01s01i280[lbproc=128] / m01s01i281[lbproc=128]
 mip_table_id = Emon Eday
 notes = Calculated at daylight grids only.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-2
 
@@ -404,7 +404,7 @@ component = cftables
 dimension = longitude latitude p220 time
 expression = m01s02i346[lbproc=128, blev=P220] / m01s02i323[lbproc=128, blev=P220]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -414,7 +414,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i309[lbproc=128]
 mip_table_id = Amon CFday
 notes = When McICA is used with convective cores, the large-scale diagnostics contain all condensate. No need to add convective because the convection diagnostics contain zeroes.
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -423,7 +423,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i319[lbproc=128]
 mip_table_id = CFmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -432,7 +432,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i453[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -449,7 +449,7 @@ component = cloud
 dimension = longitude latitude plev7c tau time
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -458,7 +458,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i392[lbproc=128]
 mip_table_id = Amon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -467,7 +467,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i396[lbproc=128]
 mip_table_id = Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -476,7 +476,7 @@ component = cftables
 dimension = longitude latitude p840 time
 expression = m01s02i344[lbproc=128, blev=P840] / m01s02i321[lbproc=128, blev=P840]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -485,7 +485,7 @@ component = cftables
 dimension = longitude latitude p560 time
 expression = m01s02i345[lbproc=128, blev=P560] / m01s02i322[lbproc=128, blev=P560]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -494,7 +494,7 @@ component = cloud
 dimension = longitude latitude alt16 tau time
 expression = fix_clmisr_height(m01s02i360[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -503,7 +503,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i312[lbproc=128] + m01s02i313[lbproc=128] - m01s02i317[lbproc=128]
 mip_table_id = CFmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -512,7 +512,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i204[lbproc=128]
 mip_table_id = Amon 3hr day
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -521,7 +521,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i347[lbproc=128] / m01s02i324[lbproc=128]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -530,7 +530,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i334[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -539,7 +539,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i451[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -549,7 +549,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i308[lbproc=128]
 mip_table_id = Amon CFday
 notes = When McICA is used with convective cores, the large-scale diagnostics contain all condensate. No need to add convective because the convection diagnostics contain zeroes.
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -558,7 +558,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i318[lbproc=128]
 mip_table_id = CFmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -567,7 +567,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i452[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -584,7 +584,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128] + m01s02i392[lbproc=128]
 mip_table_id = Amon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -593,7 +593,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i395[lbproc=128] + m01s02i396[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -602,7 +602,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = MOLECULAR_MASS_OF_AIR * ((m01s51i041[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CHLORINE) + (m01s51i042[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CLOX) + (2 * m01s51i043[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CL2O2) + (m01s51i044[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_OCLO) + (m01s51i047[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRCL) + (m01s51i051[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HOCL) + (m01s51i054[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CLONO2) + (m01s51i992[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HCL)) / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -611,7 +611,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO) * m01s34i010[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -621,7 +621,7 @@ component = carbon
 dimension = time
 expression = m01s30i465[lbproc=128]
 mip_table_id = Amon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg
 
@@ -630,7 +630,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i332[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = AERmon AERday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -639,7 +639,7 @@ component = dust
 dimension = longitude latitude alevel time
 expression = m01s17i257[lbproc=128]
 mip_table_id = Emon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -648,7 +648,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i209[lbproc=128]
 mip_table_id = Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -658,7 +658,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s03i440[lbproc=128]
 mip_table_id = Emon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -667,7 +667,7 @@ component = ocean
 dimension = longitude latitude
 expression = deptho
 mip_table_id = Ofx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -699,7 +699,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i071[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_DMS)
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -710,7 +710,7 @@ dimension = longitude latitude time
 expression = m01s03i441[lbproc=128] + m01s03i442[lbproc=128] + m01s03i443[lbproc=128] + m01s03i444[lbproc=128] + m01s03i445[lbproc=128] + m01s03i446[lbproc=128] + m01s03i451[lbproc=128] + m01s03i452[lbproc=128] + m01s03i453[lbproc=128] + m01s03i454[lbproc=128] + m01s03i455[lbproc=128] + m01s03i456[lbproc=128]
 mip_table_id = AERmon
 notes = Assumes CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -719,7 +719,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_O3, m01s50i131[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -728,7 +728,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -737,7 +737,7 @@ component = aerosol
 dimension = longitude latitude alevel lambda550nm time
 expression = m01s02i530[lbplev=3, lbproc=128] + m01s02i540[lbplev=3, lbproc=128]
 mip_table_id = Emon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-1
 
@@ -746,7 +746,7 @@ component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C, m01s38i207[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -756,7 +756,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (m01s03i495[lbproc=128] + m01s03i496[lbproc=128]) * m01s00i505
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>, Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -765,7 +765,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i158[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -774,7 +774,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i214[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -785,7 +785,7 @@ dimension = longitude latitude time
 expression = m01s03i401[lbproc=128] + m01s03i402[lbproc=128] + m01s03i403[lbproc=128] + m01s03i404[lbproc=128] + m01s03i405[lbproc=128] + m01s03i406[lbproc=128]
 mip_table_id = AERmon
 notes = Assumes CLASSIC dust.
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -795,7 +795,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_ISOPRENE / (5.0 * ATOMIC_MASS_OF_C)) * (m01s03i495[lbproc=128] * m01s00i505)
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>, Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -804,7 +804,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i081[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol s-1
 
@@ -814,7 +814,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = achem_emdrywet(1.0, m01s50i172[lbproc=128], cube2d=m01s50i156[lbproc=128], sumlev='True')
 mip_table_id = AERmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -823,7 +823,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = achem_emdrywet(1.0, m01s50i217[lbproc=128], cube2d=(m01s50i215[lbproc=128] + m01s50i216[lbproc=128]), sumlev='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = kg m-2 s-1
 
@@ -833,7 +833,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s38i201[lbproc=128] + m01s38i202[lbproc=128] + m01s38i203[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -842,7 +842,7 @@ component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL, m01s38i204[lbproc=128] + m01s38i205[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -851,7 +851,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = ((m01s50i159[lbproc=128] / MOLECULAR_MASS_OF_HCHO) + (m01s50i160[lbproc=128] * (2.0 / MOLECULAR_MASS_OF_C2H6)) + (m01s50i161[lbproc=128] * (3.0 / MOLECULAR_MASS_OF_C3H8)) + (m01s50i162[lbproc=128] * (3.0 / MOLECULAR_MASS_OF_ME2CO)) + (m01s50i163[lbproc=128] * (2.0 / MOLECULAR_MASS_OF_MECHO)) + (m01s50i212[lbproc=128] / MOLECULAR_MASS_OF_MEOH) + (m01s50i300[lbproc=128] * (5.0 / MOLECULAR_MASS_OF_ISOPRENE)) + (m01s50i301[lbproc=128] * (10.0 / MOLECULAR_MASS_OF_MONOTERPENE))) * ATOMIC_MASS_OF_C
 mip_table_id = AERmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -867,7 +867,7 @@ component = atmos-physics
 dimension = latitude plev39 time
 expression = scale_epflux(m01s30i312[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -877,7 +877,7 @@ dimension = latitude plev39 time
 expression = scale_epflux(m01s30i313[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ
 positive = up
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -886,7 +886,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i296[lbproc=128]
 mip_table_id = Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -895,7 +895,7 @@ component = ocean
 dimension = longitude latitude time
 expression = correct_evaporation(evs, sowaflup - (evs - (ficeberg + friver + prsn + pr + fsitherm) ), areacello)
 mip_table_id = Omon
-reviewer = Dave Storkey <dave.storkey@metoffice.gov.uk>
+reviewer = Dave Storkey (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -904,7 +904,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i223[lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>, Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -913,7 +913,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i334[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -922,7 +922,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i296[lbproc=128] + m01s03i298[lbproc=128] - m01s03i539[lbproc=128]
 mip_table_id = Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -931,7 +931,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -942,7 +942,7 @@ dimension = longitude latitude depth0m time
 expression = calc_fgdms(m01s00i505, m01s50i214[lbproc=128] / MOLECULAR_MASS_OF_DMS )
 mip_table_id = Omon
 positive = up
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = kmol m-2 s-1
 
@@ -952,7 +952,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(ficeberg, -1*vowflisf)
 mip_table_id = Omon
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -968,7 +968,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = div_by_area(m01s50i082[lbproc=128])
 mip_table_id = Emon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>, Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (Met Office)
 status = ok
 units = m-2 min-1
 
@@ -977,7 +977,7 @@ component = ocean
 dimension = longitude latitude time
 expression = friver
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -986,7 +986,7 @@ component = seaice
 dimension = longitude latitude time
 expression = fsitherm
 mip_table_id = Omon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -995,7 +995,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s03i261[lbproc=128]
 mip_table_id = E3hr
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1005,7 +1005,7 @@ dimension = longitude latitude typenatgr time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='grass')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -1021,7 +1021,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCHO) * m01s34i011[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1030,7 +1030,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL) * m01s34i992[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1040,7 +1040,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasin_global, hfbasin_atlantic, hfbasin_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1050,7 +1050,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpadv_global, hfbasinpadv_atlantic, hfbasinpadv_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1060,7 +1060,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpmadv_global, hfbasinpmadv_atlantic, hfbasinpmadv_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1070,7 +1070,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpmdiff_global, hfbasinpmdiff_atlantic, hfbasinpmdiff_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1080,7 +1080,7 @@ dimension = longitude latitude time
 expression = hfcorr
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Matthew Couldrey <m.p.couldrey@reading.ac.uk>
+reviewer = Matthew Couldrey (University of Reading)
 status = ok
 units = W m-2
 
@@ -1090,7 +1090,7 @@ dimension = longitude latitude time
 expression = hfds
 mip_table_id = Omon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1108,7 +1108,7 @@ dimension = longitude latitude time
 expression = hfevapds
 mip_table_id = Omon
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1118,7 +1118,7 @@ dimension = longitude latitude
 expression = hfgeou
 mip_table_id = Ofx
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1128,7 +1128,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(-1*berg_latent_heat_flux, vohflisf)
 mip_table_id = Omon
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -1138,7 +1138,7 @@ dimension = longitude latitude time
 expression = m01s03i234[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -1148,7 +1148,7 @@ dimension = longitude latitude time
 expression = hfrainds
 mip_table_id = Omon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1158,7 +1158,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(hflx_rnf, -1*vohfcisf)
 mip_table_id = Omon
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -1175,7 +1175,7 @@ dimension = longitude latitude time
 expression = m01s03i217[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -1184,7 +1184,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfx, mask_2D_U)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -1193,7 +1193,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfy, mask_2D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -1202,7 +1202,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3) * m01s34i007[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1211,7 +1211,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HO2) * m01s51i082[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 
@@ -1221,7 +1221,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfovgyre_global, hfovgyre_atlantic, hfovgyre_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1231,7 +1231,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfovovrt_global, hfovovrt_atlantic, hfovovrt_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1240,7 +1240,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i113[lbproc=128]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = %
 
@@ -1368,7 +1368,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i245[lbproc=128]
 mip_table_id = Amon day 6hrPlev
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = %
 
@@ -1400,7 +1400,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1458,7 +1458,7 @@ component = atmos-physics
 dimension = longitude latitude plev27 time
 expression = m01s30i295[blev=PLEV27, lbproc=128] / m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1530,7 +1530,7 @@ component = atmos-physics
 dimension = longitude latitude plev7h time1
 expression = m01s30i295[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1539,7 +1539,7 @@ component = atmos-physics
 dimension = longitude latitude p850 time
 expression = m01s30i295[blev=P850, lbproc=128] / m01s30i304[blev=P850, lbproc=128]
 mip_table_id = GCAmon GCday Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1555,7 +1555,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i237[lbproc=128]
 mip_table_id = Amon day
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = 1
 
@@ -1571,7 +1571,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i462[lbproc=128]
 mip_table_id = Emon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -1587,7 +1587,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i463[lbproc=128]
 mip_table_id = Emon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -1596,7 +1596,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_ISOPRENE) * m01s34i027[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1605,7 +1605,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i229[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1614,7 +1614,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = m01s52i245[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1623,7 +1623,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = m01s52i246[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1632,7 +1632,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadIc tau time
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -1641,7 +1641,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadLi tau time
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -1651,7 +1651,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i318[lbproc=128], m01s03i317[lbproc=128],
 	land_class='natural')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = 1
 
@@ -1660,7 +1660,7 @@ component = dust
 dimension = longitude latitude time
 expression = calc_loaddust(m01s17i257[lbproc=128], m01s50i255[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1670,7 +1670,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i247[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -1680,7 +1680,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i071[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -1689,7 +1689,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -1699,7 +1699,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = masscello
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2
 
@@ -1708,7 +1708,7 @@ component = ocean
 dimension = time
 expression = scvoltot * SEAWATER_DENSITY
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg
 
@@ -1717,7 +1717,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=8192]
 mip_table_id = AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -1726,7 +1726,7 @@ dimension = longitude latitude alevhalf time
 expression = (m01s05i250[lbproc=128] - m01s05i251[lbproc=128]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = Amon CFday
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1735,7 +1735,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i251[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon
 positive = down
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1744,7 +1744,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i250[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1754,7 +1754,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = (m01s51i150[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = AERmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = yr
 
@@ -1763,7 +1763,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=4096]
 mip_table_id = AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -1772,7 +1772,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotst
 mip_table_id = Omon Eday
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -1781,7 +1781,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmax
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -1790,7 +1790,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmin
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -1799,7 +1799,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstsq
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -1809,7 +1809,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i105[lbproc=128] + m01s34i109[lbproc=128] + m01s34i115[lbproc=128] + m01s34i120[lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -1818,7 +1818,7 @@ component = dust
 dimension = longitude latitude alevel time
 expression = m01s00i431[lbproc=128] + m01s00i432[lbproc=128] + m01s00i433[lbproc=128] + m01s00i434[lbproc=128] + m01s00i435[lbproc=128] + m01s00i436[lbproc=128]
 mip_table_id = AERmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg kg-1
 
@@ -1828,7 +1828,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i106[lbproc=128] + m01s34i110[lbproc=128] + m01s34i116[lbproc=128] + m01s34i121[lbproc=128] + m01s34i126[lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -1837,7 +1837,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4) * (m01s34i102[lbproc=128] + m01s34i104[lbproc=128] + m01s34i108[lbproc=128] + m01s34i114[lbproc=128])
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -1846,7 +1846,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i111[lbproc=128] + m01s34i117[lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -1855,7 +1855,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128] * m01s08i230[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Lmon
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -1878,7 +1878,7 @@ component = land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128] * m01s08i229[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Emon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -1887,7 +1887,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128] + m01s08i235[lbproc=128]
 mip_table_id = 3hr day Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1896,7 +1896,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i235[lbproc=128]
 mip_table_id = GCLmon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1905,7 +1905,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128]
 mip_table_id = Lmon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1914,7 +1914,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i230[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -1923,7 +1923,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i229[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -1932,7 +1932,7 @@ component = land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128])
 mip_table_id = day Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -1942,7 +1942,7 @@ component = land
 dimension = longitude latitude
 expression = mask_zeros(m01s00i041 * FRESHWATER_DENSITY)
 mip_table_id = fx
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = kg m-2
 
@@ -1951,7 +1951,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>, Eleanor Burke <eleanor.burke@metoffice.gov.uk
+reviewer = Ron Kahana (Met Office), Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = kg m-2
 
@@ -1960,7 +1960,7 @@ component = land
 dimension = longitude latitude sdepth1 time
 expression = m01s08i223[blev=0.05, lbproc=128]
 mip_table_id = day Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -1970,7 +1970,7 @@ component = ocean
 dimension = longitude latitude time
 expression = ocean_quasi_barotropic_streamfunc(umo_vint, areacello, cube_mask=mask_2D_T)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -1980,7 +1980,7 @@ component = ocean
 dimension = latitude basin olevel time
 expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfglo, zomsfatl, zomsfipc, mask_global=global_ocean_2D_V, mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -1990,7 +1990,7 @@ component = ocean
 dimension = latitude basin olevel time
 expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfeivglo, zomsfeivatl, zomsfeivipc, mask_global=global_ocean_2D_V, mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -1999,7 +1999,7 @@ component = chemistry
 dimension = longitude latitude plev19 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O) * m01s51i049[blev=PLEV19, lbproc=128] / m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2008,7 +2008,7 @@ component = chemistry
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i049[lbproc=128], MOLECULAR_MASS_OF_N2O)
 mip_table_id = Amon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -2017,7 +2017,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO) * m01s34i002[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2026,7 +2026,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2) * m01s34i996[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2035,7 +2035,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = MOLECULAR_MASS_OF_AIR * ((m01s51i002[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO) + (m01s51i003[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO3) + (2 * m01s51i005[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_N2O5) + (m01s51i006[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HO2NO2) + (m01s51i007[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HNO3) + (m01s51i013[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HONO) + (m01s51i025[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_MEONO2) + (m01s51i048[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRONO2) + (m01s51i054[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CLONO2) + (m01s51i058[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NITROGEN) + (m01s51i996[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO2)) / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2044,7 +2044,7 @@ component = chemistry
 dimension = longitude latitude plev19 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s51i001[blev=PLEV19, lbproc=128] / m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2053,7 +2053,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (m01s50i011[lbproc=128] + m01s50i013[lbproc=128] + m01s50i014[lbproc=128] + m01s50i015[lbproc=128]) / m01s50i255[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -2062,7 +2062,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (m01s50i001[lbproc=128] + m01s50i003[lbproc=128] + m01s50i103[lbproc=128]) / m01s50i255[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -2072,7 +2072,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(obvfsq, mask_3D_T)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = s-2
 
@@ -2082,7 +2082,7 @@ component = aerosol
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=2, lbproc=128] + m01s02i300[lbplev=2, lbproc=128] + m01s02i301[lbplev=2, lbproc=128] + m01s02i302[lbplev=2, lbproc=128] + m01s02i303[lbplev=2, lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2092,7 +2092,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=2, lbproc=128]
 mip_table_id = Emon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2101,7 +2101,7 @@ component = aerosol
 dimension = longitude latitude lambda550nm time
 expression = m01s02i285[lbplev=3, lbproc=128] + m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128] + m01s02i302[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERmon AERday
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2111,7 +2111,7 @@ component = aerosol
 dimension = longitude latitude lambda550nm time
 expression = m01s02i251[lbplev=3, lbproc=128] + m01s02i252[lbplev=3, lbproc=128] + m01s02i253[lbplev=3, lbproc=128] + m01s02i254[lbplev=3, lbproc=128]
 mip_table_id = Emon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2120,7 +2120,7 @@ component = dust
 dimension = longitude latitude lambda550nm time
 expression = m01s02i285[lbplev=3, lbproc=128]
 mip_table_id = AERmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2130,7 +2130,7 @@ component = aerosol
 dimension = longitude latitude lambda550nm time
 expression = m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2140,7 +2140,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=5, lbproc=128]
 mip_table_id = Emon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2150,7 +2150,7 @@ component = aerosol
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=5, lbproc=128] + m01s02i300[lbplev=5, lbproc=128] + m01s02i301[lbplev=5, lbproc=128] + m01s02i302[lbplev=5, lbproc=128] + m01s02i303[lbplev=5, lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2159,7 +2159,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH) * m01s34i081[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2169,7 +2169,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempdiff
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2179,7 +2179,7 @@ component = ocean
 dimension = longitude latitude time
 expression = opottempmint
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC kg m-2
 
@@ -2189,7 +2189,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemppmdiff
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2199,7 +2199,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempadvect
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2209,7 +2209,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemptend
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2218,7 +2218,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = m01s00i033
 mip_table_id = fx
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -2228,7 +2228,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltdiff
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2238,7 +2238,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltpmdiff
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2248,7 +2248,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltadvect
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2258,7 +2258,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osalttend
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2267,7 +2267,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_PAN) * m01s34i017[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2276,7 +2276,7 @@ component = cftables
 dimension = longitude latitude sza5 time
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -2285,7 +2285,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = pathetao
 mip_table_id = Emon OPmonLev
-reviewer = Matthew Couldrey <m.p.couldrey@reading.ac.uk>
+reviewer = Matthew Couldrey (University of Reading)
 status = ok
 units = degC
 
@@ -2294,7 +2294,7 @@ component = ocean
 dimension = longitude latitude time
 expression = pbo
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = dbar
 
@@ -2303,7 +2303,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i333[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -2312,7 +2312,7 @@ component = atmos-physics cftables
 dimension = longitude latitude alevel time
 expression = m01s00i408[lbproc=128]
 mip_table_id = AERmon CFday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2322,7 +2322,7 @@ component = aerosol cftables
 dimension = longitude latitude alevhalf time
 expression = m01s00i407[lbproc=128]
 mip_table_id = AERmon CFday
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = Pa
 
@@ -2331,7 +2331,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i228[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -2340,7 +2340,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128]
 mip_table_id = 3hr 6hrPlev Amon E1hr day CresAERday AP1hr AP3hr AP6hr APday APmon mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2350,7 +2350,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128] + m01s05i206[lbproc=128]
 mip_table_id = Amon 3hr E1hr day
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2360,7 +2360,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i227[lbproc=0]
 mip_table_id = CF3hr
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2369,7 +2369,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i223[lbproc=0]
 mip_table_id = CF3hr
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2378,7 +2378,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i222[lbproc=0]
 mip_table_id = CF3hr
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2387,7 +2387,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i214[lbproc=128]
 mip_table_id = E3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2396,7 +2396,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128]
 mip_table_id = E3hr Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2405,7 +2405,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i215[lbproc=128]
 mip_table_id = Amon 3hr day
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2415,7 +2415,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = prthetao
 mip_table_id = Emon OPmonLev
-reviewer = Matthew Couldrey <m.p.couldrey@reading.ac.uk>
+reviewer = Matthew Couldrey (University of Reading)
 status = ok
 units = degC
 
@@ -2424,7 +2424,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i461[lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2
 
@@ -2433,7 +2433,7 @@ component = atmos-physics cftables
 dimension = longitude latitude time
 expression = m01s00i409[lbproc=128]
 mip_table_id = Amon AERhr CFmon AERmon Emon CFday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2442,7 +2442,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s16i222[lbproc=128]
 mip_table_id = 6hrPlev Amon day APmon AP6hr APday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2451,7 +2451,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i451[lbproc=128]
 mip_table_id = AERmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2461,7 +2461,7 @@ component = cloud
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128], m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2470,7 +2470,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2479,7 +2479,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2488,7 +2488,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2497,7 +2497,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2506,7 +2506,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s01i245[lbproc=128] / m01s01i246[lbproc=128]
 mip_table_id = AERmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2516,7 +2516,7 @@ component = cloud
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128], m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128] + m01s02i396[lbproc=128]))
 mip_table_id = Eday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2528,7 +2528,7 @@ dimension = longitude latitude typeresidual time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='residual')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -2539,7 +2539,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i218[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2549,7 +2549,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i522[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2560,7 +2560,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i220[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2570,7 +2570,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i524[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2581,7 +2581,7 @@ dimension = longitude latitude time
 expression = m01s02i207[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2592,7 +2592,7 @@ dimension = longitude latitude time
 expression = m01s02i208[lbproc=128]
 mip_table_id = Amon 3hr CFday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2602,7 +2602,7 @@ dimension = longitude latitude time
 expression = m01s02i201[lbproc=128] - (m01s03i332[lbproc=128] - m01s02i205[lbproc=128])
 mip_table_id = Emon Eday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2612,7 +2612,7 @@ dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i217[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2622,7 +2622,7 @@ dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i521[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2632,7 +2632,7 @@ dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i219[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2642,7 +2642,7 @@ dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i523[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2653,7 +2653,7 @@ dimension = longitude latitude time
 expression = m01s02i207[lbproc=128] - m01s02i201[lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2663,7 +2663,7 @@ dimension = longitude latitude time
 expression = m01s03i332[lbproc=128]
 mip_table_id = Amon day
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2673,7 +2673,7 @@ dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i521[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2683,7 +2683,7 @@ dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i517[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -2693,7 +2693,7 @@ dimension = longitude latitude time
 expression = m01s02i206[lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = Amon CFday
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2703,7 +2703,7 @@ dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i523[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2713,7 +2713,7 @@ dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i519[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -2724,7 +2724,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i218[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2734,7 +2734,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i522[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2745,7 +2745,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i220[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2755,7 +2755,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i524[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2790,7 +2790,7 @@ dimension = longitude latitude olevel time
 expression = rsdo
 mip_table_id = Omon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2800,7 +2800,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = rsdoabsorb
 mip_table_id = Emon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = W m-2
 
@@ -2811,7 +2811,7 @@ dimension = longitude latitude time
 expression = m01s01i235[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2822,7 +2822,7 @@ dimension = longitude latitude time
 expression = m01s01i210[lbproc=128]
 mip_table_id = Amon 3hr CFday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2856,7 +2856,7 @@ dimension = longitude latitude time
 expression = m01s01i216[lbproc=128]
 mip_table_id = 3hr Emon Eday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2866,7 +2866,7 @@ dimension = longitude latitude time
 expression = m01s01i207[lbproc=128]
 mip_table_id = Amon CFday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2876,7 +2876,7 @@ dimension = longitude latitude time
 expression = m01s01i201[lbproc=128]
 mip_table_id = Emon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2887,7 +2887,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i217[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2897,7 +2897,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i521[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2908,7 +2908,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i219[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2918,7 +2918,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i523[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2953,7 +2953,7 @@ dimension = longitude latitude time
 expression = m01s01i235[lbproc=128] - m01s01i201[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2963,7 +2963,7 @@ dimension = longitude latitude time
 expression = m01s01i211[lbproc=128]
 mip_table_id = Amon 3hr CFday
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2998,7 +2998,7 @@ dimension = longitude latitude time
 expression = m01s01i208[lbproc=128]
 mip_table_id = Amon CFday
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3008,7 +3008,7 @@ dimension = longitude latitude time
 expression = m01s01i521[lblev=86, lbproc=128]
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3018,7 +3018,7 @@ dimension = longitude latitude time
 expression = m01s01i517[lblev=86, lbproc=128]
 mip_table_id = AERmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3028,7 +3028,7 @@ dimension = longitude latitude time
 expression = m01s01i209[lbproc=128]
 mip_table_id = Amon E3hr CFday
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3038,7 +3038,7 @@ dimension = longitude latitude time
 expression = m01s01i523[lblev=86, lbproc=128]
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3048,7 +3048,7 @@ dimension = longitude latitude time
 expression = m01s01i519[lblev=86, lbproc=128]
 mip_table_id = AERmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3058,7 +3058,7 @@ dimension = longitude latitude time
 expression = m01s01i207[lbproc=128] - m01s01i208[lbproc=128] - m01s03i332[lbproc=128]
 mip_table_id = Amon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3074,7 +3074,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i331[lbproc=128], m01s03i317[lbproc=128], land_class='all')
 mip_table_id = LImon Eday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3083,7 +3083,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i270[lbproc=128]
 mip_table_id = Amon
-reviewer = Rachel Stratton <rachel.stratton@metoffice.gov.uk>
+reviewer = Rachel Stratton (Met Office)
 status = ok
 units = 1
 
@@ -3093,7 +3093,7 @@ component = cloud
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128], m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128] + m01s02i396[lbproc=128]))
 mip_table_id = Eday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -3102,7 +3102,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s17i257[lblev=1, lbproc=128]
 mip_table_id = Emon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -3112,7 +3112,7 @@ dimension = longitude latitude height10m time
 expression = m01s03i230[lbproc=128]
 mip_table_id = Amon E3hr day 6hrPlev
 notes = An arbitrary choice between 'B-grid' or 'C-grid' but it would seem sensible to use the same throughout.
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -3136,7 +3136,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2) * m01s34i996[lblev=1, lbproc=128]
 mip_table_id = AERhr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -3145,7 +3145,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s34i001[lblev=1, lbproc=128]
 mip_table_id = AERhr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -3154,7 +3154,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s34i001[lblev=1, lbproc=8192]
 mip_table_id = AERday
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3171,7 +3171,7 @@ component = land
 dimension = longitude latitude typeland
 expression = m01s00i505
 mip_table_id = fx
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = 1
 
@@ -3180,7 +3180,7 @@ component = ocean
 dimension = longitude latitude typesea
 expression = sftof
 mip_table_id = Ofx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = %
 
@@ -3190,7 +3190,7 @@ dimension = longitude latitude typeshrub time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='shrub')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -3199,7 +3199,7 @@ component = seaice
 dimension = longitude latitude time
 expression = iage * SECONDS_IN_DAY * DAYS_IN_YEAR
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s
 
@@ -3208,7 +3208,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sicompstren
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-1
 
@@ -3217,7 +3217,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3226,7 +3226,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = m01s00i031[lbproc=128]
 mip_table_id = SImon SIday
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3235,7 +3235,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcdyn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -3244,7 +3244,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcth
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -3253,7 +3253,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtd * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3263,7 +3263,7 @@ dimension = longitude latitude time
 expression = -1 * evap_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3272,7 +3272,7 @@ component = seaice
 dimension = longitude latitude time
 expression = congel * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3281,7 +3281,7 @@ component = seaice
 dimension = longitude latitude time
 expression = frazil * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3290,7 +3290,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltl * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3299,7 +3299,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltb * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3308,7 +3308,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3317,7 +3317,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3326,7 +3326,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3335,7 +3335,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstranx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -3344,7 +3344,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstrany
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -3353,7 +3353,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i538[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3362,7 +3362,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sifb
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3372,7 +3372,7 @@ dimension = longitude latitude time
 expression = siflcondbot
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -3382,7 +3382,7 @@ dimension = longitude latitude time
 expression = siflcondtop
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -3391,7 +3391,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ((meltt + meltb + meltl - congel - frazil) * ICE_DENSITY + melts * SNOW_DENSITY) / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [siflfwdrain]
@@ -3399,7 +3399,7 @@ component = seaice
 dimension = longitude latitude time
 expression = (meltt * ICE_DENSITY + melts * SNOW_DENSITY) / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sifllatstop]
@@ -3416,7 +3416,7 @@ dimension = longitude latitude time
 expression = m01s02i501[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -3426,7 +3426,7 @@ dimension = longitude latitude time
 expression = m01s03i531[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -3467,7 +3467,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecoriolx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -3476,7 +3476,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecorioly
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -3485,7 +3485,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstrx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -3494,7 +3494,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstry
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -3503,7 +3503,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetiltx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -3512,7 +3512,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetilty
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -3521,7 +3521,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sihc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -3530,7 +3530,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3539,7 +3539,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = snowfracn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3548,7 +3548,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vsnon / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3557,7 +3557,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vicen / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3566,7 +3566,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi * ICE_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -3576,7 +3576,7 @@ component = seaice
 dimension = longitude latitude typemp time
 expression = apond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3586,7 +3586,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hpond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3596,7 +3596,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ipond_ai / apond_ai
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3605,7 +3605,7 @@ component = seaice
 dimension = longitude latitude time
 expression = rain_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sirdgconc]
@@ -3613,7 +3613,7 @@ component = seaice
 dimension = longitude latitude typesirdg time
 expression = ardg
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3630,7 +3630,7 @@ dimension = longitude latitude time
 expression = sisaltmass
 mip_table_id = SImon
 notes = The interpretation of this variable in CICE is not obvious as CICE has two simultaneous salinity profiles (when prognostic salinity is not being used).
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -3639,7 +3639,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snowfrac / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3648,7 +3648,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnhc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -3657,7 +3657,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hs * SNOW_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -3666,7 +3666,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnthick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3675,7 +3675,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sispeed
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -3716,7 +3716,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sitempbot
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -3725,7 +3725,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i535[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon SIday
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -3734,7 +3734,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sithick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3743,7 +3743,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ice_present
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3752,7 +3752,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siu
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -3761,7 +3761,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siv
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -3770,7 +3770,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3780,7 +3780,7 @@ component = ocean
 dimension = latitude basin time
 expression = 1.026 * combine_cubes_to_basin_coord(sltbasin_global, sltbasin_atlantic, sltbasin_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = EmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -3790,7 +3790,7 @@ component = ocean
 dimension = latitude basin time
 expression = 1.026 * combine_cubes_to_basin_coord(sltovgyre_global, sltovgyre_atlantic, sltovgyre_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -3800,7 +3800,7 @@ component = ocean
 dimension = latitude basin time
 expression = 1.026 * combine_cubes_to_basin_coord(sltovovrt_global, sltovovrt_atlantic, sltovovrt_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -3810,7 +3810,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = snc_calc(m01s08i236[lbproc=128], m01s03i317[lbproc=128], m01s03i395[lbproc=128])
 mip_table_id = day LImon
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = %
 
@@ -3820,7 +3820,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i376[lbproc=128], m01s03i317[lbproc=128], land_class='all')
 mip_table_id = LImon Eday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = m
 
@@ -3829,7 +3829,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvsdtd * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3838,7 +3838,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * melts * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3847,7 +3847,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3856,7 +3856,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snow_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3865,7 +3865,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i237[lbproc=128], m01s03i317[lbproc=128], land_class='all')
 mip_table_id = LImon Eday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3875,7 +3875,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i236[lbproc=128], m01s03i317[lbproc=128], land_class='all')
 mip_table_id = day LImon
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -3885,7 +3885,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = so
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -3894,7 +3894,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i072[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_SO2)
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -3903,7 +3903,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sob
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -3912,7 +3912,7 @@ component = ocean
 dimension = time
 expression = soga
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -3929,7 +3929,7 @@ component = ocean
 dimension = longitude latitude time
 expression = somint
 mip_table_id = Emon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = 1e-3 kg m-2
 
@@ -3938,7 +3938,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sos
 mip_table_id = Oday Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -3947,7 +3947,7 @@ component = ocean
 dimension = time
 expression = area_mean(sos, areacello)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -3956,7 +3956,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sossq
 mip_table_id = Oday Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-6
 
@@ -3965,7 +3965,7 @@ component = snow-permafrost
 dimension = longitude latitude landUse time
 expression = land_use_tile_mean( m01s08i236[lbproc=128] / FRESHWATER_DENSITY, m01s03i317[lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = m
 
@@ -3974,7 +3974,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i044[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1e5 K2
 
@@ -3984,7 +3984,7 @@ dimension = longitude latitude time
 expression = t20d
 mip_table_id = Emon Eday
 notes = PMIP variables: Variable will be output with a time dimension and with cell_methods for time.
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -3993,7 +3993,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4051,7 +4051,7 @@ component = atmos-physics
 dimension = longitude latitude plev27 time
 expression = m01s30i294[blev=PLEV27, lbproc=128] / m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4088,7 +4088,7 @@ component = atmos-physics
 dimension = longitude latitude p500 time
 expression = m01s30i294[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
 mip_table_id = GCAmon GCday Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4111,7 +4111,7 @@ component = cftables
 dimension = longitude latitude p700 time
 expression = m01s30i294[blev=P700, lbproc=128] / m01s30i304[blev=P700, lbproc=128]
 mip_table_id = GCAmon GCday CFday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
@@ -4120,7 +4120,7 @@ component = atmos-physics
 dimension = longitude latitude plev7h time1
 expression = m01s30i294[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt E3hrPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
@@ -4129,7 +4129,7 @@ component = atmos-physics
 dimension = longitude latitude p850 time
 expression = m01s30i294[blev=P850, lbproc=128] / m01s30i304[blev=P850, lbproc=128]
 mip_table_id = GCAmon GCday Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4145,7 +4145,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=128]
 mip_table_id = 6hrPlev Amon day CresAERday Cres1HrMn AP6hr APday APmon mon 1hr
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = K
 
@@ -4154,7 +4154,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=8192])
 mip_table_id = Amon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4163,7 +4163,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=4096])
 mip_table_id = Amon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4181,7 +4181,7 @@ dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Amon Eday
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -4191,7 +4191,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauuo, mask_2D_U)
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -4200,7 +4200,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -4211,7 +4211,7 @@ dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Amon Eday
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -4221,7 +4221,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauvo, mask_2D_V)
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -4230,7 +4230,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -4246,7 +4246,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i316[lbplev=8, lbproc=128]
 mip_table_id = Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = K
 
@@ -4256,7 +4256,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thetao
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4265,7 +4265,7 @@ component = ocean
 dimension = time
 expression = thetaoga
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4274,7 +4274,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao, thkcello)
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4283,7 +4283,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<2025], thkcello[depth<2025])
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4292,7 +4292,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<300], thkcello[depth<300])
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4301,7 +4301,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<735], thkcello[depth<735])
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4311,7 +4311,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thkcello
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -4320,7 +4320,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i182[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4330,7 +4330,7 @@ dimension = longitude latitude alevel time
 expression = (m01s12i182[lbproc=128] + m01s12i382[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
 notes = Obtained by advection plus solver
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4339,7 +4339,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i162[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4349,7 +4349,7 @@ dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s04i982[lbproc=128] + m01s05i182[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128] + m01s35i025[lbproc=128] ) / ATMOS_TIMESTEP
 mip_table_id = CFmon
 notes = Methane Oxidation added.
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4358,7 +4358,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i190[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4367,7 +4367,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] - m01s03i190[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4377,7 +4377,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4400,7 +4400,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i181[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4410,7 +4410,7 @@ dimension = longitude latitude alevel time
 expression = (m01s10i181[lbproc=128] + m01s12i181[lbproc=128] + m01s12i381[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
 notes = Obtained by Solver plus Advection plus Conservations Corrections
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4419,7 +4419,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4428,7 +4428,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s14i181[lbproc=128] + m01s01i181[lbproc=128] + m01s02i181[lbproc=128] + m01s03i181[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s05i181[lbproc=128] + m01s06i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s35i029[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4437,7 +4437,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i189[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4446,7 +4446,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s01i161[lbproc=128] + m01s02i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4456,7 +4456,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4465,7 +4465,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i233[lbproc=128]
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4475,7 +4475,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4484,7 +4484,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i233[lbproc=128]
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4493,7 +4493,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s03i181[lbproc=128] - m01s03i189[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s01i181[lbproc=128] - m01s01i161[lbproc=128] + m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4503,7 +4503,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s03i181[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s01i181[lbproc=128] - m01s01i161[lbproc=128] + m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -4512,7 +4512,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tob
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4521,7 +4521,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tos
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4530,7 +4530,7 @@ component = ocean
 dimension = time
 expression = area_mean(tos, areacello)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4539,7 +4539,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tossq
 mip_table_id = Oday Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC2
 
@@ -4548,7 +4548,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i219[lblev=1, lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = 1e-5 m
 
@@ -4558,7 +4558,7 @@ dimension = longitude latitude time
 expression = m01s03i539[lbproc=128]
 mip_table_id = Lmon Eday
 positive = up
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4568,7 +4568,7 @@ dimension = longitude latitude typetree time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='tree')
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -4578,7 +4578,7 @@ dimension = longitude latitude typetreebd time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='broadLeafTreeDeciduous')
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -4588,7 +4588,7 @@ dimension = longitude latitude typetreene time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='needleLeafTreeEvergreen')
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -4597,7 +4597,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = trop_o3col(m01s34i001[lbproc=128] * m01s50i063[lbproc=128] * m01s50i062[lbproc=128])
 mip_table_id = AERmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>, Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (Met Office)
 status = ok
 units = 1.0e-5 m
 
@@ -4606,7 +4606,7 @@ component = atmos-physics boundary-layer
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4615,7 +4615,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Lmon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>, Eleanor Burke <eleanor.burke@metoffice.gov.uk
+reviewer = Ron Kahana (Met Office), Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = K
 
@@ -4631,7 +4631,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i011[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -4640,7 +4640,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128] / m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -4650,7 +4650,7 @@ component = atmos-physics
 dimension = longitude latitude p10 time
 expression = m01s30i201[blev=P10, lbproc=128]
 mip_table_id = AERday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -4709,7 +4709,7 @@ component = atmos-physics
 dimension = longitude latitude plev27 time
 expression = m01s30i201[blev=PLEV27, lbproc=128] / m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -4788,7 +4788,7 @@ component = boundary-layer
 dimension = longitude latitude height10m time
 expression = m01s03i209[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr day AP6hr APday APmon AP3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -4798,7 +4798,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(umo, mask_3D_U)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -4808,7 +4808,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(uo, mask_3D_U)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -4818,7 +4818,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i428[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -4827,7 +4827,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i014[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -4837,7 +4837,7 @@ component = atmos-physics
 dimension = latitude plev39 time
 expression = zonal_apply_heaviside(m01s30i314[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-2
 
@@ -4853,7 +4853,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s06i247[blev=PLEV19, lbproc=128]
 mip_table_id = Emon
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 
@@ -4862,7 +4862,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i012[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -4871,7 +4871,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i022[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -4880,7 +4880,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128] / m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -4946,7 +4946,7 @@ component = atmos-physics
 dimension = longitude latitude plev27 time
 expression = m01s30i202[blev=PLEV27, lbproc=128] / m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -5025,7 +5025,7 @@ component = boundary-layer
 dimension = longitude latitude height10m time
 expression = m01s03i210[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr day AP3hr AP6hr APday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5035,7 +5035,7 @@ dimension = longitude latitude typeveg time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='natural')
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = %
 
@@ -5045,7 +5045,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vmo, mask_3D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -5055,7 +5055,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * (m01s51i997[blev=PLEV39, lbproc=192] + 3.0 * m01s51i001[blev=PLEV39, lbproc=192] + m01s51i059[blev=PLEV39, lbproc=192]) / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -5065,7 +5065,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vo, mask_3D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -5075,7 +5075,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = volcello(thkcello, areacello)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -5084,7 +5084,7 @@ component = ocean
 dimension = time
 expression = scvoltot
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -5093,7 +5093,7 @@ component = atmos-physics
 dimension = longitude latitude pl700 time1
 expression = vortmean(m01s30i457[blev=600 700 850, lbproc=0])
 mip_table_id = 6hrPlevPt
-reviewer = Malcolm Roberts <malcolm.roberts@metoffice.gov.uk>
+reviewer = Malcolm Roberts (Met Office)
 status = ok
 units = s-1
 
@@ -5103,7 +5103,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i429[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -5112,7 +5112,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i024[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -5123,7 +5123,7 @@ dimension = latitude plev39 time
 expression = mask_vtem(m01s30i310[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APmonZ APdayZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -5132,7 +5132,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s00i150[lbproc=128]
 mip_table_id = AERmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5260,7 +5260,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i298[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -5332,7 +5332,7 @@ component = atmos-physics
 dimension = longitude latitude plev4 time
 expression = m01s30i298[blev=PLEV4, lbproc=128] / m01s30i304[blev=PLEV4, lbproc=128]
 mip_table_id = 6hrPlev
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -5355,7 +5355,7 @@ component = cftables
 dimension = longitude latitude p500 time
 expression = m01s30i298[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
 mip_table_id = GCAmon CFday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = Pa s-1
 
@@ -5385,7 +5385,7 @@ component = atmos-physics
 dimension = longitude latitude plev7h time1
 expression = m01s30i298[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = E3hrPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -5415,7 +5415,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s04i231[lbproc=128] + m01s04i232[lbproc=128] + m01s04i233[lbproc=128] + m01s04i234[lbproc=128] + m01s04i235[lbproc=128] + m01s04i236[lbproc=128] + m01s05i281[lbproc=128] + m01s05i282[lbproc=128] + m01s05i283[lbproc=128] + m01s05i284[lbproc=128] + m01s05i285[lbproc=128] + m01s05i286[lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5424,7 +5424,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s08i242[lbproc=128] * MOLECULAR_MASS_OF_CH4 / ATOMIC_MASS_OF_C
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = ug m-2 s-1
 
@@ -5433,7 +5433,7 @@ component = carbon
 dimension = longitude latitude typewetla time
 expression = m01s08i248[lbproc=128] * m01s03i395[lbproc=128]
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = 1
 
@@ -5442,7 +5442,7 @@ component = ocean
 dimension = longitude latitude time
 expression = -1 * (sowaflup + sowflisf)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5452,7 +5452,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wmo, mask_3D_T)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -5462,7 +5462,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wo, mask_3D_T)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -5478,7 +5478,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i249[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>, Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = m
 
@@ -5487,7 +5487,7 @@ component = atmos-physics
 dimension = latitude plev39 time
 expression = mask_polar_column_zonal_means( m01s30i311[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -5504,7 +5504,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = zfull
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -5513,7 +5513,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -5522,7 +5522,7 @@ component = atmos-physics
 dimension = longitude latitude p10 time
 expression = m01s30i297[blev=P10, lbproc=128] / m01s30i304[blev=P10, lbproc=128]
 mip_table_id = AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -5531,7 +5531,7 @@ component = atmos-physics
 dimension = longitude latitude p100 time
 expression = m01s30i297[blev=P100, lbproc=128] / m01s30i304[blev=P100, lbproc=128]
 mip_table_id = AERday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -5540,7 +5540,7 @@ component = atmos-physics
 dimension = longitude latitude p1000 time
 expression = m01s30i297[blev=P1000, lbproc=128] / m01s30i304[blev=P1000, lbproc=128]
 mip_table_id = GCAmon GCday 6hrPlev AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -5563,7 +5563,7 @@ component = atmos-physics
 dimension = longitude latitude plev27 time
 expression = m01s30i297[blev=PLEV27, lbproc=128] / m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -5586,7 +5586,7 @@ component = atmos-physics
 dimension = longitude latitude p500 time
 expression = m01s30i297[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
 mip_table_id = GCAmon GCday AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -5609,7 +5609,7 @@ component = atmos-physics
 dimension = longitude latitude plev7h time1
 expression = m01s30i297[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -5640,7 +5640,7 @@ component = ocean
 dimension = longitude latitude olevhalf time
 expression = zhalf
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -5649,7 +5649,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -5658,7 +5658,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zos
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -5667,7 +5667,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zossq
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -5679,7 +5679,7 @@ dimension = time
 expression = calc_zostoga(thetao, thkcello, areacello,
 	zfullo_0, so_0, rho_0_mean, deptho_0_mean)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -5688,6 +5688,6 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i453[lbproc=128] + m01s00i033[lbproc=128]
 mip_table_id = AERmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m

--- a/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3/data/HadGEM3_mappings.cfg
@@ -1951,7 +1951,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Ron Kahana (Met Office), Eleanor Burke <eleanor.burke@metoffice.gov.uk
+reviewer = Ron Kahana (Met Office), Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -4615,7 +4615,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Lmon Eday
-reviewer = Ron Kahana (Met Office), Eleanor Burke <eleanor.burke@metoffice.gov.uk
+reviewer = Ron Kahana (Met Office), Eleanor Burke (Met Office)
 status = ok
 units = K
 

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_3hr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_3hr_mappings.cfg
@@ -28,14 +28,14 @@ units = %
 [mrsos]
 dimension = longitude latitude sdepth1 time1
 expression = m01s08i223[blev=0.05, lbproc=0]
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -61,8 +61,8 @@ units = W m-2
 component = atmos-physics
 dimension = longitude latitude height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = K
 
@@ -75,14 +75,14 @@ units = m s-1
 [uas]
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [vas]
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_6hrLev_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_6hrLev_mappings.cfg
@@ -18,7 +18,7 @@ uva_native_levels = Note that the vertical levels for this variable correspond
 [ec550aer]
 dimension = longitude latitude alevel lambda550nm time1
 expression = m01s02i530[lbplev=3, lbproc=0] + m01s02i540[lbplev=3, lbproc=0]
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-1
 positive = None
@@ -27,8 +27,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = 1
 positive = None
@@ -37,8 +37,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i408[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -47,8 +47,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -57,8 +57,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s30i111[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = K
 positive = None
@@ -69,8 +69,8 @@ comment = Note that the vertical levels for this variable correspond
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i002[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -81,8 +81,8 @@ comment = Note that the vertical levels for this variable correspond
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i003[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = m s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_6hrPlevPt_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_6hrPlevPt_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [psl]
 dimension = longitude latitude time1
 expression = m01s16i222[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -29,7 +29,7 @@ positive = None
 dimension = longitude latitude plev3 time1
 expression = m01s30i294[blev=PLEV3, lbproc=0]
 	/ m01s30i304[blev=PLEV3, lbproc=0]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -44,7 +44,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -53,7 +53,7 @@ positive = None
 dimension = longitude latitude plev3 time1
 expression = m01s30i201[blev=PLEV3, lbproc=0]
 	/ m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -62,7 +62,7 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -71,7 +71,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -80,7 +80,7 @@ positive = None
 dimension = longitude latitude plev3 time1
 expression = m01s30i202[blev=PLEV3, lbproc=0]
 	/ m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -89,7 +89,7 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -97,7 +97,7 @@ positive = None
 [zg500]
 dimension = longitude latitude p500 time1
 expression = m01s30i297[blev=P500, lbproc=0] / m01s30i304[blev=P500, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_AERday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_AERday_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [toz]
 dimension = longitude latitude time
 expression = m01s50i219[lblev=1, lbproc=128]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = 1e-5 m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_AERmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_AERmonZ_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s51i009[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -23,8 +23,8 @@ positive = None
 [hcl]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL)
 	* m01s51i992[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-	Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Guang Zeng (NIWA),
+	Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 positive = None
@@ -32,7 +32,7 @@ positive = None
 [hno3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3)
 	* m01s51i007[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -40,7 +40,7 @@ positive = None
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s51i049[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -48,7 +48,7 @@ positive = None
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s51i001[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -56,7 +56,7 @@ positive = None
 [oh]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH)
 	* m01s51i081[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
@@ -64,7 +64,7 @@ positive = None
 [ta]
 expression = m01s30i294[blev=PLEV39, lbproc=192]
 	/ m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -72,7 +72,7 @@ positive = None
 [ua]
 expression = m01s30i201[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -80,7 +80,7 @@ positive = None
 [va]
 expression = m01s30i202[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -88,7 +88,7 @@ positive = None
 [zg]
 expression = m01s30i297[blev=PLEV39, lbproc=192]
 	/ m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_AERmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_AERmon_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s34i009[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
@@ -23,7 +23,7 @@ positive = None
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s34i049[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
@@ -31,28 +31,28 @@ positive = None
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s34i001[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_APday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_APday_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None
@@ -25,7 +25,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 positive = None
@@ -34,7 +34,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -42,7 +42,7 @@ positive = None
 [sfcWindmax]
 dimension = longitude latitude height10m time
 expression = m01s03i230[lbproc=8192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -50,7 +50,7 @@ positive = None
 [tasmax]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=8192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -58,7 +58,7 @@ positive = None
 [tasmin]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=4096]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -67,7 +67,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -76,7 +76,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -85,7 +85,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 positive = None
@@ -94,7 +94,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i297[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_APmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_APmon_mappings.cfg
@@ -17,7 +17,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_Amon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_Amon_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_CF3hr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_CF3hr_mappings.cfg
@@ -21,7 +21,7 @@ positive = None
 [clc]
 dimension = longitude latitude alevel time1
 expression = m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -29,7 +29,7 @@ positive = None
 [clic]
 dimension = longitude latitude alevel time1
 expression = m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -37,7 +37,7 @@ positive = None
 [clis]
 dimension = longitude latitude alevel time1
 expression = m01s02i309[lbproc=0] - m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -51,7 +51,7 @@ positive = None
 [cls]
 dimension = longitude latitude alevel time1
 expression = m01s02i312[lbproc=0] + m01s02i313[lbproc=0] - m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -66,7 +66,7 @@ positive = None
 [clwc]
 dimension = longitude latitude alevel time1
 expression = m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -74,7 +74,7 @@ positive = None
 [clws]
 dimension = longitude latitude alevel time1
 expression = m01s02i308[lbproc=0] - m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -149,7 +149,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i228[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -164,7 +164,7 @@ positive = None
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -180,7 +180,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -189,7 +189,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -198,7 +198,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -207,7 +207,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -337,7 +337,7 @@ units = Pa
 [ts]
 dimension = longitude latitude time1
 expression = m01s00i024[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_CFday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_CFday_mappings.cfg
@@ -15,42 +15,42 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 positive = None
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [wap]
 expression = m01s30i008[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = Pa s-1
 positive = None
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_CFmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_CFmon_mappings.cfg
@@ -15,14 +15,14 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 positive = None
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_CFsubhr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_CFsubhr_mappings.cfg
@@ -22,7 +22,7 @@ rld_rldcs = Physically, the radiation scheme used in this model ignores any
 [ci]
 dimension = site time1
 expression = m01s05i269[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -30,7 +30,7 @@ positive = None
 [cl]
 dimension = alevel site time1
 expression = m01s02i261[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -38,7 +38,7 @@ positive = None
 [cli]
 dimension = alevel site time1
 expression = m01s02i309[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg kg-1
 positive = None
@@ -46,7 +46,7 @@ positive = None
 [clivi]
 dimension = site time1
 expression = m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -54,7 +54,7 @@ positive = None
 [clt]
 dimension = site time1
 expression = m01s02i204[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -62,7 +62,7 @@ positive = None
 [clw]
 dimension = alevel site time1
 expression = m01s02i308[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg kg-1
 positive = None
@@ -70,7 +70,7 @@ positive = None
 [clwvi]
 dimension = site time1
 expression = m01s02i391[lbproc=0] + m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -78,7 +78,7 @@ positive = None
 [evspsbl]
 dimension = site time1
 expression = m01s03i223[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -88,7 +88,7 @@ comment = Includes both evaporation and sublimation.
 dimension = site time1
 expression = m01s03i234[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -96,14 +96,14 @@ units = W m-2
 dimension = site time1
 expression = m01s03i217[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
 [hur]
 dimension = alevel site time1
 expression = m01s30i113[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = %
 positive = None
@@ -111,7 +111,7 @@ positive = None
 [hurs]
 dimension = site height2m time1
 expression = m01s03i245[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = %
 positive = None
@@ -120,7 +120,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s00i010[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -128,7 +128,7 @@ positive = None
 [huss]
 dimension = site height2m time1
 expression = m01s03i237[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -140,14 +140,14 @@ component = cftables
 dimension = alevhalf site time1
 expression = (m01s05i250[lbproc=0] - m01s05i251[lbproc=0]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 positive = up
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>, William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [pfull]
 dimension = alevel site time1
 expression = m01s00i408[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -155,7 +155,7 @@ positive = None
 [phalf]
 dimension = alevhalf site time1
 expression = m01s00i407[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -163,7 +163,7 @@ positive = None
 [pr]
 dimension = site time1
 expression = m01s05i216[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -171,7 +171,7 @@ positive = None
 [prc]
 dimension = site time1
 expression = m01s05i205[lbproc=0] + m01s05i206[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -179,7 +179,7 @@ positive = None
 [prsn]
 dimension = site time1
 expression = m01s05i215[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -187,7 +187,7 @@ positive = None
 [prw]
 dimension = site time1
 expression = m01s30i461[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -195,7 +195,7 @@ positive = None
 [ps]
 dimension = site time1
 expression = m01s00i409[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -203,7 +203,7 @@ positive = None
 [psl]
 dimension = site time1
 expression = m01s16i222[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -218,7 +218,7 @@ comment = Physically, the radiation scheme used in this model ignores any
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i218[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -232,7 +232,7 @@ comment = Physically, the radiation scheme used in this model ignores any
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i220[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -240,7 +240,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i207[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -248,7 +248,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i208[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -256,7 +256,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i207[lbproc=0] - m01s02i201[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -265,7 +265,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i217[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -274,7 +274,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i219[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -283,7 +283,7 @@ component = cftables
 dimension = site time1
 expression = m01s02i205[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -291,7 +291,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i206[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -299,7 +299,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i218[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -307,7 +307,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i220[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -315,7 +315,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i235[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -323,7 +323,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i210[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -331,7 +331,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i207[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -339,7 +339,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i217[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -347,7 +347,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i219[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -356,7 +356,7 @@ component = cftables
 dimension = site time1
 expression = m01s01i235[lbproc=0] - m01s01i201[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -364,7 +364,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i211[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -372,7 +372,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i208[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -380,7 +380,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i209[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -395,14 +395,14 @@ component = boundary-layer
 dimension = site time1
 expression = m01s03i298[lbproc=0]
 positive = None
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [sci]
 dimension = site time1
 expression = m01s05i270[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -412,7 +412,7 @@ comment = This is the mean of the speed, not the speed computed from the mean u
 	and v components of wind.
 dimension = site height10m time1
 expression = m01s03i230[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -421,7 +421,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s30i111[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 positive = None
@@ -429,7 +429,7 @@ positive = None
 [tas]
 dimension = site height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 positive = None
@@ -438,7 +438,7 @@ positive = None
 dimension = site time1
 expression = m01s03i460[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
@@ -446,14 +446,14 @@ units = Pa
 dimension = site time1
 expression = m01s03i461[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
 [tnhus]
 dimension = alevel site time1
 expression = m01s30i182[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -462,7 +462,7 @@ positive = None
 dimension = alevel site time1
 expression = (m01s12i182[lbproc=0] + m01s12i382[lbproc=0])
 	/ ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -470,7 +470,7 @@ positive = None
 [tnhusc]
 dimension = alevel site time1
 expression = m01s05i162[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -481,7 +481,7 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
 	+ m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
 	+ m01s04i982[lbproc=0] + m01s05i182[lbproc=0] + m01s16i162[lbproc=0]
 	+ m01s16i182[lbproc=0] + m01s35i025[lbproc=0] ) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -492,7 +492,7 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
 	+ m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
 	+ m01s05i182[lbproc=0] - m01s05i162[lbproc=0] + m01s16i162[lbproc=0]
 	+ m01s16i182[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -500,7 +500,7 @@ positive = None
 [tnt]
 dimension = alevel site time1
 expression = m01s30i181[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -516,7 +516,7 @@ positive = None
 [tntc]
 dimension = alevel site time1
 expression = m01s05i161[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -535,7 +535,7 @@ positive = None
 [tntr]
 dimension = alevel site time1
 expression = (m01s01i161[lbproc=0] + m01s02i161[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -547,7 +547,7 @@ expression = (m01s03i181[lbproc=0] + m01s04i141[lbproc=0]
 	+ m01s01i181[lbproc=0] - m01s01i161[lbproc=0] + m01s02i181[lbproc=0]
 	- m01s02i161[lbproc=0] + m01s05i181[lbproc=0] - m01s05i161[lbproc=0])
 	/ ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -555,7 +555,7 @@ positive = None
 [ts]
 dimension = site time1
 expression = m01s00i024[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 positive = None
@@ -564,7 +564,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s00i002[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -572,7 +572,7 @@ positive = None
 [uas]
 dimension = site height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -581,7 +581,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s00i003[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -589,7 +589,7 @@ positive = None
 [vas]
 dimension = site height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -598,7 +598,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s30i008[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa s-1
 positive = None
@@ -607,7 +607,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s16i201[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_E3hrPt_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_E3hrPt_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 dimension = longitude latitude alt40 dbze time1
 expression = m01s02i372[lbproc=0]
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -23,7 +23,7 @@ units = 1
 dimension = longitude latitude alt40 scatratio time1
 expression = m01s02i370[lbproc=0]
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -39,7 +39,7 @@ component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i371[lbproc=0] / m01s02i325[lbproc=0]
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -48,7 +48,7 @@ component = cloud
 dimension = longitude latitude p220 time1
 expression = m01s02i346[blev=P220, lbproc=0] / m01s02i323[blev=P220, lbproc=0]
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -56,7 +56,7 @@ units = 1
 dimension = longitude latitude plev7c tau time1
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=0], m01s02i330[lbproc=0])
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -66,7 +66,7 @@ component = cloud
 dimension = longitude latitude p840 time1
 expression = m01s02i344[blev=P840, lbproc=0] / m01s02i321[blev=P840, lbproc=0]
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -75,7 +75,7 @@ component = cloud
 dimension = longitude latitude p560 time1
 expression = m01s02i345[blev=P560, lbproc=0] / m01s02i322[blev=P560, lbproc=0]
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -83,7 +83,7 @@ units = 1
 dimension = longitude latitude alt16 tau time1
 expression = fix_clmisr_height(m01s02i360[lbproc=0], m01s02i330[lbproc=0])
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -92,7 +92,7 @@ component = cloud
 dimension = longitude latitude time1
 expression = m01s02i347[lbproc=0] / m01s02i324[lbproc=0]
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -100,7 +100,7 @@ units = 1
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
 positive = None
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 
@@ -115,7 +115,7 @@ units = 1
 dimension = longitude latitude plev7c effectRadIc tau time1
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=0], m01s02i330[lbproc=0])
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -123,7 +123,7 @@ units = 1
 dimension = longitude latitude plev7c effectRadLi tau time1
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=0], m01s02i330[lbproc=0])
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -145,7 +145,7 @@ units = mol mol-1
 dimension = longitude latitude sza5 time1
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=0])
 positive = None
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -153,7 +153,7 @@ units = 1
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
 positive = None
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -200,7 +200,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -209,7 +209,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_EdayZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_EdayZ_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 dimension = latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 positive = None
@@ -24,7 +24,7 @@ positive = None
 dimension = latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -33,7 +33,7 @@ positive = None
 dimension = latitude plev39 time
 expression = m01s30i201[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -41,7 +41,7 @@ positive = None
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 positive = None
@@ -49,7 +49,7 @@ positive = None
 [utendogw]
 dimension = latitude plev39 time
 expression = m01s06i247[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 positive = None
@@ -58,7 +58,7 @@ positive = None
 dimension = latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=192]
 	/ m01s30i301[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -67,7 +67,7 @@ positive = None
 dimension = latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_Eday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_Eday_mappings.cfg
@@ -23,7 +23,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i330[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -32,7 +32,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i290[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_EmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_EmonZ_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-2
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_Emon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_Emon_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 dimension = longitude latitude plev7h time
 expression = m01s30i295[blev=PLEV7H, lbproc=128]
 	/ m01s30i304[blev=PLEV7H, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 positive = None
@@ -25,7 +25,7 @@ comment = Monthly mean orography (needed if land ice has time varying
 	altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None
@@ -33,7 +33,7 @@ positive = None
 [wap]
 dimension = longitude latitude alevel time
 expression = m01s30i008[lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_GA7mon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_GA7mon_mappings.cfg
@@ -13,14 +13,14 @@ status = Internal
 [pr]
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = kg m-2 s-1
 positive = None
 
 [ts]
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = K
 positive = None
 
@@ -28,7 +28,7 @@ positive = None
 dimension = longitude latitude plev17 time
 expression = m01s30i201[blev=PLEV17, lbproc=128]
 	/ m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = m s-1
 positive = None
 
@@ -36,7 +36,7 @@ positive = None
 dimension = longitude latitude plev17 time
 expression = m01s30i202[blev=PLEV17, lbproc=128]
 	/ m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = m s-1
 positive = None
 

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_LPmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_LPmon_mappings.cfg
@@ -16,7 +16,7 @@ comment = Monthly mean orography (needed if land ice has time varying
 	altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_Omon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_Omon_mappings.cfg
@@ -18,7 +18,7 @@ comment = Computed as the total mass of liquid water falling as liquid rain
 	portion of the grid cell.
 dimension = longitude latitude time
 expression = pr
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -26,7 +26,7 @@ positive = None
 [prsn]
 dimension = longitude latitude time
 expression = prsn
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_SIday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_SIday_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [siconc]
 dimension = longitude latitude typesi time
 expression = aice
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = 1
 positive = None

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_day_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_day_mappings.cfg
@@ -45,7 +45,7 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 
@@ -53,7 +53,7 @@ units = %
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -150,7 +150,7 @@ units = W m-2
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -258,7 +258,7 @@ units = K
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -336,7 +336,7 @@ units = m s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -432,7 +432,7 @@ units = m s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -531,7 +531,7 @@ units = m
 dimension = longitude latitude plev8 time
 expression = m01s30i297[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_mappings.cfg
@@ -2220,7 +2220,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Eday Emon LPday LPmon mon day
 reviewer = Ron Kahana (Met Office),
-	Eleanor Burke <eleanor.burke@metoffice.gov.uk
+	Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -5283,7 +5283,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon mon day
 reviewer = Ron Kahana (Met Office),
-	Eleanor Burke <eleanor.burke@metoffice.gov.uk
+	Eleanor Burke (Met Office)
 status = ok
 units = K
 

--- a/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem3/data/HadREM3_mappings.cfg
@@ -51,7 +51,7 @@ expression = m01s02i240[lbplev=3, lbproc=128]
 	+ m01s02i243[lbplev=3, lbproc=128] + m01s02i585[lbplev=3, lbproc=128]
 mip_table_id = AERmon AEmon
 notes = Assuming CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -63,7 +63,7 @@ expression = combine_sw_lw(m01s01i508[lbproc=0] / m01s01i507[lbproc=0],
 	m01s02i508[lbproc=0] / m01s02i507[lbproc=0],
 	minval= '-1.0', maxval= '1.0')
 mip_table_id = E3hrPt AP3hrPtLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -74,7 +74,7 @@ dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i506[lbproc=0], m01s02i506[lbproc=0],
 	swmask= m01s01i200[lbproc=0], minval= '0', maxval= '10')
 mip_table_id = E3hrPt AP3hrPtLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -85,7 +85,7 @@ dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i507[lbproc=0] / m01s01i506[lbproc=0],
 	m01s02i507[lbproc=0] / m01s02i506[lbproc=0], minval='0.0', maxval='1.0')
 mip_table_id = E3hrPt AP3hrPtLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -95,7 +95,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = agessc
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = yr
 
@@ -104,7 +104,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = div_by_area(m01s50i063[lbproc=128])
 mip_table_id = AERmon AEmonLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = kg m-2
 
@@ -128,7 +128,7 @@ dimension = longitude latitude time
 expression = fix_packing_division(m01s02i331[lbproc=128],
 	m01s02i334[lbproc=128])
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -137,7 +137,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = areacella(m01s00i505)
 mip_table_id = APfx mon day 6hr 3hr 1hr
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok
 units = m2
 
@@ -146,7 +146,7 @@ component = ocean
 dimension = longitude latitude
 expression = areacello
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -155,7 +155,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i054[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = s m-1
 
@@ -167,7 +167,7 @@ component = ocean
 dimension = longitude latitude
 expression = basin
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1
 
@@ -176,7 +176,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = 6hrPlev AERmon AE6hr AEmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -192,7 +192,7 @@ expression = MOLECULAR_MASS_OF_AIR
 	+ (m01s51i994[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRO))
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -203,7 +203,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C2H6)
 	* m01s34i014[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -214,7 +214,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C3H8)
 	* m01s34i018[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -226,7 +226,7 @@ dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128],
 	m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -236,7 +236,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s01i241[lbproc=128] / m01s01i223[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -245,7 +245,7 @@ component = cloud
 dimension = longitude latitude alt40 dbze time
 expression = m01s02i372[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -254,7 +254,7 @@ component = cloud
 dimension = longitude latitude alt40 scatratio time
 expression = m01s02i370[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -264,7 +264,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i055[lbproc=128],
 	MOLECULAR_MASS_OF_CFC11)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -274,7 +274,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i056[lbproc=128],
 	MOLECULAR_MASS_OF_CFC12)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -284,7 +284,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH3COCH3)
 	* m01s34i022[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -295,7 +295,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s51i009[blev=PLEV19, lbproc=128]
 	/ m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -305,7 +305,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i009[lbproc=128],
 	MOLECULAR_MASS_OF_CH4)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -321,7 +321,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
 	+ m01s38i289[lbproc=128]), areadiv='True')
 mip_table_id = AERmon AEmonLev
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -332,7 +332,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
 	m01s50i150[lbproc=128], areadiv='True')
 mip_table_id = AERmon AEmonLev
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -341,7 +341,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i269[lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Mark Webb <mark.webb@metoffice.gov.uk>
+reviewer = Mark Webb (Met Office)
 status = ok
 units = 1
 
@@ -350,7 +350,7 @@ component = cftables cloud
 dimension = longitude latitude alevel time
 expression = m01s02i261[lbproc=128]
 mip_table_id = Amon CFday APmonLev APdayLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -360,7 +360,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i317[lbproc=128]
 mip_table_id = CFmon APmonLev
 notes = Using convective cores in this model configuration.
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -369,7 +369,7 @@ component = cftables
 dimension = longitude latitude alt40 time
 expression = m01s02i371[lbproc=128] / m01s02i325[lbproc=128]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -378,7 +378,7 @@ component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i374[lbproc=0] / m01s02i325[lbproc=0]
 mip_table_id = E3hrPt AP3hrPt
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -409,7 +409,7 @@ dimension = longitude latitude time
 expression = m01s01i280[lbproc=128] / m01s01i281[lbproc=128]
 mip_table_id = Eday Emon APmon APday
 notes = Calculated at daylight grids only.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-2
 
@@ -419,7 +419,7 @@ dimension = longitude latitude p220 time
 expression = m01s02i346[lbproc=128, blev=P220]
 	/ m01s02i323[lbproc=128, blev=P220]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -429,7 +429,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i309[lbproc=128]
 mip_table_id = Amon CFday APmonLev APdayLev
 notes = ${COMMON:convective_notes}
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -438,7 +438,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i319[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -447,7 +447,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i453[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -465,7 +465,7 @@ dimension = longitude latitude plev7c tau time
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=128],
 	m01s02i330[lbproc=128])
 mip_table_id = CFmon CFday APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -474,7 +474,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i392[lbproc=128]
 mip_table_id = Amon CFday APmon APday day mon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -483,7 +483,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i396[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -493,7 +493,7 @@ dimension = longitude latitude p840 time
 expression = m01s02i344[lbproc=128, blev=P840]
 	/ m01s02i321[lbproc=128, blev=P840]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -503,7 +503,7 @@ dimension = longitude latitude p560 time
 expression = m01s02i345[lbproc=128, blev=P560]
 	/ m01s02i322[lbproc=128, blev=P560]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -512,7 +512,7 @@ component = cloud
 dimension = longitude latitude alt16 tau time
 expression = fix_clmisr_height(m01s02i360[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -522,7 +522,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i312[lbproc=128] + m01s02i313[lbproc=128]
 	- m01s02i317[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -531,7 +531,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i204[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon sem mon 1hr
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -540,7 +540,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i347[lbproc=128] / m01s02i324[lbproc=128]
 mip_table_id = CFday CFmon APmon APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -549,7 +549,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i334[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -558,7 +558,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i451[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -568,7 +568,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i308[lbproc=128]
 mip_table_id = Amon CFday APdayLev APmonLev
 notes = ${COMMON:convective_notes}
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -577,7 +577,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i318[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -586,7 +586,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i452[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -603,7 +603,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128] + m01s02i392[lbproc=128]
 mip_table_id = Amon CFday APday APmon mon day
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -612,7 +612,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i395[lbproc=128] + m01s02i396[lbproc=128]
 mip_table_id = Eday Emon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -630,7 +630,7 @@ expression = MOLECULAR_MASS_OF_AIR
 	+ (m01s51i992[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HCL))
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -640,7 +640,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO)
 	* m01s34i010[lbproc=128]
 mip_table_id = AERmon CresAERday AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -650,7 +650,7 @@ component = carbon
 dimension = time
 expression = m01s30i465[lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg
 
@@ -659,7 +659,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i332[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = AERday AERmon AEday AEmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -668,7 +668,7 @@ component = dust
 dimension = longitude latitude alevel time
 expression = m01s17i257[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -677,7 +677,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i209[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -687,7 +687,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s03i440[lbproc=128]
 mip_table_id = Emon AEmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -696,7 +696,7 @@ component = ocean
 dimension = longitude latitude
 expression = deptho
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -729,7 +729,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i071[lbproc=128]
 	* (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_DMS)
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -744,7 +744,7 @@ expression = m01s03i441[lbproc=128] + m01s03i442[lbproc=128]
 	+ m01s03i456[lbproc=128]
 mip_table_id = AERmon CresAERday AEmon
 notes = Assumes CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -754,7 +754,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_O3,
 	m01s50i131[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -763,7 +763,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -773,7 +773,7 @@ dimension = longitude latitude alevel lambda550nm time
 expression = m01s02i530[lbplev=3, lbproc=128]
 	+ m01s02i540[lbplev=3, lbproc=128]
 mip_table_id = Emon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-1
 
@@ -783,7 +783,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C,
 	m01s38i207[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -796,8 +796,8 @@ dimension = longitude latitude time
 expression = (m01s03i495[lbproc=128] + m01s03i496[lbproc=128]) *
 	m01s00i505
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-	Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (NIWA),
+	Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -806,7 +806,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i158[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -815,7 +815,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i214[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -828,7 +828,7 @@ expression = m01s03i401[lbproc=128] + m01s03i402[lbproc=128]
 	+ m01s03i406[lbproc=128]
 mip_table_id = AERmon AEmon
 notes = Assumes CLASSIC dust.
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -839,8 +839,8 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_ISOPRENE / (5.0 * ATOMIC_MASS_OF_C))
 	* (m01s03i495[lbproc=128] * m01s00i505)
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-	Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (NIWA),
+	Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -849,7 +849,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i081[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol s-1
 
@@ -861,7 +861,7 @@ expression = achem_emdrywet(1.0,
 	m01s50i172[lbproc=128], cube2d=m01s50i156[lbproc=128],
 	sumlev='True')
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -872,7 +872,7 @@ expression = achem_emdrywet(1.0,
 	m01s50i217[lbproc=128], cube2d=(m01s50i215[lbproc=128]
 	+ m01s50i216[lbproc=128]), sumlev='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = kg m-2 s-1
 
@@ -884,7 +884,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
 	sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -895,7 +895,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL,
 	m01s38i204[lbproc=128] + m01s38i205[lbproc=128],
 	sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -912,7 +912,7 @@ expression = ((m01s50i159[lbproc=128] / MOLECULAR_MASS_OF_HCHO)
 	+ (m01s50i301[lbproc=128] * (10.0 / MOLECULAR_MASS_OF_MONOTERPENE)))
 	* ATOMIC_MASS_OF_C
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -929,7 +929,7 @@ dimension = latitude plev39 time
 expression = scale_epflux(m01s30i312[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APdayZ APmonZ
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -940,7 +940,7 @@ expression = scale_epflux(m01s30i313[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APdayZ APmonZ
 positive = up
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -949,7 +949,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i296[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -966,7 +966,7 @@ dimension = longitude latitude time
 expression = correct_evaporation(evs, sowaflup - (evs - (ficeberg
 	+ friver + prsn + pr + fsitherm) ), areacello)
 mip_table_id = Omon OPmon
-reviewer = Dave Storkey <dave.storkey@metoffice.gov.uk>
+reviewer = Dave Storkey (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -975,8 +975,8 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i223[lbproc=128]
 mip_table_id = Amon Eday APmon LPday sem mon day 6hr 1hr
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>,
-	Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office),
+	Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -985,7 +985,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i334[lbproc=128]
 mip_table_id = Emon LPmon mon day 1hr
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -995,7 +995,7 @@ dimension = longitude latitude time
 expression = m01s03i296[lbproc=128] + m01s03i298[lbproc=128]
 	- m01s03i539[lbproc=128]
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1004,7 +1004,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1017,7 +1017,7 @@ expression = calc_fgdms(m01s00i505, m01s50i214[lbproc=128]
 	/ MOLECULAR_MASS_OF_DMS )
 mip_table_id = Omon OBmon
 positive = up
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = kmol m-2 s-1
 
@@ -1027,7 +1027,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(ficeberg, -1*vowflisf)
 mip_table_id = Omon OPmonLev
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1043,8 +1043,8 @@ component = chemistry
 dimension = longitude latitude time
 expression = div_by_area(m01s50i082[lbproc=128])
 mip_table_id = Emon ACmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>,
-	Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (University of Cambridge),
+	Mohit Dalvi (Met Office)
 status = ok
 units = m-2 min-1
 
@@ -1053,7 +1053,7 @@ component = ocean
 dimension = longitude latitude time
 expression = friver
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1062,7 +1062,7 @@ component = seaice
 dimension = longitude latitude time
 expression = fsitherm
 mip_table_id = Omon OPmon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1071,7 +1071,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s03i261[lbproc=128]
 mip_table_id = E3hr LP3hr
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1089,7 +1089,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCHO)
 	* m01s34i011[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1099,7 +1099,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL)
 	* m01s34i992[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1111,7 +1111,7 @@ expression = combine_cubes_to_basin_coord(hfbasin_global, hfbasin_atlantic,
 	hfbasin_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1124,7 +1124,7 @@ expression = combine_cubes_to_basin_coord(hfbasinpadv_global,
 	mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V,
 	mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1137,7 +1137,7 @@ expression = combine_cubes_to_basin_coord(hfbasinpmadv_global,
 	mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V,
 	mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1150,7 +1150,7 @@ expression = combine_cubes_to_basin_coord(hfbasinpmdiff_global,
 	mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V,
 	mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1160,7 +1160,7 @@ dimension = longitude latitude time
 expression = hfds
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1178,7 +1178,7 @@ dimension = longitude latitude time
 expression = hfevapds
 mip_table_id = Omon OPmon
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1188,7 +1188,7 @@ dimension = longitude latitude
 expression = hfgeou
 mip_table_id = Ofx OPfx
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1198,7 +1198,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(-1*berg_latent_heat_flux, vohflisf)
 mip_table_id = Omon OPmonLev
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -1208,7 +1208,7 @@ dimension = longitude latitude time
 expression = m01s03i234[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon sem mon 1hr
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -1218,7 +1218,7 @@ dimension = longitude latitude time
 expression = hfrainds
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1229,7 +1229,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(hflx_rnf, -1*vohfcisf)
 mip_table_id = Omon OPmonLev
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -1247,7 +1247,7 @@ dimension = longitude latitude time
 expression = m01s03i217[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon sem mon 1hr
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -1256,7 +1256,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfx, mask_2D_U)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -1265,7 +1265,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfy, mask_2D_V)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -1275,7 +1275,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3)
 	* m01s34i007[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1286,7 +1286,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HO2)
 	* m01s51i082[blev=PLEV39, lbproc=192]
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 
@@ -1298,7 +1298,7 @@ expression = combine_cubes_to_basin_coord(hfovgyre_global, hfovgyre_atlantic,
 	hfovgyre_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1310,7 +1310,7 @@ expression = combine_cubes_to_basin_coord(hfovovrt_global, hfovovrt_atlantic,
 	hfovovrt_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1319,7 +1319,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i113[lbproc=128]
 mip_table_id = CFday CFmon APdayLev APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = %
 
@@ -1447,7 +1447,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i245[lbproc=128]
 mip_table_id = 6hrPlev Amon day AP6hr APday APmon sem mon
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = %
 
@@ -1482,7 +1482,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1520,7 +1520,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1551,7 +1551,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i295[blev=PLEV27, lbproc=128]
 	/ m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1625,7 +1625,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i295[blev=PLEV7H, lbproc=0]
 	/ m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt AP6hrPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1635,7 +1635,7 @@ dimension = longitude latitude p850 time
 expression = m01s30i295[blev=P850, lbproc=128]
 	/ m01s30i304[blev=P850, lbproc=128]
 mip_table_id = Eday GCAmon GCday APday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1651,7 +1651,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i237[lbproc=128]
 mip_table_id = Amon day APday APmon day
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = 1
 
@@ -1668,7 +1668,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i462[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -1685,7 +1685,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i463[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -1695,7 +1695,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_ISOPRENE)
 	* m01s34i027[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1704,7 +1704,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i229[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1714,7 +1714,7 @@ dimension = latitude plev39 time
 expression = m01s52i245[blev=PLEV39, lbproc=192]
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ APmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1724,7 +1724,7 @@ dimension = latitude plev39 time
 expression = m01s52i246[blev=PLEV39, lbproc=192]
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ APmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1733,7 +1733,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadIc tau time
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -1742,7 +1742,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadLi tau time
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday APmon APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -1751,7 +1751,7 @@ component = dust
 dimension = longitude latitude time
 expression = calc_loaddust(m01s17i257[lbproc=128], m01s50i255[lbproc=128])
 mip_table_id = Emon Eday APday APmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1762,7 +1762,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i247[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -1772,7 +1772,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i071[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -1781,7 +1781,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -1791,7 +1791,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = masscello
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2
 
@@ -1800,7 +1800,7 @@ component = ocean
 dimension = time
 expression = scvoltot * SEAWATER_DENSITY
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg
 
@@ -1809,7 +1809,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=8192]
 mip_table_id = AERday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -1818,7 +1818,7 @@ dimension = longitude latitude alevhalf time
 expression = (m01s05i250[lbproc=128] - m01s05i251[lbproc=128]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = Amon CFday APdayLev APmonLev
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1827,7 +1827,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i251[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1836,7 +1836,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i250[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1849,7 +1849,7 @@ expression = (m01s51i150[blev=PLEV39, lbproc=192]
 	/ m01s51i999[blev=PLEV39, lbproc=192])
 	/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = AERmonZ AEmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = yr
 
@@ -1858,7 +1858,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=4096]
 mip_table_id = AERday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -1867,7 +1867,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotst
 mip_table_id = Eday Omon OPday OPmon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -1876,7 +1876,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmax
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -1885,7 +1885,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmin
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -1894,7 +1894,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstsq
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -2061,7 +2061,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i105[lbproc=128] + m01s34i109[lbproc=128]
 	+ m01s34i115[lbproc=128] + m01s34i120[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2072,7 +2072,7 @@ expression = m01s00i431[lbproc=128] + m01s00i432[lbproc=128]
 	+ m01s00i433[lbproc=128] + m01s00i434[lbproc=128] + m01s00i435[lbproc=128]
 	+ m01s00i436[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2083,7 +2083,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i106[lbproc=128] + m01s34i110[lbproc=128]
 	+ m01s34i116[lbproc=128] + m01s34i121[lbproc=128] + m01s34i126[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2096,7 +2096,7 @@ expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4)
 	+ m01s34i108[lbproc=128]
 	+ m01s34i114[lbproc=128])
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2105,7 +2105,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i111[lbproc=128] + m01s34i117[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2116,7 +2116,7 @@ expression = level_sum(m01s08i223[lbproc=128]
 	* m01s08i230[lbproc=128]
 	/ (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Lmon LPmon sem mon day
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -2143,7 +2143,7 @@ expression = level_sum(m01s08i223[lbproc=128]
 	* m01s08i229[lbproc=128]
 	/ (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2152,7 +2152,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128] + m01s08i235[lbproc=128]
 mip_table_id = 3hr Lmon day LP3hr LPday LPmon sem mon 6hr
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2161,7 +2161,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i235[lbproc=128]
 mip_table_id = Eday GCLmon LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2170,7 +2170,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon sem mon day 6hr
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2180,7 +2180,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i230[lbproc=128]
 	/ (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Eday Emon LPday LPmon mon day 6hr
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2190,7 +2190,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i229[lbproc=128]
 	/ (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Eday Emon LPday LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2199,7 +2199,7 @@ component = land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128])
 mip_table_id = Lmon day LPmon LPday sem mon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2210,7 +2210,7 @@ component = land
 dimension = longitude latitude
 expression = mask_zeros(m01s00i041 * FRESHWATER_DENSITY)
 mip_table_id = fx LPfx
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = kg m-2
 
@@ -2219,7 +2219,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Eday Emon LPday LPmon mon day
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>,
+reviewer = Ron Kahana (Met Office),
 	Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = kg m-2
@@ -2229,7 +2229,7 @@ component = land
 dimension = longitude latitude sdepth1 time
 expression = m01s08i223[blev=0.05, lbproc=128]
 mip_table_id = day Lmon LPmon LPday mon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2241,7 +2241,7 @@ dimension = longitude latitude time
 expression = ocean_quasi_barotropic_streamfunc(umo_vint, areacello,
 	cube_mask=mask_2D_T)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -2253,7 +2253,7 @@ expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfglo,
 	zomsfatl, zomsfipc, mask_global=global_ocean_2D_V,
 	mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -2265,7 +2265,7 @@ expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfeivglo,
 	zomsfeivatl, zomsfeivipc, mask_global=global_ocean_2D_V,
 	mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -2276,7 +2276,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s51i049[blev=PLEV19, lbproc=128]
 	/ m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2286,7 +2286,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i049[lbproc=128],
 	MOLECULAR_MASS_OF_N2O)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -2296,7 +2296,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO)
 	* m01s34i002[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2306,7 +2306,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2)
 	* m01s34i996[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2327,7 +2327,7 @@ expression = MOLECULAR_MASS_OF_AIR
 	+ (m01s51i996[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO2))
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2338,7 +2338,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s51i001[blev=PLEV19, lbproc=128]
 	/ m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2349,7 +2349,7 @@ expression = (m01s50i011[lbproc=128] + m01s50i013[lbproc=128]
 	+ m01s50i014[lbproc=128] + m01s50i015[lbproc=128])
 	/ m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -2360,7 +2360,7 @@ expression = (m01s50i001[lbproc=128] + m01s50i003[lbproc=128]
 	+ m01s50i103[lbproc=128])
 	/ m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -2370,7 +2370,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(obvfsq, mask_3D_T)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = s-2
 
@@ -2382,7 +2382,7 @@ expression = m01s02i285[lbplev=2, lbproc=128]
 	+ m01s02i300[lbplev=2, lbproc=128] + m01s02i301[lbplev=2, lbproc=128]
 	+ m01s02i302[lbplev=2, lbproc=128] + m01s02i303[lbplev=2, lbproc=128]
 mip_table_id = AERmon CresAERday Cres1HrMn AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2392,7 +2392,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=2, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2403,7 +2403,7 @@ expression = m01s02i285[lbplev=3, lbproc=128]
 	+ m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128]
 	+ m01s02i302[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERday AERmon CresAERday Cres1HrMn AEday AEmon mon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2415,7 +2415,7 @@ expression = m01s02i251[lbplev=3, lbproc=128]
 	+ m01s02i252[lbplev=3, lbproc=128] + m01s02i253[lbplev=3, lbproc=128]
 	+ m01s02i254[lbplev=3, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2424,7 +2424,7 @@ component = dust
 dimension = longitude latitude lambda550nm time
 expression = m01s02i285[lbplev=3, lbproc=128]
 mip_table_id = AERmon CresAERday AEmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2435,7 +2435,7 @@ dimension = longitude latitude lambda550nm time
 expression = m01s02i300[lbplev=3, lbproc=128]
 	+ m01s02i301[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2445,7 +2445,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=5, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2457,7 +2457,7 @@ expression = m01s02i285[lbplev=5, lbproc=128]
 	+ m01s02i300[lbplev=5, lbproc=128] + m01s02i301[lbplev=5, lbproc=128]
 	+ m01s02i302[lbplev=5, lbproc=128] + m01s02i303[lbplev=5, lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2467,7 +2467,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH)
 	* m01s34i081[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2477,7 +2477,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2489,7 +2489,7 @@ component = ocean
 dimension = longitude latitude time
 expression = opottempmint
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC kg m-2
 
@@ -2499,7 +2499,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemppmdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2509,7 +2509,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempadvect
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2519,7 +2519,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemptend
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2528,7 +2528,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = m01s00i033
 mip_table_id = fx LPfx mon day 6hr 3hr 1hr
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -2538,7 +2538,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2548,7 +2548,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltpmdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2558,7 +2558,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltadvect
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2568,7 +2568,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osalttend
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2578,7 +2578,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_PAN)
 	* m01s34i017[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2587,7 +2587,7 @@ component = cftables
 dimension = longitude latitude sza5 time
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=128])
 mip_table_id = Eday Emon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -2596,7 +2596,7 @@ component = ocean
 dimension = longitude latitude time
 expression = pbo
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = dbar
 
@@ -2605,7 +2605,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i333[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -2614,7 +2614,7 @@ component = atmos-physics cftables
 dimension = longitude latitude alevel time
 expression = m01s00i408[lbproc=128]
 mip_table_id = AERmon CFday AEmonLev APdayLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2625,7 +2625,7 @@ component = aerosol cftables
 dimension = longitude latitude alevhalf time
 expression = m01s00i407[lbproc=128]
 mip_table_id = AERmon CFday APdayLev AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = Pa
 
@@ -2634,7 +2634,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i228[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -2650,7 +2650,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128]
 mip_table_id = 3hr 6hrPlev Amon E1hr day CresAERday AP1hr AP3hr AP6hr APday APmon mon 1hr sem mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2660,7 +2660,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128] + m01s05i206[lbproc=128]
 mip_table_id = 3hr Amon E1hr day AP1hr AP3hr APday APmon mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2670,7 +2670,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i227[lbproc=0]
 mip_table_id = CF3hr AP3hrPtLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2687,7 +2687,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i223[lbproc=0]
 mip_table_id = CF3hr AP3hrPtLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2696,7 +2696,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i222[lbproc=0]
 mip_table_id = CF3hr AP3hrPtLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2705,7 +2705,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i214[lbproc=128]
 mip_table_id = E3hr AP3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2714,7 +2714,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128]
 mip_table_id = E3hr Eday AP3hr APday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2723,7 +2723,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i215[lbproc=128]
 mip_table_id = 3hr Amon AP3hr APday APmon mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2733,7 +2733,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i206[lbproc=128]
 mip_table_id = E3hr GCAmon AP3hr E3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2742,7 +2742,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i461[lbproc=128]
 mip_table_id = Amon Eday APday APmon day mon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2
 
@@ -2751,7 +2751,7 @@ component = atmos-physics cftables
 dimension = longitude latitude time
 expression = m01s00i409[lbproc=128]
 mip_table_id = AERhr AERmon Amon CFday CFmon Emon CresAERday Cres1HrMn AP1hr APday APmon sem mon day
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2760,7 +2760,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s16i222[lbproc=128]
 mip_table_id = 6hrPlev Amon day APmon AP6hr APday sem mon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2769,7 +2769,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i451[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2781,7 +2781,7 @@ dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128],
 	m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2790,7 +2790,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2799,7 +2799,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2808,7 +2808,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2817,7 +2817,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2826,7 +2826,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s01i245[lbproc=128] / m01s01i246[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2839,7 +2839,7 @@ expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128],
 	m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128]
 	+ m01s02i396[lbproc=128]))
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2850,7 +2850,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i218[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2860,7 +2860,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i522[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2871,7 +2871,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i220[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2881,7 +2881,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i524[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2892,7 +2892,7 @@ dimension = longitude latitude time
 expression = m01s02i207[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon sem mon 1hr
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2903,7 +2903,7 @@ dimension = longitude latitude time
 expression = m01s02i208[lbproc=128]
 mip_table_id = 3hr Amon CFday AP3hr APday APmon mon day 6hr
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2914,7 +2914,7 @@ expression = m01s02i201[lbproc=128] - (m01s03i332[lbproc=128]
 	- m01s02i205[lbproc=128])
 mip_table_id = Eday Emon APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2925,7 +2925,7 @@ expression = hotspot(m01s02i217[lbproc=128], m01s03i332[lbproc=128],
 	m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2936,7 +2936,7 @@ expression = hotspot(m01s02i521[lbproc=128], m01s03i332[lbproc=128],
 	m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2947,7 +2947,7 @@ expression = hotspot(m01s02i219[lbproc=128], m01s03i332[lbproc=128],
 	m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2958,7 +2958,7 @@ expression = hotspot(m01s02i523[lbproc=128], m01s03i332[lbproc=128],
 	m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2970,7 +2970,7 @@ expression = m01s02i207[lbproc=128] - m01s02i201[lbproc=128]
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = Amon AP3hr APday APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2980,7 +2980,7 @@ dimension = longitude latitude time
 expression = m01s03i332[lbproc=128]
 mip_table_id = Amon day APmon APday sem mon 6hr 1hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2991,7 +2991,7 @@ expression = remove_altitude_coords(m01s02i521[lblev=86, lbproc=128])
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3002,7 +3002,7 @@ expression = remove_altitude_coords(m01s02i517[lblev=86, lbproc=128])
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -3013,7 +3013,7 @@ expression = m01s02i206[lbproc=128] + m01s03i332[lbproc=128]
 	- m01s02i205[lbproc=128]
 mip_table_id = Amon CFday APday APmon mon day 6hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3024,7 +3024,7 @@ expression = remove_altitude_coords(m01s02i523[lblev=86, lbproc=128])
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3035,7 +3035,7 @@ expression = remove_altitude_coords(m01s02i519[lblev=86, lbproc=128])
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -3053,7 +3053,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i218[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3063,7 +3063,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i522[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3074,7 +3074,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i220[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3084,7 +3084,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i524[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3119,7 +3119,7 @@ dimension = longitude latitude olevel time
 expression = rsdo
 mip_table_id = Omon OPmonLev
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -3129,7 +3129,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = rsdoabsorb
 mip_table_id = Emon OPmonLev
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = W m-2
 
@@ -3140,7 +3140,7 @@ dimension = longitude latitude time
 expression = m01s01i235[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon sem mon 1hr
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3151,7 +3151,7 @@ dimension = longitude latitude time
 expression = m01s01i210[lbproc=128]
 mip_table_id = 3hr Amon CFday APmon AP3hr APday mon day 6hr
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3185,7 +3185,7 @@ dimension = longitude latitude time
 expression = m01s01i216[lbproc=128]
 mip_table_id = 3hr Eday Emon AP3hr APday APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3203,7 +3203,7 @@ dimension = longitude latitude time
 expression = m01s01i207[lbproc=128]
 mip_table_id = Amon CFday APmon APday sem mon day 6hr 1hr
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3213,7 +3213,7 @@ dimension = longitude latitude time
 expression = m01s01i201[lbproc=128]
 mip_table_id = Emon APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3224,7 +3224,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i217[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3234,7 +3234,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i521[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3245,7 +3245,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i219[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3255,7 +3255,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i523[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3290,7 +3290,7 @@ dimension = longitude latitude time
 expression = m01s01i235[lbproc=128] - m01s01i201[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon sem mon 1hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3300,7 +3300,7 @@ dimension = longitude latitude time
 expression = m01s01i211[lbproc=128]
 mip_table_id = 3hr Amon CFday AP3hr APday APmon mon day 6hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3335,7 +3335,7 @@ dimension = longitude latitude time
 expression = m01s01i208[lbproc=128]
 mip_table_id = Amon CFday APday APmon sem mon day 3hr 1hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3345,7 +3345,7 @@ dimension = longitude latitude time
 expression = m01s01i521[lblev=86, lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3355,7 +3355,7 @@ dimension = longitude latitude time
 expression = m01s01i517[lblev=86, lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3365,7 +3365,7 @@ dimension = longitude latitude time
 expression = m01s01i209[lbproc=128]
 mip_table_id = Amon CFday E3hr AP3hr APday APmon mon day 6hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3375,7 +3375,7 @@ dimension = longitude latitude time
 expression = m01s01i523[lblev=86, lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3385,7 +3385,7 @@ dimension = longitude latitude time
 expression = m01s01i519[lblev=86, lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3412,7 +3412,7 @@ expression = m01s01i207[lbproc=128] - m01s01i208[lbproc=128]
 	- m01s03i332[lbproc=128]
 mip_table_id = Amon APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3429,7 +3429,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i331[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 mip_table_id = LImon Eday LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3438,7 +3438,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i270[lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Rachel Stratton <rachel.stratton@metoffice.gov.uk>
+reviewer = Rachel Stratton (Met Office)
 status = ok
 units = 1
 
@@ -3451,7 +3451,7 @@ expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128],
 	m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128]
 	+ m01s02i396[lbproc=128]))
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -3460,7 +3460,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s17i257[lblev=1, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -3471,7 +3471,7 @@ expression = m01s03i230[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr Prim3hr AP3hr AP6hr APday APmon
 notes = An arbitrary choice between 'B-grid' or 'C-grid' but it would seem
 	sensible to use the same throughout.
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -3747,7 +3747,7 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2)
 	* m01s34i996[lblev=1, lbproc=128]
 mip_table_id = AERhr AE1hr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -3757,7 +3757,7 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s34i001[lblev=1, lbproc=128]
 mip_table_id = AERhr AE1hr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -3767,7 +3767,7 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s34i001[lblev=1, lbproc=8192]
 mip_table_id = AERday AEday
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3785,7 +3785,7 @@ component = land
 dimension = longitude latitude typeland
 expression = m01s00i505
 mip_table_id = APfx mon day 6hr 3hr 1hr
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = 1
 
@@ -3794,7 +3794,7 @@ component = ocean
 dimension = longitude latitude typesea
 expression = sftof
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = %
 
@@ -3803,7 +3803,7 @@ component = seaice
 dimension = longitude latitude time
 expression = iage * SECONDS_IN_DAY * DAYS_IN_YEAR
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s
 
@@ -3826,7 +3826,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sicompstren
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-1
 
@@ -3835,7 +3835,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3844,7 +3844,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = m01s00i031[lbproc=128]
 mip_table_id = SIday SImon mon day
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3853,7 +3853,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcdyn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -3862,7 +3862,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcth
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -3871,7 +3871,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtd * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3881,7 +3881,7 @@ dimension = longitude latitude time
 expression = -1 * evap_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3890,7 +3890,7 @@ component = seaice
 dimension = longitude latitude time
 expression = congel * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3899,7 +3899,7 @@ component = seaice
 dimension = longitude latitude time
 expression = frazil * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3908,7 +3908,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltl * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3917,7 +3917,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltb * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3926,7 +3926,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3935,7 +3935,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3944,7 +3944,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3953,7 +3953,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstranx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -3962,7 +3962,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstrany
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -3971,7 +3971,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i538[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3980,7 +3980,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sifb
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3990,7 +3990,7 @@ dimension = longitude latitude time
 expression = siflcondbot
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4000,7 +4000,7 @@ dimension = longitude latitude time
 expression = siflcondtop
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4010,7 +4010,7 @@ dimension = longitude latitude time
 expression = ((meltt + meltb + meltl - congel - frazil) * ICE_DENSITY + melts
 	* SNOW_DENSITY) / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [siflfwdrain]
@@ -4019,7 +4019,7 @@ dimension = longitude latitude time
 expression = (meltt * ICE_DENSITY + melts * SNOW_DENSITY)
 	/ (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sifllatstop]
@@ -4036,7 +4036,7 @@ dimension = longitude latitude time
 expression = m01s02i501[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4046,7 +4046,7 @@ dimension = longitude latitude time
 expression = m01s03i531[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4095,7 +4095,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecoriolx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4104,7 +4104,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecorioly
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4113,7 +4113,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstrx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4122,7 +4122,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstry
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4131,7 +4131,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetiltx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4140,7 +4140,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetilty
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4149,7 +4149,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sihc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -4158,7 +4158,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4167,7 +4167,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = snowfracn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4176,7 +4176,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vsnon / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4185,7 +4185,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vicen / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4194,7 +4194,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi * ICE_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -4206,7 +4206,7 @@ component = seaice
 dimension = longitude latitude typemp time
 expression = apond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4217,7 +4217,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hpond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4230,7 +4230,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ipond_ai / apond_ai
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4239,7 +4239,7 @@ component = seaice
 dimension = longitude latitude time
 expression = rain_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sirdgconc]
@@ -4247,7 +4247,7 @@ component = seaice
 dimension = longitude latitude typesirdg time
 expression = ardg
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4266,7 +4266,7 @@ mip_table_id = SImon
 notes = The interpretation of this variable in CICE is not obvious as CICE has
 	two simultaneous salinity profiles (when prognostic salinity is not being
 	used).
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -4275,7 +4275,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snowfrac / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4284,7 +4284,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnhc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -4293,7 +4293,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hs * SNOW_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -4302,7 +4302,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnthick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4311,7 +4311,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sispeed
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -4352,7 +4352,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sitempbot
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -4361,7 +4361,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i535[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SIday SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -4370,7 +4370,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sithick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4379,7 +4379,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ice_present
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4388,7 +4388,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siu
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -4397,7 +4397,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siv
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -4406,7 +4406,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4418,7 +4418,7 @@ expression = 1.026 * combine_cubes_to_basin_coord(sltbasin_global,
 	sltbasin_atlantic, sltbasin_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = EmonZ OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -4430,7 +4430,7 @@ expression = 1.026 * combine_cubes_to_basin_coord(sltovgyre_global,
 	sltovgyre_atlantic, sltovgyre_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -4442,7 +4442,7 @@ expression = 1.026 * combine_cubes_to_basin_coord(sltovovrt_global,
 	sltovovrt_atlantic, sltovovrt_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -4459,7 +4459,7 @@ expression = snc_calc(m01s08i236[lbproc=128],
 	m01s03i317[lbproc=128],
 	m01s03i395[lbproc=128])
 mip_table_id = LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = %
 
@@ -4471,7 +4471,7 @@ expression = land_class_mean(m01s08i376[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='all')
 mip_table_id = Eday LImon LIday sem mon day
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = m
 
@@ -4480,7 +4480,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvsdtd * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4489,7 +4489,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * melts * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4498,7 +4498,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4507,7 +4507,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snow_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4517,7 +4517,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i237[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 mip_table_id = Eday LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4528,7 +4528,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i236[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 mip_table_id = LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -4538,7 +4538,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = so
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4548,7 +4548,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i072[lbproc=128] * (MOLECULAR_MASS_OF_AIR
 	/ MOLECULAR_MASS_OF_SO2)
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -4557,7 +4557,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sob
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4566,7 +4566,7 @@ component = ocean
 dimension = time
 expression = soga
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4585,7 +4585,7 @@ component = ocean
 dimension = longitude latitude time
 expression = somint
 mip_table_id = Emon OPmon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = 1e-3 kg m-2
 
@@ -4594,7 +4594,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sos
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4603,7 +4603,7 @@ component = ocean
 dimension = time
 expression = area_mean(sos, areacello)
 mip_table_id = Oday Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4612,7 +4612,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sossq
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-6
 
@@ -4622,7 +4622,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(
 	m01s08i236[lbproc=128] / FRESHWATER_DENSITY, m01s03i317[lbproc=128])
 mip_table_id = Emon LPmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = m
 
@@ -4631,7 +4631,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i044[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1e5 K2
 
@@ -4642,7 +4642,7 @@ expression = t20d
 mip_table_id = Eday Emon OPday OPmon
 notes = PMIP variables: Variable will be output with a time dimension and with
 	cell_methods for time.
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -4652,7 +4652,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4711,7 +4711,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i294[blev=PLEV27, lbproc=128]
 	/ m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4749,7 +4749,7 @@ dimension = longitude latitude p500 time
 expression = m01s30i294[blev=P500, lbproc=128]
 	/ m01s30i304[blev=P500, lbproc=128]
 mip_table_id = Eday GCAmon GCday APday sem mon day
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4773,7 +4773,7 @@ dimension = longitude latitude p700 time
 expression = m01s30i294[blev=P700, lbproc=128]
 	/ m01s30i304[blev=P700, lbproc=128]
 mip_table_id = CFday GCAmon GCday APday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
@@ -4783,7 +4783,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i294[blev=PLEV7H, lbproc=0]
 	/ m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt E3hrPt AP6hrPt AP3hrPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
@@ -4793,7 +4793,7 @@ dimension = longitude latitude p850 time
 expression = m01s30i294[blev=P850, lbproc=128]
 	/ m01s30i304[blev=P850, lbproc=128]
 mip_table_id = Eday GCAmon GCday APday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4809,7 +4809,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=128]
 mip_table_id = 6hrPlev Amon day CresAERday Cres1HrMn AP6hr APday APmon sem
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = K
 
@@ -4818,7 +4818,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=8192])
 mip_table_id = Amon CresAERday APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4827,7 +4827,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=4096])
 mip_table_id = Amon APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4847,7 +4847,7 @@ dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Amon Eday APday APmon sem mon day 6hr 1hr
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -4857,7 +4857,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauuo, mask_2D_U)
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -4866,7 +4866,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -4879,7 +4879,7 @@ dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Amon Eday APday APmon sem mon day 6hr 1hr
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -4889,7 +4889,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauvo, mask_2D_V)
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -4898,7 +4898,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -4914,7 +4914,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i316[lbplev=8, lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = K
 
@@ -4924,7 +4924,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thetao
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4933,7 +4933,7 @@ component = ocean
 dimension = time
 expression = thetaoga
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4942,7 +4942,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao, thkcello)
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4951,7 +4951,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<2025], thkcello[depth<2025])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4960,7 +4960,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<300], thkcello[depth<300])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4969,7 +4969,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<735], thkcello[depth<735])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4979,7 +4979,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thkcello
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -4988,7 +4988,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i182[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -4998,7 +4998,7 @@ dimension = longitude latitude alevel time
 expression = (m01s12i182[lbproc=128] + m01s12i382[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
 notes = Obtained by advection plus solver
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5007,7 +5007,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i162[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5020,7 +5020,7 @@ expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128]
 	+ m01s16i182[lbproc=128] + m01s35i025[lbproc=128] ) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
 notes = Methane Oxidation added.
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5029,7 +5029,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i190[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5041,7 +5041,7 @@ expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128]
 	+ m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128]
 	+ m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5056,7 +5056,7 @@ expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128]
 	+ m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128]
 	+ m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5079,7 +5079,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i181[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5090,7 +5090,7 @@ expression = (m01s10i181[lbproc=128] + m01s12i181[lbproc=128]
 	+ m01s12i381[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
 notes = Obtained by Solver plus Advection plus Conservations Corrections
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5099,7 +5099,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5112,7 +5112,7 @@ expression = (m01s14i181[lbproc=128] + m01s01i181[lbproc=128]
 	+ m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s35i029[lbproc=128])
 	/ ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5121,7 +5121,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i189[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5130,7 +5130,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s01i161[lbproc=128] + m01s02i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5140,7 +5140,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon AEmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5149,7 +5149,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i233[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5159,7 +5159,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon AEmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5168,7 +5168,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i233[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5181,7 +5181,7 @@ expression = (m01s03i181[lbproc=128] - m01s03i189[lbproc=128]
 	+ m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128]
 	- m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5197,7 +5197,7 @@ expression = (m01s03i181[lbproc=128] + m01s04i141[lbproc=128]
 	- m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128])
 	/ ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5206,7 +5206,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tob
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -5215,7 +5215,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tos
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -5224,7 +5224,7 @@ component = ocean
 dimension = time
 expression = area_mean(tos, areacello)
 mip_table_id = Oday Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -5233,7 +5233,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tossq
 mip_table_id = Oday Omon OPday OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC2
 
@@ -5242,7 +5242,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i219[lblev=1, lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = 1e-5 m
 
@@ -5252,7 +5252,7 @@ dimension = longitude latitude time
 expression = m01s03i539[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon
 positive = up
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5262,8 +5262,8 @@ dimension = longitude latitude time
 expression = trop_o3col(m01s34i001[lbproc=128]
 	* m01s50i063[lbproc=128] * m01s50i062[lbproc=128])
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>,
-	Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (University of Cambridge),
+	Mohit Dalvi (Met Office)
 status = ok
 units = 1.0e-5 m
 
@@ -5273,7 +5273,7 @@ component = atmos-physics boundary-layer
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128]
 mip_table_id = Amon Eday APday APmon day mon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -5282,7 +5282,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon mon day
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>,
+reviewer = Ron Kahana (Met Office),
 	Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = K
@@ -5299,7 +5299,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i011[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -5309,7 +5309,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128]
 	/ m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5319,7 +5319,7 @@ dimension = longitude latitude p10 time
 expression = m01s30i201[blev=P10, lbproc=128]
 	/ m01s30i301[blev=P10, lbproc=128]
 mip_table_id = AERday GCAmon AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5366,7 +5366,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128]
 	/ m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5411,7 +5411,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i201[blev=PLEV27, lbproc=128]
 	/ m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -5512,7 +5512,7 @@ component = boundary-layer
 dimension = longitude latitude height10m time
 expression = m01s03i209[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr AP6hr APday APmon AP3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5522,7 +5522,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(umo, mask_3D_U)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -5532,7 +5532,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(uo, mask_3D_U)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -5545,7 +5545,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i428[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -5554,7 +5554,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i014[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -5565,7 +5565,7 @@ dimension = latitude plev39 time
 expression = zonal_apply_heaviside(m01s30i314[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APmonZ APdayZ
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-2
 
@@ -5581,7 +5581,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s06i247[blev=PLEV19, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 
@@ -5590,7 +5590,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i012[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -5599,7 +5599,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i022[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -5609,7 +5609,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128]
 	/ m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5663,7 +5663,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128]
 	/ m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5694,7 +5694,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i202[blev=PLEV27, lbproc=128]
 	/ m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -5781,7 +5781,7 @@ component = boundary-layer
 dimension = longitude latitude height10m time
 expression = m01s03i210[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr AP3hr AP6hr APday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5791,7 +5791,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vmo, mask_3D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -5805,7 +5805,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	+ m01s51i059[blev=PLEV39, lbproc=192])
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ ACmonZ
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -5815,7 +5815,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vo, mask_3D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -5825,7 +5825,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = volcello(thkcello, areacello)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -5834,7 +5834,7 @@ component = ocean
 dimension = time
 expression = scvoltot
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -5843,7 +5843,7 @@ component = atmos-physics
 dimension = longitude latitude pl700 time1
 expression = vortmean(m01s30i457[blev=600 700 850, lbproc=0])
 mip_table_id = 6hrPlevPt AP6hrPt
-reviewer = Malcolm Roberts <malcolm.roberts@metoffice.gov.uk>
+reviewer = Malcolm Roberts (Met Office)
 status = ok
 units = s-1
 
@@ -5856,7 +5856,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i429[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -5865,7 +5865,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i024[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -5876,7 +5876,7 @@ dimension = latitude plev39 time
 expression = mask_vtem(m01s30i310[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APmonZ APdayZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -5885,7 +5885,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s00i150[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -6021,7 +6021,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i298[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6094,7 +6094,7 @@ dimension = longitude latitude plev4 time
 expression = m01s30i298[blev=PLEV4, lbproc=128]
 	/ m01s30i304[blev=PLEV4, lbproc=128]
 mip_table_id = 6hrPlev AP6hr
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6118,7 +6118,7 @@ dimension = longitude latitude p500 time
 expression = m01s30i298[blev=P500, lbproc=128]
 	/ m01s30i304[blev=P500, lbproc=128]
 mip_table_id = CFday GCAmon APday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6149,7 +6149,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i298[blev=PLEV7H, lbproc=0]
 	/ m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = E3hrPt AP3hrPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6191,7 +6191,7 @@ expression = m01s04i231[lbproc=128] + m01s04i232[lbproc=128]
 	+ m01s05i283[lbproc=128] + m01s05i284[lbproc=128] + m01s05i285[lbproc=128]
 	+ m01s05i286[lbproc=128]
 mip_table_id = AERmon CresAERday AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -6200,7 +6200,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s08i242[lbproc=128] * MOLECULAR_MASS_OF_CH4 / ATOMIC_MASS_OF_C
 mip_table_id = Emon LPmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = ug m-2 s-1
 
@@ -6209,7 +6209,7 @@ component = carbon
 dimension = longitude latitude typewetla time
 expression = m01s08i248[lbproc=128] * m01s03i395[lbproc=128]
 mip_table_id = Emon LPmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = 1
 
@@ -6218,7 +6218,7 @@ component = ocean
 dimension = longitude latitude time
 expression = -1 * (sowaflup + sowflisf)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -6228,7 +6228,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wmo, mask_3D_T)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -6238,7 +6238,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wo, mask_3D_T)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -6261,8 +6261,8 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i249[lbproc=128]
 mip_table_id = Eday Emon LPday LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -6272,7 +6272,7 @@ dimension = latitude plev39 time
 expression = mask_polar_column_zonal_means(
 	m01s30i311[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APdayZ APmonZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -6296,7 +6296,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = zfull
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6306,7 +6306,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6316,7 +6316,7 @@ dimension = longitude latitude p10 time
 expression = m01s30i297[blev=P10, lbproc=128]
 	/ m01s30i304[blev=P10, lbproc=128]
 mip_table_id = AERday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6326,7 +6326,7 @@ dimension = longitude latitude p100 time
 expression = m01s30i297[blev=P100, lbproc=128]
 	/ m01s30i304[blev=P100, lbproc=128]
 mip_table_id = AERday AEday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -6336,7 +6336,7 @@ dimension = longitude latitude p1000 time
 expression = m01s30i297[blev=P1000, lbproc=128]
 	/ m01s30i304[blev=P1000, lbproc=128]
 mip_table_id = GCAmon GCday 6hrPlev AERday AP6hr APday mon day
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6369,7 +6369,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i297[blev=PLEV27, lbproc=128]
 	/ m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -6411,7 +6411,7 @@ dimension = longitude latitude p500 time
 expression = m01s30i297[blev=P500, lbproc=128]
 	/ m01s30i304[blev=P500, lbproc=128]
 mip_table_id = AERday GCAmon GCday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6444,7 +6444,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i297[blev=PLEV7H, lbproc=0]
 	/ m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt Prim3hrPt AP6hrPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -6476,7 +6476,7 @@ component = ocean
 dimension = longitude latitude olevhalf time
 expression = zhalf
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6485,7 +6485,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6494,7 +6494,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zos
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6503,7 +6503,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zossq
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -6515,7 +6515,7 @@ dimension = time
 expression = calc_zostoga(thetao, thkcello, areacello,
 	zfullo_0, so_0, rho_0_mean, deptho_0_mean)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6524,6 +6524,6 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i453[lbproc=128] + m01s00i033[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_3hr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_3hr_mappings.cfg
@@ -14,21 +14,21 @@ status = embargoed
 [huss]
 dimension = longitude latitude height2m time1
 expression = m01s03i237[lbproc=0]
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = 1
 
 [mrsos]
 dimension = longitude latitude sdepth1 time1
 expression = m01s08i223[blev=0.05, lbproc=0]
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -36,22 +36,22 @@ units = Pa
 component = atmos-physics
 dimension = longitude latitude height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = K
 
 [uas]
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [vas]
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_6hrLev_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_6hrLev_mappings.cfg
@@ -18,7 +18,7 @@ uva_native_levels = Note that the vertical levels for this variable correspond
 [ec550aer]
 dimension = longitude latitude alevel lambda550nm time1
 expression = m01s02i530[lbplev=3, lbproc=0] + m01s02i540[lbplev=3, lbproc=0]
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-1
 
@@ -26,8 +26,8 @@ units = m-1
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = 1
 
@@ -35,8 +35,8 @@ units = 1
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i408[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = Pa
 
@@ -44,8 +44,8 @@ units = Pa
 component = atmos-physics
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = Pa
 
@@ -53,8 +53,8 @@ units = Pa
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s30i111[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = K
 
@@ -64,8 +64,8 @@ comment = Note that the vertical levels for this variable correspond
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i002[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = m s-1
 
@@ -75,8 +75,8 @@ comment = Note that the vertical levels for this variable correspond
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i003[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = m s-1
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_6hrPlevPt_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_6hrPlevPt_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [psl]
 dimension = longitude latitude time1
 expression = m01s16i222[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -27,7 +27,7 @@ units = s-1
 dimension = longitude latitude plev3 time1
 expression = m01s30i294[blev=PLEV3, lbproc=0]
 	/ m01s30i304[blev=PLEV3, lbproc=0]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -40,7 +40,7 @@ units = K
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -48,7 +48,7 @@ units = m s-1
 dimension = longitude latitude plev3 time1
 expression = m01s30i201[blev=PLEV3, lbproc=0]
 	/ m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -56,7 +56,7 @@ units = m s-1
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -64,7 +64,7 @@ units = m s-1
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -72,7 +72,7 @@ units = m s-1
 dimension = longitude latitude plev3 time1
 expression = m01s30i202[blev=PLEV3, lbproc=0]
 	/ m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -80,14 +80,14 @@ units = m s-1
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [zg500]
 dimension = longitude latitude p500 time1
 expression = m01s30i297[blev=P500, lbproc=0] / m01s30i304[blev=P500, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_AERday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_AERday_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [toz]
 dimension = longitude latitude time
 expression = m01s50i219[lblev=1, lbproc=128]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = 1e-5 m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_AERmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_AERmonZ_mappings.cfg
@@ -15,71 +15,71 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s51i009[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 
 [hcl]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL)
 	* m01s51i992[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-	Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Guang Zeng (NIWA),
+	Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
 [hno3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3)
 	* m01s51i007[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s51i049[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s51i001[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 
 [oh]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH)
 	* m01s51i081[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
 [ta]
 expression = m01s30i294[blev=PLEV39, lbproc=192]
 	/ m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
 [ua]
 expression = m01s30i201[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [va]
 expression = m01s30i202[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [zg]
 expression = m01s30i297[blev=PLEV39, lbproc=192]
 	/ m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_AERmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_AERmon_mappings.cfg
@@ -15,39 +15,39 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s34i009[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s34i049[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s34i001[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_APday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_APday_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 
@@ -24,7 +24,7 @@ units = %
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -32,28 +32,28 @@ units = 1
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
 [sfcWindmax]
 dimension = longitude latitude height10m time
 expression = m01s03i230[lbproc=8192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [tasmax]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=8192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
 [tasmin]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=4096]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -61,7 +61,7 @@ units = K
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -69,7 +69,7 @@ units = m s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -77,7 +77,7 @@ units = m s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -85,7 +85,7 @@ units = Pa s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i297[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_APmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_APmon_mappings.cfg
@@ -17,7 +17,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_Amon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_Amon_mappings.cfg
@@ -20,7 +20,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_CF3hr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_CF3hr_mappings.cfg
@@ -20,21 +20,21 @@ units = 1.0
 [clc]
 dimension = longitude latitude alevel time1
 expression = m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [clic]
 dimension = longitude latitude alevel time1
 expression = m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [clis]
 dimension = longitude latitude alevel time1
 expression = m01s02i309[lbproc=0] - m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -46,7 +46,7 @@ units = kg m-2
 [cls]
 dimension = longitude latitude alevel time1
 expression = m01s02i312[lbproc=0] + m01s02i313[lbproc=0] - m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -59,14 +59,14 @@ units = 1
 [clwc]
 dimension = longitude latitude alevel time1
 expression = m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [clws]
 dimension = longitude latitude alevel time1
 expression = m01s02i308[lbproc=0] - m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -132,7 +132,7 @@ units = kg m-2 s-1
 component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i228[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -145,7 +145,7 @@ units = kg m-2
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -159,7 +159,7 @@ units = Pa
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -167,7 +167,7 @@ units = m
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -175,7 +175,7 @@ units = m
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -183,7 +183,7 @@ units = m
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -308,7 +308,7 @@ units = Pa
 [ts]
 dimension = longitude latitude time1
 expression = m01s00i024[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_CFday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_CFday_mappings.cfg
@@ -15,37 +15,37 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-1
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-1
 
 [wap]
 expression = m01s30i008[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = Pa s-1
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_CFmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_CFmon_mappings.cfg
@@ -15,13 +15,13 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_CFsubhr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_CFsubhr_mappings.cfg
@@ -22,56 +22,56 @@ rld_rldcs = Physically, the radiation scheme used in this model ignores any
 [ci]
 dimension = site time1
 expression = m01s05i269[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 
 [cl]
 dimension = alevel site time1
 expression = m01s02i261[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 
 [cli]
 dimension = alevel site time1
 expression = m01s02i309[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg kg-1
 
 [clivi]
 dimension = site time1
 expression = m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 
 [clt]
 dimension = site time1
 expression = m01s02i204[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 
 [clw]
 dimension = alevel site time1
 expression = m01s02i308[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg kg-1
 
 [clwvi]
 dimension = site time1
 expression = m01s02i391[lbproc=0] + m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 
 [evspsbl]
 dimension = site time1
 expression = m01s03i223[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -80,7 +80,7 @@ comment = Includes both evaporation and sublimation.
 dimension = site time1
 expression = m01s03i234[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -88,21 +88,21 @@ units = W m-2
 dimension = site time1
 expression = m01s03i217[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
 [hur]
 dimension = alevel site time1
 expression = m01s30i113[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = %
 
 [hurs]
 dimension = site height2m time1
 expression = m01s03i245[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = %
 
@@ -110,14 +110,14 @@ units = %
 component = cftables
 dimension = alevel site time1
 expression = m01s00i010[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 
 [huss]
 dimension = site height2m time1
 expression = m01s03i237[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 
@@ -128,63 +128,63 @@ component = cftables
 dimension = alevhalf site time1
 expression = (m01s05i250[lbproc=0] - m01s05i251[lbproc=0]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 positive = up
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>, William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [pfull]
 dimension = alevel site time1
 expression = m01s00i408[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
 [phalf]
 dimension = alevhalf site time1
 expression = m01s00i407[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
 [pr]
 dimension = site time1
 expression = m01s05i216[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [prc]
 dimension = site time1
 expression = m01s05i205[lbproc=0] + m01s05i206[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [prsn]
 dimension = site time1
 expression = m01s05i215[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [prw]
 dimension = site time1
 expression = m01s30i461[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 
 [ps]
 dimension = site time1
 expression = m01s00i409[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
 [psl]
 dimension = site time1
 expression = m01s16i222[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
@@ -198,7 +198,7 @@ comment = Physically, the radiation scheme used in this model ignores any
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i218[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -212,7 +212,7 @@ comment = Physically, the radiation scheme used in this model ignores any
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i220[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -220,7 +220,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i207[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -228,7 +228,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i208[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -236,7 +236,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i207[lbproc=0] - m01s02i201[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -245,7 +245,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i217[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -254,7 +254,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i219[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -263,7 +263,7 @@ component = cftables
 dimension = site time1
 expression = m01s02i205[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -271,7 +271,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i206[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -279,7 +279,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i218[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -287,7 +287,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i220[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -295,7 +295,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i235[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -303,7 +303,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i210[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -311,7 +311,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i207[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -319,7 +319,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i217[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -327,7 +327,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i219[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -336,7 +336,7 @@ component = cftables
 dimension = site time1
 expression = m01s01i235[lbproc=0] - m01s01i201[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -344,7 +344,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i211[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -352,7 +352,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i208[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -360,7 +360,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i209[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -375,14 +375,14 @@ component = boundary-layer
 dimension = site time1
 expression = m01s03i298[lbproc=0]
 positive = None
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [sci]
 dimension = site time1
 expression = m01s05i270[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 
@@ -391,7 +391,7 @@ comment = This is the mean of the speed, not the speed computed from the mean u
 	and v components of wind.
 dimension = site height10m time1
 expression = m01s03i230[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 
@@ -399,14 +399,14 @@ units = m s-1
 component = cftables
 dimension = alevel site time1
 expression = m01s30i111[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 
 [tas]
 dimension = site height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 
@@ -414,7 +414,7 @@ units = K
 dimension = site time1
 expression = m01s03i460[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
@@ -422,14 +422,14 @@ units = Pa
 dimension = site time1
 expression = m01s03i461[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
 [tnhus]
 dimension = alevel site time1
 expression = m01s30i182[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 
@@ -437,14 +437,14 @@ units = s-1
 dimension = alevel site time1
 expression = (m01s12i182[lbproc=0] + m01s12i382[lbproc=0])
 	/ ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 
 [tnhusc]
 dimension = alevel site time1
 expression = m01s05i162[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 
@@ -454,7 +454,7 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
 	+ m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
 	+ m01s04i982[lbproc=0] + m01s05i182[lbproc=0] + m01s16i162[lbproc=0]
 	+ m01s16i182[lbproc=0] + m01s35i025[lbproc=0] ) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 
@@ -464,14 +464,14 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
 	+ m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
 	+ m01s05i182[lbproc=0] - m01s05i162[lbproc=0] + m01s16i162[lbproc=0]
 	+ m01s16i182[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 
 [tnt]
 dimension = alevel site time1
 expression = m01s30i181[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 
@@ -485,7 +485,7 @@ units = K s-1
 [tntc]
 dimension = alevel site time1
 expression = m01s05i161[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 
@@ -502,7 +502,7 @@ units = K s-1
 [tntr]
 dimension = alevel site time1
 expression = (m01s01i161[lbproc=0] + m01s02i161[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 
@@ -513,14 +513,14 @@ expression = (m01s03i181[lbproc=0] + m01s04i141[lbproc=0]
 	+ m01s01i181[lbproc=0] - m01s01i161[lbproc=0] + m01s02i181[lbproc=0]
 	- m01s02i161[lbproc=0] + m01s05i181[lbproc=0] - m01s05i161[lbproc=0])
 	/ ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 
 [ts]
 dimension = site time1
 expression = m01s00i024[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 
@@ -528,14 +528,14 @@ units = K
 component = cftables
 dimension = alevel site time1
 expression = m01s00i002[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 
 [uas]
 dimension = site height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 
@@ -543,14 +543,14 @@ units = m s-1
 component = cftables
 dimension = alevel site time1
 expression = m01s00i003[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 
 [vas]
 dimension = site height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 
@@ -558,7 +558,7 @@ units = m s-1
 component = cftables
 dimension = alevel site time1
 expression = m01s30i008[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa s-1
 
@@ -566,7 +566,7 @@ units = Pa s-1
 component = cftables
 dimension = alevel site time1
 expression = m01s16i201[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_E3hrPt_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_E3hrPt_mappings.cfg
@@ -14,14 +14,14 @@ status = embargoed
 [cfadDbze94]
 dimension = longitude latitude alt40 dbze time1
 expression = m01s02i372[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [cfadLidarsr532]
 dimension = longitude latitude alt40 scatratio time1
 expression = m01s02i370[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -35,7 +35,7 @@ units = mol mol-1
 component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i371[lbproc=0] / m01s02i325[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -43,14 +43,14 @@ units = 1
 component = cloud
 dimension = longitude latitude p220 time1
 expression = m01s02i346[blev=P220, lbproc=0] / m01s02i323[blev=P220, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [clisccp]
 dimension = longitude latitude plev7c tau time1
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -59,7 +59,7 @@ comment = CALIPSO Low Level Cloud Fraction
 component = cloud
 dimension = longitude latitude p840 time1
 expression = m01s02i344[blev=P840, lbproc=0] / m01s02i321[blev=P840, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -67,14 +67,14 @@ units = 1
 component = cloud
 dimension = longitude latitude p560 time1
 expression = m01s02i345[blev=P560, lbproc=0] / m01s02i322[blev=P560, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [clmisr]
 dimension = longitude latitude alt16 tau time1
 expression = fix_clmisr_height(m01s02i360[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -82,14 +82,14 @@ units = 1
 component = cloud
 dimension = longitude latitude time1
 expression = m01s02i347[lbproc=0] / m01s02i324[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [hus]
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 
@@ -102,14 +102,14 @@ units = 1
 [jpdftaureicemodis]
 dimension = longitude latitude plev7c effectRadIc tau time1
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [jpdftaureliqmodis]
 dimension = longitude latitude plev7c effectRadLi tau time1
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -128,14 +128,14 @@ units = mol mol-1
 [parasolRefl]
 dimension = longitude latitude sza5 time1
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -180,7 +180,7 @@ units = K
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -188,7 +188,7 @@ units = m s-1
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_EdayZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_EdayZ_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 dimension = latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -23,7 +23,7 @@ units = 1
 dimension = latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -31,21 +31,21 @@ units = K
 dimension = latitude plev39 time
 expression = m01s30i201[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 
 [utendogw]
 dimension = latitude plev39 time
 expression = m01s06i247[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 
@@ -53,7 +53,7 @@ units = m s-2
 dimension = latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=192]
 	/ m01s30i301[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -61,7 +61,7 @@ units = m s-1
 dimension = latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_Eday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_Eday_mappings.cfg
@@ -22,7 +22,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i330[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -31,7 +31,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i290[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_EmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_EmonZ_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-2
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_Emon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_Emon_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 dimension = longitude latitude plev7h time
 expression = m01s30i295[blev=PLEV7H, lbproc=128]
 	/ m01s30i304[blev=PLEV7H, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -24,14 +24,14 @@ comment = Monthly mean orography (needed if land ice has time varying
 	altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
 [wap]
 dimension = longitude latitude alevel time
 expression = m01s30i008[lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_GA7mon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_GA7mon_mappings.cfg
@@ -13,26 +13,26 @@ status = Internal
 [pr]
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = kg m-2 s-1
 
 [ts]
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = K
 
 [ua]
 dimension = longitude latitude plev17 time
 expression = m01s30i201[blev=PLEV17, lbproc=128]
 	/ m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = m s-1
 
 [va]
 dimension = longitude latitude plev17 time
 expression = m01s30i202[blev=PLEV17, lbproc=128]
 	/ m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = m s-1
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_GC3hrPt_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_GC3hrPt_mappings.cfg
@@ -6,7 +6,7 @@
 # 'model to MIP mapping'. Please see the 'User Guide' for more
 # information.
 # This list follows the same order as the "CP4A variables to be 
-# CMORised" spreadsheet, contact joshua.macholl@metoffice.gov.uk 
+# CMORised" spreadsheet, contact Joshua Macholl 
 
 [DEFAULT]
 mip_table_id = GC3hrPt

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_LPmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_LPmon_mappings.cfg
@@ -16,7 +16,7 @@ comment = Monthly mean orography (needed if land ice has time varying
 	altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_Omon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_Omon_mappings.cfg
@@ -18,14 +18,14 @@ comment = Computed as the total mass of liquid water falling as liquid rain
 	portion of the grid cell.
 dimension = longitude latitude time
 expression = pr
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [prsn]
 dimension = longitude latitude time
 expression = prsn
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_SIday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_SIday_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [siconc]
 dimension = longitude latitude typesi time
 expression = aice
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = 1
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_day_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_day_mappings.cfg
@@ -20,7 +20,7 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 
@@ -28,7 +28,7 @@ units = %
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -50,28 +50,28 @@ units = kg m-2 s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
 [sfcWindmax]
 dimension = longitude latitude height10m time
 expression = m01s03i230[lbproc=8192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [tasmax]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=8192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
 [tasmin]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=4096]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -79,7 +79,7 @@ units = K
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -95,7 +95,7 @@ units = m s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -111,7 +111,7 @@ units = m s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -119,7 +119,7 @@ units = Pa s-1
 dimension = longitude latitude plev8 time
 expression = m01s30i297[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_mappings.cfg
@@ -55,7 +55,7 @@ expression = m01s02i240[lbplev=3, lbproc=128]
 	+ m01s02i243[lbplev=3, lbproc=128] + m01s02i585[lbplev=3, lbproc=128]
 mip_table_id = AERmon AEmon
 notes = Assuming CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -67,7 +67,7 @@ expression = combine_sw_lw(m01s01i508[lbproc=0] / m01s01i507[lbproc=0],
 	m01s02i508[lbproc=0] / m01s02i507[lbproc=0],
 	minval= '-1.0', maxval= '1.0')
 mip_table_id = E3hrPt AP3hrPtLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -78,7 +78,7 @@ dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i506[lbproc=0], m01s02i506[lbproc=0],
 	swmask= m01s01i200[lbproc=0], minval= '0', maxval= '10')
 mip_table_id = E3hrPt AP3hrPtLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -89,7 +89,7 @@ dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i507[lbproc=0] / m01s01i506[lbproc=0],
 	m01s02i507[lbproc=0] / m01s02i506[lbproc=0], minval='0.0', maxval='1.0')
 mip_table_id = E3hrPt AP3hrPtLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -99,7 +99,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = agessc
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = yr
 
@@ -108,7 +108,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = div_by_area(m01s50i063[lbproc=128])
 mip_table_id = AERmon AEmonLev
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = kg m-2
 
@@ -132,7 +132,7 @@ dimension = longitude latitude time
 expression = fix_packing_division(m01s02i331[lbproc=128],
 	m01s02i334[lbproc=128])
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -141,7 +141,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = areacella(m01s00i505)
 mip_table_id = fx APfx mon day 6hr 3hr 1hr
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok
 units = m2
 
@@ -150,7 +150,7 @@ component = ocean
 dimension = longitude latitude
 expression = areacello
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -159,7 +159,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i054[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = s m-1
 
@@ -171,7 +171,7 @@ component = ocean
 dimension = longitude latitude
 expression = basin
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1
 
@@ -180,7 +180,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = 6hrPlev AERmon AE6hr AEmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -196,7 +196,7 @@ expression = MOLECULAR_MASS_OF_AIR
 	+ (m01s51i994[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRO))
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -207,7 +207,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C2H6)
 	* m01s34i014[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -218,7 +218,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C3H8)
 	* m01s34i018[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -230,7 +230,7 @@ dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128],
 	m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -240,7 +240,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s01i241[lbproc=128] / m01s01i223[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -249,7 +249,7 @@ component = cloud
 dimension = longitude latitude alt40 dbze time
 expression = m01s02i372[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -258,7 +258,7 @@ component = cloud
 dimension = longitude latitude alt40 scatratio time
 expression = m01s02i370[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -268,7 +268,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i055[lbproc=128],
 	MOLECULAR_MASS_OF_CFC11)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -278,7 +278,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i056[lbproc=128],
 	MOLECULAR_MASS_OF_CFC12)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -288,7 +288,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH3COCH3)
 	* m01s34i022[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -299,7 +299,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s51i009[blev=PLEV19, lbproc=128]
 	/ m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -309,7 +309,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i009[lbproc=128],
 	MOLECULAR_MASS_OF_CH4)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -325,7 +325,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
 	+ m01s38i289[lbproc=128]), areadiv='True')
 mip_table_id = AERmon AEmonLev
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -336,7 +336,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
 	m01s50i150[lbproc=128], areadiv='True')
 mip_table_id = AERmon AEmonLev
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -345,7 +345,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i269[lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Mark Webb <mark.webb@metoffice.gov.uk>
+reviewer = Mark Webb (Met Office)
 status = ok
 units = 1
 
@@ -354,7 +354,7 @@ component = cftables cloud
 dimension = longitude latitude alevel time
 expression = m01s02i261[lbproc=128]
 mip_table_id = Amon CFday APmonLev APdayLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -364,7 +364,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i317[lbproc=128]
 mip_table_id = CFmon APmonLev
 notes = Using convective cores in this model configuration.
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -373,7 +373,7 @@ component = cftables
 dimension = longitude latitude alt40 time
 expression = m01s02i371[lbproc=128] / m01s02i325[lbproc=128]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -382,7 +382,7 @@ component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i374[lbproc=0] / m01s02i325[lbproc=0]
 mip_table_id = E3hrPt AP3hrPt
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -413,7 +413,7 @@ dimension = longitude latitude time
 expression = m01s01i280[lbproc=128] / m01s01i281[lbproc=128]
 mip_table_id = Eday Emon APmon APday
 notes = Calculated at daylight grids only.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-2
 
@@ -423,7 +423,7 @@ dimension = longitude latitude p220 time
 expression = m01s02i346[lbproc=128, blev=P220]
 	/ m01s02i323[lbproc=128, blev=P220]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -433,7 +433,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i309[lbproc=128]
 mip_table_id = Amon CFday APmonLev APdayLev
 notes = ${COMMON:convective_notes}
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -442,7 +442,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i319[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -451,7 +451,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i453[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -469,7 +469,7 @@ dimension = longitude latitude plev7c tau time
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=128],
 	m01s02i330[lbproc=128])
 mip_table_id = CFmon CFday APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -478,7 +478,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i392[lbproc=128]
 mip_table_id = Amon CFday APmon APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -487,7 +487,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i396[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -497,7 +497,7 @@ dimension = longitude latitude p840 time
 expression = m01s02i344[lbproc=128, blev=P840]
 	/ m01s02i321[lbproc=128, blev=P840]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -507,7 +507,7 @@ dimension = longitude latitude p560 time
 expression = m01s02i345[lbproc=128, blev=P560]
 	/ m01s02i322[lbproc=128, blev=P560]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -516,7 +516,7 @@ component = cloud
 dimension = longitude latitude alt16 tau time
 expression = fix_clmisr_height(m01s02i360[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -526,7 +526,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i312[lbproc=128] + m01s02i313[lbproc=128]
 	- m01s02i317[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -536,7 +536,7 @@ dimension = longitude latitude time
 expression = m01s02i204[lbproc=128]
 mip_table_id = GC1hr 3hr Amon day AP3hr APday APmon
 units = 1
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 
 [cltcalipso]
@@ -544,7 +544,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i347[lbproc=128] / m01s02i324[lbproc=128]
 mip_table_id = CFday CFmon APmon APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -553,7 +553,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i334[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -562,7 +562,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i451[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -572,7 +572,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i308[lbproc=128]
 mip_table_id = Amon CFday APdayLev APmonLev
 notes = ${COMMON:convective_notes}
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -581,7 +581,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i318[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -590,7 +590,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i452[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -607,7 +607,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128] + m01s02i392[lbproc=128]
 mip_table_id = Amon CFday APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -616,7 +616,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i395[lbproc=128] + m01s02i396[lbproc=128]
 mip_table_id = Eday Emon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -634,7 +634,7 @@ expression = MOLECULAR_MASS_OF_AIR
 	+ (m01s51i992[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HCL))
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -644,7 +644,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO)
 	* m01s34i010[lbproc=128]
 mip_table_id = AERmon CresAERday AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -654,7 +654,7 @@ component = carbon
 dimension = time
 expression = m01s30i465[lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg
 
@@ -663,7 +663,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i332[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = AERday AERmon AEday AEmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -672,7 +672,7 @@ component = dust
 dimension = longitude latitude alevel time
 expression = m01s17i257[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -681,7 +681,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i209[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -691,7 +691,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s03i440[lbproc=128]
 mip_table_id = Emon AEmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -700,7 +700,7 @@ component = ocean
 dimension = longitude latitude
 expression = deptho
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -733,7 +733,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i071[lbproc=128]
 	* (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_DMS)
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -748,7 +748,7 @@ expression = m01s03i441[lbproc=128] + m01s03i442[lbproc=128]
 	+ m01s03i456[lbproc=128]
 mip_table_id = AERmon CresAERday AEmon
 notes = Assumes CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -758,7 +758,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_O3,
 	m01s50i131[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -767,7 +767,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -777,7 +777,7 @@ dimension = longitude latitude alevel lambda550nm time
 expression = m01s02i530[lbplev=3, lbproc=128]
 	+ m01s02i540[lbplev=3, lbproc=128]
 mip_table_id = Emon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-1
 
@@ -787,7 +787,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C,
 	m01s38i207[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -800,8 +800,8 @@ dimension = longitude latitude time
 expression = (m01s03i495[lbproc=128] + m01s03i496[lbproc=128]) *
 	m01s00i505
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-	Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (NIWA),
+	Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -810,7 +810,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i158[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -819,7 +819,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i214[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -832,7 +832,7 @@ expression = m01s03i401[lbproc=128] + m01s03i402[lbproc=128]
 	+ m01s03i406[lbproc=128]
 mip_table_id = AERmon AEmon
 notes = Assumes CLASSIC dust.
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -843,8 +843,8 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_ISOPRENE / (5.0 * ATOMIC_MASS_OF_C))
 	* (m01s03i495[lbproc=128] * m01s00i505)
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-	Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (NIWA),
+	Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -853,7 +853,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i081[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol s-1
 
@@ -865,7 +865,7 @@ expression = achem_emdrywet(1.0,
 	m01s50i172[lbproc=128], cube2d=m01s50i156[lbproc=128],
 	sumlev='True')
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -876,7 +876,7 @@ expression = achem_emdrywet(1.0,
 	m01s50i217[lbproc=128], cube2d=(m01s50i215[lbproc=128]
 	+ m01s50i216[lbproc=128]), sumlev='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = kg m-2 s-1
 
@@ -888,7 +888,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
 	sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -899,7 +899,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL,
 	m01s38i204[lbproc=128] + m01s38i205[lbproc=128],
 	sumlev='True', areadiv='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -916,7 +916,7 @@ expression = ((m01s50i159[lbproc=128] / MOLECULAR_MASS_OF_HCHO)
 	+ (m01s50i301[lbproc=128] * (10.0 / MOLECULAR_MASS_OF_MONOTERPENE)))
 	* ATOMIC_MASS_OF_C
 mip_table_id = AERmon AEmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -933,7 +933,7 @@ dimension = latitude plev39 time
 expression = scale_epflux(m01s30i312[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APdayZ APmonZ
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -944,7 +944,7 @@ expression = scale_epflux(m01s30i313[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APdayZ APmonZ
 positive = up
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -953,7 +953,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i296[lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -971,7 +971,7 @@ expression = correct_evaporation(evs, sowaflup - (evs - (ficeberg
 	+ friver + prsn + pr + fsitherm) ), areacello)
 mip_table_id = Omon OPmon
 positive = None
-reviewer = Dave Storkey <dave.storkey@metoffice.gov.uk>
+reviewer = Dave Storkey (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -980,8 +980,8 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i223[lbproc=128]
 mip_table_id = Amon Eday APmon LPday
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>,
-	Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office),
+	Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -990,7 +990,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i334[lbproc=128]
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1000,7 +1000,7 @@ dimension = longitude latitude time
 expression = m01s03i296[lbproc=128] + m01s03i298[lbproc=128]
 	- m01s03i539[lbproc=128]
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1009,7 +1009,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Lmon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1022,7 +1022,7 @@ expression = calc_fgdms(m01s00i505, m01s50i214[lbproc=128]
 	/ MOLECULAR_MASS_OF_DMS )
 mip_table_id = Omon OBmon
 positive = up
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = kmol m-2 s-1
 
@@ -1032,7 +1032,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(ficeberg, -1*vowflisf)
 mip_table_id = Omon OPmonLev
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1048,8 +1048,8 @@ component = chemistry
 dimension = longitude latitude time
 expression = div_by_area(m01s50i082[lbproc=128])
 mip_table_id = Emon ACmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>,
-	Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (University of Cambridge),
+	Mohit Dalvi (Met Office)
 status = ok
 units = m-2 min-1
 
@@ -1058,7 +1058,7 @@ component = ocean
 dimension = longitude latitude time
 expression = friver
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1067,7 +1067,7 @@ component = seaice
 dimension = longitude latitude time
 expression = fsitherm
 mip_table_id = Omon OPmon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1076,7 +1076,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s03i261[lbproc=128]
 mip_table_id = E3hr LP3hr
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1094,7 +1094,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCHO)
 	* m01s34i011[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1104,7 +1104,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL)
 	* m01s34i992[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1116,7 +1116,7 @@ expression = combine_cubes_to_basin_coord(hfbasin_global, hfbasin_atlantic,
 	hfbasin_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1129,7 +1129,7 @@ expression = combine_cubes_to_basin_coord(hfbasinpadv_global,
 	mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V,
 	mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1142,7 +1142,7 @@ expression = combine_cubes_to_basin_coord(hfbasinpmadv_global,
 	mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V,
 	mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1155,7 +1155,7 @@ expression = combine_cubes_to_basin_coord(hfbasinpmdiff_global,
 	mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V,
 	mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1165,7 +1165,7 @@ dimension = longitude latitude time
 expression = hfds
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1183,7 +1183,7 @@ dimension = longitude latitude time
 expression = hfevapds
 mip_table_id = Omon OPmon
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1193,7 +1193,7 @@ dimension = longitude latitude
 expression = hfgeou
 mip_table_id = Ofx OPfx
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1203,7 +1203,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(-1*berg_latent_heat_flux, vohflisf)
 mip_table_id = Omon OPmonLev
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -1214,7 +1214,7 @@ expression = m01s03i234[lbproc=128]
 mip_table_id = GC1hr 3hr Amon day AP3hr APday APmon
 positive = up
 units = W m-2
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 
 [hfrainds]
@@ -1223,7 +1223,7 @@ dimension = longitude latitude time
 expression = hfrainds
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -1234,7 +1234,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(hflx_rnf, -1*vohfcisf)
 mip_table_id = Omon OPmonLev
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -1253,7 +1253,7 @@ expression = m01s03i217[lbproc=128]
 mip_table_id = GC1hr 3hr Amon day AP3hr APday APmon
 positive = up
 units = W m-2
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 
 [hfx]
@@ -1261,7 +1261,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfx, mask_2D_U)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -1270,7 +1270,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfy, mask_2D_V)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -1280,7 +1280,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3)
 	* m01s34i007[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1291,7 +1291,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HO2)
 	* m01s51i082[blev=PLEV39, lbproc=192]
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 
@@ -1303,7 +1303,7 @@ expression = combine_cubes_to_basin_coord(hfovgyre_global, hfovgyre_atlantic,
 	hfovgyre_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1315,7 +1315,7 @@ expression = combine_cubes_to_basin_coord(hfovovrt_global, hfovovrt_atlantic,
 	hfovovrt_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -1324,7 +1324,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i113[lbproc=128]
 mip_table_id = CFday CFmon APdayLev APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = %
 
@@ -1452,7 +1452,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i245[lbproc=128]
 mip_table_id = 6hrPlev Amon day AP6hr APday APmon
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = %
 
@@ -1487,7 +1487,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1526,7 +1526,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1559,7 +1559,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i295[blev=PLEV27, lbproc=128]
 	/ m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1638,7 +1638,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i295[blev=PLEV7H, lbproc=0]
 	/ m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt AP6hrPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -1650,7 +1650,7 @@ expression = m01s30i295[blev=P850, lbproc=128]
 	/ m01s30i304[blev=P850, lbproc=128]
 mip_table_id = Eday GCAmon APday
 units = 1
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [hus925]
@@ -1666,7 +1666,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i237[lbproc=128]
 mip_table_id = Amon day APday APmon
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = 1
 
@@ -1683,7 +1683,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i462[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -1700,7 +1700,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i463[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -1710,7 +1710,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_ISOPRENE)
 	* m01s34i027[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -1719,7 +1719,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i229[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1729,7 +1729,7 @@ dimension = latitude plev39 time
 expression = m01s52i245[blev=PLEV39, lbproc=192]
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ APmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1739,7 +1739,7 @@ dimension = latitude plev39 time
 expression = m01s52i246[blev=PLEV39, lbproc=192]
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ APmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -1748,7 +1748,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadIc tau time
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -1757,7 +1757,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadLi tau time
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday APmon APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -1766,7 +1766,7 @@ component = dust
 dimension = longitude latitude time
 expression = calc_loaddust(m01s17i257[lbproc=128], m01s50i255[lbproc=128])
 mip_table_id = Emon Eday APday APmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -1777,7 +1777,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i247[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -1787,7 +1787,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i071[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -1796,7 +1796,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -1806,7 +1806,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = masscello
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2
 
@@ -1815,7 +1815,7 @@ component = ocean
 dimension = time
 expression = scvoltot * SEAWATER_DENSITY
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg
 
@@ -1824,7 +1824,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=8192]
 mip_table_id = AERday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -1833,7 +1833,7 @@ dimension = longitude latitude alevhalf time
 expression = (m01s05i250[lbproc=128] - m01s05i251[lbproc=128]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = Amon CFday APdayLev APmonLev
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1842,7 +1842,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i251[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1851,7 +1851,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i250[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1864,7 +1864,7 @@ expression = (m01s51i150[blev=PLEV39, lbproc=192]
 	/ m01s51i999[blev=PLEV39, lbproc=192])
 	/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = AERmonZ AEmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = yr
 
@@ -1873,7 +1873,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=4096]
 mip_table_id = AERday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -1896,7 +1896,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotst
 mip_table_id = Eday Omon OPday OPmon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -1905,7 +1905,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmax
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -1914,7 +1914,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmin
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -1923,7 +1923,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstsq
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -2090,7 +2090,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i105[lbproc=128] + m01s34i109[lbproc=128]
 	+ m01s34i115[lbproc=128] + m01s34i120[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2101,7 +2101,7 @@ expression = m01s00i431[lbproc=128] + m01s00i432[lbproc=128]
 	+ m01s00i433[lbproc=128] + m01s00i434[lbproc=128] + m01s00i435[lbproc=128]
 	+ m01s00i436[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2112,7 +2112,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i106[lbproc=128] + m01s34i110[lbproc=128]
 	+ m01s34i116[lbproc=128] + m01s34i121[lbproc=128] + m01s34i126[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2125,7 +2125,7 @@ expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4)
 	+ m01s34i108[lbproc=128]
 	+ m01s34i114[lbproc=128])
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2134,7 +2134,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i111[lbproc=128] + m01s34i117[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -2145,7 +2145,7 @@ expression = level_sum(m01s08i223[lbproc=128]
 	* m01s08i230[lbproc=128]
 	/ (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Lmon LPmon
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -2172,7 +2172,7 @@ expression = level_sum(m01s08i223[lbproc=128]
 	* m01s08i229[lbproc=128]
 	/ (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Emon LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2181,7 +2181,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128] + m01s08i235[lbproc=128]
 mip_table_id = 3hr Lmon day LP3hr LPday LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2190,7 +2190,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i235[lbproc=128]
 mip_table_id = Eday GCLmon LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2200,7 +2200,7 @@ dimension = longitude latitude time
 expression = m01s08i234[lbproc=128]
 mip_table_id = GC3hr Lmon Eday Lmon LPday LPmon
 units = kg m-2 s-1
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 
 [mrsfl]
@@ -2209,7 +2209,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i230[lbproc=128]
 	/ (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Eday Emon LPday LPmon mon day 6hr
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2219,7 +2219,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i229[lbproc=128]
 	/ (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Eday Emon LPday LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2228,7 +2228,7 @@ component = land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128])
 mip_table_id = Lmon day LPmon LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2239,7 +2239,7 @@ component = land
 dimension = longitude latitude
 expression = mask_zeros(m01s00i041 * FRESHWATER_DENSITY)
 mip_table_id = fx LPfx
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = kg m-2
 
@@ -2248,7 +2248,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Eday Emon LPday LPmon mon day
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>,
+reviewer = Ron Kahana (Met Office),
 	Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = kg m-2
@@ -2258,7 +2258,7 @@ component = land
 dimension = longitude latitude sdepth1 time
 expression = m01s08i223[blev=0.05, lbproc=128]
 mip_table_id = day Lmon LPmon LPday mon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -2270,7 +2270,7 @@ dimension = longitude latitude time
 expression = ocean_quasi_barotropic_streamfunc(umo_vint, areacello,
 	cube_mask=mask_2D_T)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -2282,7 +2282,7 @@ expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfglo,
 	zomsfatl, zomsfipc, mask_global=global_ocean_2D_V,
 	mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -2294,7 +2294,7 @@ expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfeivglo,
 	zomsfeivatl, zomsfeivipc, mask_global=global_ocean_2D_V,
 	mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -2305,7 +2305,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s51i049[blev=PLEV19, lbproc=128]
 	/ m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2315,7 +2315,7 @@ dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i049[lbproc=128],
 	MOLECULAR_MASS_OF_N2O)
 mip_table_id = Amon APmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -2325,7 +2325,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO)
 	* m01s34i002[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2335,7 +2335,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2)
 	* m01s34i996[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2356,7 +2356,7 @@ expression = MOLECULAR_MASS_OF_AIR
 	+ (m01s51i996[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO2))
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ AEmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2367,7 +2367,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s51i001[blev=PLEV19, lbproc=128]
 	/ m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2378,7 +2378,7 @@ expression = (m01s50i011[lbproc=128] + m01s50i013[lbproc=128]
 	+ m01s50i014[lbproc=128] + m01s50i015[lbproc=128])
 	/ m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -2389,7 +2389,7 @@ expression = (m01s50i001[lbproc=128] + m01s50i003[lbproc=128]
 	+ m01s50i103[lbproc=128])
 	/ m01s50i255[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -2399,7 +2399,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(obvfsq, mask_3D_T)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = s-2
 
@@ -2411,7 +2411,7 @@ expression = m01s02i285[lbplev=2, lbproc=128]
 	+ m01s02i300[lbplev=2, lbproc=128] + m01s02i301[lbplev=2, lbproc=128]
 	+ m01s02i302[lbplev=2, lbproc=128] + m01s02i303[lbplev=2, lbproc=128]
 mip_table_id = AERmon CresAERday Cres1HrMn AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2421,7 +2421,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=2, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2432,7 +2432,7 @@ expression = m01s02i285[lbplev=3, lbproc=128]
 	+ m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128]
 	+ m01s02i302[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERday AERmon CresAERday Cres1HrMn AEday AEmon mon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2444,7 +2444,7 @@ expression = m01s02i251[lbplev=3, lbproc=128]
 	+ m01s02i252[lbplev=3, lbproc=128] + m01s02i253[lbplev=3, lbproc=128]
 	+ m01s02i254[lbplev=3, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2453,7 +2453,7 @@ component = dust
 dimension = longitude latitude lambda550nm time
 expression = m01s02i285[lbplev=3, lbproc=128]
 mip_table_id = AERmon CresAERday AEmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2464,7 +2464,7 @@ dimension = longitude latitude lambda550nm time
 expression = m01s02i300[lbplev=3, lbproc=128]
 	+ m01s02i301[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2474,7 +2474,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=5, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -2486,7 +2486,7 @@ expression = m01s02i285[lbplev=5, lbproc=128]
 	+ m01s02i300[lbplev=5, lbproc=128] + m01s02i301[lbplev=5, lbproc=128]
 	+ m01s02i302[lbplev=5, lbproc=128] + m01s02i303[lbplev=5, lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -2496,7 +2496,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH)
 	* m01s34i081[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2506,7 +2506,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2518,7 +2518,7 @@ component = ocean
 dimension = longitude latitude time
 expression = opottempmint
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC kg m-2
 
@@ -2528,7 +2528,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemppmdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2538,7 +2538,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempadvect
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2548,7 +2548,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemptend
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2557,7 +2557,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = m01s00i033
 mip_table_id = fx LPfx mon day 6hr 3hr 1hr
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -2567,7 +2567,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2577,7 +2577,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltpmdiff
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2587,7 +2587,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltadvect
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2597,7 +2597,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osalttend
 mip_table_id = Emon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2607,7 +2607,7 @@ dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_PAN)
 	* m01s34i017[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2616,7 +2616,7 @@ component = cftables
 dimension = longitude latitude sza5 time
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=128])
 mip_table_id = Eday Emon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -2625,7 +2625,7 @@ component = ocean
 dimension = longitude latitude time
 expression = pbo
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = dbar
 
@@ -2634,7 +2634,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i333[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -2643,7 +2643,7 @@ component = atmos-physics cftables
 dimension = longitude latitude alevel time
 expression = m01s00i408[lbproc=128]
 mip_table_id = AERmon CFday AEmonLev APdayLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2654,7 +2654,7 @@ component = aerosol cftables
 dimension = longitude latitude alevhalf time
 expression = m01s00i407[lbproc=128]
 mip_table_id = AERmon CFday APdayLev AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = Pa
 
@@ -2663,7 +2663,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i228[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -2679,7 +2679,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128]
 mip_table_id = 3hr 6hrPlev E1hr CresAERday AP1hr AP3hr AP6hr APday APmon mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2689,7 +2689,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128] + m01s05i206[lbproc=128]
 mip_table_id = 3hr Amon E1hr day AP1hr AP3hr APday APmon mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -2699,7 +2699,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i227[lbproc=0]
 mip_table_id = CF3hr AP3hrPtLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2708,7 +2708,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i223[lbproc=0]
 mip_table_id = CF3hr AP3hrPtLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2717,7 +2717,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i222[lbproc=0]
 mip_table_id = CF3hr AP3hrPtLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2726,7 +2726,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i214[lbproc=128]
 mip_table_id = E3hr AP3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2735,7 +2735,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128]
 mip_table_id = E3hr Eday AP3hr APday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2746,7 +2746,7 @@ dimension = longitude latitude time
 expression = m01s05i215[lbproc=128]
 mip_table_id = 3hr AP3hr APday APmon mon 1hr
 units = kg m-2 s-1
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 valid_min = 0.0
 
@@ -2755,7 +2755,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i206[lbproc=128]
 mip_table_id = E3hr GCAmon AP3hr E3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2764,7 +2764,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i461[lbproc=128]
 mip_table_id = Amon Eday APday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2
 
@@ -2773,7 +2773,7 @@ component = atmos-physics cftables
 dimension = longitude latitude time
 expression = m01s00i409[lbproc=128]
 mip_table_id = AERhr AERmon Amon CFday CFmon Emon CresAERday Cres1HrMn AP1hr APday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2782,7 +2782,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s16i222[lbproc=128]
 mip_table_id = 6hrPlev Amon day APmon AP6hr APday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2791,7 +2791,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i451[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -2803,7 +2803,7 @@ dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128],
 	m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2812,7 +2812,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2821,7 +2821,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2830,7 +2830,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2839,7 +2839,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -2848,7 +2848,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s01i245[lbproc=128] / m01s01i246[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2861,7 +2861,7 @@ expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128],
 	m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128]
 	+ m01s02i396[lbproc=128]))
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -2872,7 +2872,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i218[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2882,7 +2882,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i522[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2893,7 +2893,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i220[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2903,7 +2903,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i524[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2915,7 +2915,7 @@ mip_table_id = 3hr Amon day AP3hr APday APmon GC1hr
 positive = down
 units = W m-2
 comment = ${COMMON:radiation_comment}
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 
 [rldscs]
@@ -2925,7 +2925,7 @@ dimension = longitude latitude time
 expression = m01s02i208[lbproc=128]
 mip_table_id = 3hr Amon CFday AP3hr APday APmon mon day 6hr
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2936,7 +2936,7 @@ expression = m01s02i201[lbproc=128] - (m01s03i332[lbproc=128]
 	- m01s02i205[lbproc=128])
 mip_table_id = Eday Emon APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -2947,7 +2947,7 @@ expression = hotspot(m01s02i217[lbproc=128], m01s03i332[lbproc=128],
 	m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2958,7 +2958,7 @@ expression = hotspot(m01s02i521[lbproc=128], m01s03i332[lbproc=128],
 	m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2969,7 +2969,7 @@ expression = hotspot(m01s02i219[lbproc=128], m01s03i332[lbproc=128],
 	m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2980,7 +2980,7 @@ expression = hotspot(m01s02i523[lbproc=128], m01s03i332[lbproc=128],
 	m01s02i205[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -2992,7 +2992,7 @@ expression = m01s02i207[lbproc=128] - m01s02i201[lbproc=128]
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3003,7 +3003,7 @@ expression = m01s03i332[lbproc=128]
 mip_table_id = GC1hr Amon day APmon APday
 positive = up
 units = W m-2
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 
 [rlut4co2]
@@ -3013,7 +3013,7 @@ expression = remove_altitude_coords(m01s02i521[lblev=86, lbproc=128])
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3024,7 +3024,7 @@ expression = remove_altitude_coords(m01s02i517[lblev=86, lbproc=128])
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -3035,7 +3035,7 @@ expression = m01s02i206[lbproc=128] + m01s03i332[lbproc=128]
 	- m01s02i205[lbproc=128]
 mip_table_id = Amon CFday APday APmon mon day 6hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3046,7 +3046,7 @@ expression = remove_altitude_coords(m01s02i523[lblev=86, lbproc=128])
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3057,7 +3057,7 @@ expression = remove_altitude_coords(m01s02i519[lblev=86, lbproc=128])
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -3068,7 +3068,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i218[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3078,7 +3078,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i522[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3089,7 +3089,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i220[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3099,7 +3099,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i524[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3134,7 +3134,7 @@ dimension = longitude latitude olevel time
 expression = rsdo
 mip_table_id = Omon OPmonLev
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -3144,7 +3144,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = rsdoabsorb
 mip_table_id = Emon OPmonLev
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = W m-2
 
@@ -3156,7 +3156,7 @@ mip_table_id = 3hr Amon day AP3hr APday APmon GC1hr
 positive = down
 units = W m-2
 comment = ${COMMON:radiation_comment}
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 
 [rsdscs]
@@ -3166,7 +3166,7 @@ dimension = longitude latitude time
 expression = m01s01i210[lbproc=128]
 mip_table_id = 3hr Amon CFday APmon AP3hr APday mon day 6hr
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3200,7 +3200,7 @@ dimension = longitude latitude time
 expression = m01s01i216[lbproc=128]
 mip_table_id = 3hr Eday Emon AP3hr APday APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3210,7 +3210,7 @@ dimension = longitude latitude time
 expression = m01s01i207[lbproc=128]
 mip_table_id = Amon CFday APmon APday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3220,7 +3220,7 @@ dimension = longitude latitude time
 expression = m01s01i201[lbproc=128]
 mip_table_id = Emon APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3231,7 +3231,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i217[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3241,7 +3241,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i521[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3252,7 +3252,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i219[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3262,7 +3262,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i523[lbproc=128])
 mip_table_id = CFmon APmonLev
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3298,7 +3298,7 @@ expression = m01s01i235[lbproc=128] - m01s01i201[lbproc=128]
 mip_table_id = 3hr Amon day AP3hr APday APmon
 positive = up
 units = W m-2
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 
 [rsuscs]
@@ -3307,7 +3307,7 @@ dimension = longitude latitude time
 expression = m01s01i211[lbproc=128]
 mip_table_id = 3hr Amon CFday AP3hr APday APmon mon day 6hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3342,7 +3342,7 @@ dimension = longitude latitude time
 expression = m01s01i208[lbproc=128]
 mip_table_id = Amon CFday APday APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3352,7 +3352,7 @@ dimension = longitude latitude time
 expression = m01s01i521[lblev=86, lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3362,7 +3362,7 @@ dimension = longitude latitude time
 expression = m01s01i517[lblev=86, lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3372,7 +3372,7 @@ dimension = longitude latitude time
 expression = m01s01i209[lbproc=128]
 mip_table_id = Amon CFday E3hr AP3hr APday APmon mon day 6hr
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3382,7 +3382,7 @@ dimension = longitude latitude time
 expression = m01s01i523[lblev=86, lbproc=128]
 mip_table_id = CFmon APmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3392,7 +3392,7 @@ dimension = longitude latitude time
 expression = m01s01i519[lblev=86, lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3419,7 +3419,7 @@ expression = m01s01i207[lbproc=128] - m01s01i208[lbproc=128]
 	- m01s03i332[lbproc=128]
 mip_table_id = Amon APmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -3436,7 +3436,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s03i331[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 mip_table_id = LImon Eday LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3445,7 +3445,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i270[lbproc=128]
 mip_table_id = Amon APmon
-reviewer = Rachel Stratton <rachel.stratton@metoffice.gov.uk>
+reviewer = Rachel Stratton (Met Office)
 status = ok
 units = 1
 
@@ -3458,7 +3458,7 @@ expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128],
 	m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128]
 	+ m01s02i396[lbproc=128]))
 mip_table_id = Eday APday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -3467,7 +3467,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s17i257[lblev=1, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -3478,7 +3478,7 @@ expression = m01s03i230[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr Prim3hr day AP3hr AP6hr APday APmon
 notes = An arbitrary choice between 'B-grid' or 'C-grid' but it would seem
 	sensible to use the same throughout.
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -3754,7 +3754,7 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2)
 	* m01s34i996[lblev=1, lbproc=128]
 mip_table_id = AERhr AE1hr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -3764,7 +3764,7 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s34i001[lblev=1, lbproc=128]
 mip_table_id = AERhr AE1hr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -3774,7 +3774,7 @@ dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s34i001[lblev=1, lbproc=8192]
 mip_table_id = AERday AEday
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3792,7 +3792,7 @@ component = land
 dimension = longitude latitude typeland
 expression = m01s00i505
 mip_table_id = fx APfx mon day 6hr 3hr 1hr
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = 1
 
@@ -3801,7 +3801,7 @@ component = ocean
 dimension = longitude latitude typesea
 expression = sftof
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = %
 
@@ -3810,7 +3810,7 @@ component = seaice
 dimension = longitude latitude time
 expression = iage * SECONDS_IN_DAY * DAYS_IN_YEAR
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s
 
@@ -3826,7 +3826,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sicompstren
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-1
 
@@ -3835,7 +3835,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3844,7 +3844,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = m01s00i031[lbproc=128]
 mip_table_id = SIday SImon mon day
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3853,7 +3853,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcdyn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -3862,7 +3862,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcth
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -3871,7 +3871,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtd * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3881,7 +3881,7 @@ dimension = longitude latitude time
 expression = -1 * evap_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3890,7 +3890,7 @@ component = seaice
 dimension = longitude latitude time
 expression = congel * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3899,7 +3899,7 @@ component = seaice
 dimension = longitude latitude time
 expression = frazil * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3908,7 +3908,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltl * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3917,7 +3917,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltb * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3926,7 +3926,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3935,7 +3935,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3944,7 +3944,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3953,7 +3953,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstranx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -3962,7 +3962,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstrany
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -3971,7 +3971,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i538[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -3980,7 +3980,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sifb
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -3990,7 +3990,7 @@ dimension = longitude latitude time
 expression = siflcondbot
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4000,7 +4000,7 @@ dimension = longitude latitude time
 expression = siflcondtop
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4010,7 +4010,7 @@ dimension = longitude latitude time
 expression = ((meltt + meltb + meltl - congel - frazil) * ICE_DENSITY + melts
 	* SNOW_DENSITY) / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [siflfwdrain]
@@ -4019,7 +4019,7 @@ dimension = longitude latitude time
 expression = (meltt * ICE_DENSITY + melts * SNOW_DENSITY)
 	/ (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sifllatstop]
@@ -4036,7 +4036,7 @@ dimension = longitude latitude time
 expression = m01s02i501[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4046,7 +4046,7 @@ dimension = longitude latitude time
 expression = m01s03i531[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -4095,7 +4095,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecoriolx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4104,7 +4104,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecorioly
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4113,7 +4113,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstrx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4122,7 +4122,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstry
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4131,7 +4131,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetiltx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4140,7 +4140,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetilty
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -4149,7 +4149,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sihc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -4158,7 +4158,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4167,7 +4167,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = snowfracn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4176,7 +4176,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vsnon / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4185,7 +4185,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vicen / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4194,7 +4194,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi * ICE_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -4206,7 +4206,7 @@ component = seaice
 dimension = longitude latitude typemp time
 expression = apond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4217,7 +4217,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hpond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4230,7 +4230,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ipond_ai / apond_ai
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4239,7 +4239,7 @@ component = seaice
 dimension = longitude latitude time
 expression = rain_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sirdgconc]
@@ -4247,7 +4247,7 @@ component = seaice
 dimension = longitude latitude typesirdg time
 expression = ardg
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4266,7 +4266,7 @@ mip_table_id = SImon
 notes = The interpretation of this variable in CICE is not obvious as CICE has
 	two simultaneous salinity profiles (when prognostic salinity is not being
 	used).
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -4275,7 +4275,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snowfrac / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4284,7 +4284,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnhc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -4293,7 +4293,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hs * SNOW_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -4302,7 +4302,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnthick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4311,7 +4311,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sispeed
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -4352,7 +4352,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sitempbot
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -4361,7 +4361,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i535[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SIday SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -4370,7 +4370,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sithick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4379,7 +4379,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ice_present
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -4388,7 +4388,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siu
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -4397,7 +4397,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siv
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -4406,7 +4406,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -4418,7 +4418,7 @@ expression = 1.026 * combine_cubes_to_basin_coord(sltbasin_global,
 	sltbasin_atlantic, sltbasin_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = EmonZ OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -4430,7 +4430,7 @@ expression = 1.026 * combine_cubes_to_basin_coord(sltovgyre_global,
 	sltovgyre_atlantic, sltovgyre_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -4442,7 +4442,7 @@ expression = 1.026 * combine_cubes_to_basin_coord(sltovovrt_global,
 	sltovovrt_atlantic, sltovovrt_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -4459,7 +4459,7 @@ expression = snc_calc(m01s08i236[lbproc=128],
 	m01s03i317[lbproc=128],
 	m01s03i395[lbproc=128])
 mip_table_id = day LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = %
 
@@ -4471,7 +4471,7 @@ expression = land_class_mean(m01s08i376[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='all')
 mip_table_id = Eday LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = m
 
@@ -4480,7 +4480,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvsdtd * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4489,7 +4489,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * melts * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4498,7 +4498,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4507,7 +4507,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snow_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4517,7 +4517,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i237[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 mip_table_id = Eday LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4528,7 +4528,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i236[lbproc=128], m01s03i317[lbproc=128],
 	land_class='all')
 mip_table_id = day LImon LIday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -4538,7 +4538,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = so
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4548,7 +4548,7 @@ dimension = longitude latitude alevel time
 expression = m01s34i072[lbproc=128] * (MOLECULAR_MASS_OF_AIR
 	/ MOLECULAR_MASS_OF_SO2)
 mip_table_id = AERmon AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -4557,7 +4557,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sob
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4566,7 +4566,7 @@ component = ocean
 dimension = time
 expression = soga
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4585,7 +4585,7 @@ component = ocean
 dimension = longitude latitude time
 expression = somint
 mip_table_id = Emon OPmon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = 1e-3 kg m-2
 
@@ -4594,7 +4594,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sos
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4603,7 +4603,7 @@ component = ocean
 dimension = time
 expression = area_mean(sos, areacello)
 mip_table_id = Oday Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -4612,7 +4612,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sossq
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-6
 
@@ -4622,7 +4622,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(
 	m01s08i236[lbproc=128] / FRESHWATER_DENSITY, m01s03i317[lbproc=128])
 mip_table_id = Emon LPmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = m
 
@@ -4631,7 +4631,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i044[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1e5 K2
 
@@ -4642,7 +4642,7 @@ expression = t20d
 mip_table_id = Eday Emon OPday OPmon
 notes = PMIP variables: Variable will be output with a time dimension and with
 	cell_methods for time.
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -4652,7 +4652,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4714,7 +4714,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i294[blev=PLEV27, lbproc=128]
 	/ m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4756,7 +4756,7 @@ expression = m01s30i294[blev=P500, lbproc=128]
 	/ m01s30i304[blev=P500, lbproc=128]
 mip_table_id = Eday GCAmon APday
 units = K
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [ta600]
@@ -4782,7 +4782,7 @@ expression = m01s30i294[blev=P700, lbproc=128]
 	/ m01s30i304[blev=P700, lbproc=128]
 mip_table_id = CFday GCAmon APday mon day 6hr
 units = K
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 
 [ta7h]
@@ -4791,7 +4791,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i294[blev=PLEV7H, lbproc=0]
 	/ m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt E3hrPt AP6hrPt AP3hrPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
@@ -4803,7 +4803,7 @@ expression = m01s30i294[blev=P850, lbproc=128]
 	/ m01s30i304[blev=P850, lbproc=128]
 mip_table_id = Eday GCAmon APday
 units = K
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 
 [ta925]
@@ -4819,7 +4819,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=128]
 mip_table_id = 6hrPlev Amon day CresAERday Cres1HrMn AP6hr APday APmon mon 1hr
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = K
 
@@ -4828,7 +4828,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=8192])
 mip_table_id = Amon CresAERday APmon mon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4837,7 +4837,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=4096])
 mip_table_id = Amon APmon mon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -4857,7 +4857,7 @@ dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Amon Eday APday APmon
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -4867,7 +4867,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauuo, mask_2D_U)
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -4876,7 +4876,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -4889,7 +4889,7 @@ dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Amon Eday APday APmon
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -4899,7 +4899,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauvo, mask_2D_V)
 mip_table_id = Omon OPmon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -4908,7 +4908,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Eday APday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -4924,7 +4924,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i316[lbplev=8, lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = K
 
@@ -4934,7 +4934,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thetao
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4943,7 +4943,7 @@ component = ocean
 dimension = time
 expression = thetaoga
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4952,7 +4952,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao, thkcello)
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4961,7 +4961,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<2025], thkcello[depth<2025])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4970,7 +4970,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<300], thkcello[depth<300])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4979,7 +4979,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<735], thkcello[depth<735])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -4989,7 +4989,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thkcello
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -4998,7 +4998,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i182[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5008,7 +5008,7 @@ dimension = longitude latitude alevel time
 expression = (m01s12i182[lbproc=128] + m01s12i382[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
 notes = Obtained by advection plus solver
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5017,7 +5017,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i162[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5030,7 +5030,7 @@ expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128]
 	+ m01s16i182[lbproc=128] + m01s35i025[lbproc=128] ) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
 notes = Methane Oxidation added.
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5039,7 +5039,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i190[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5051,7 +5051,7 @@ expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128]
 	+ m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128]
 	+ m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5066,7 +5066,7 @@ expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128]
 	+ m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128]
 	+ m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -5089,7 +5089,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i181[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5100,7 +5100,7 @@ expression = (m01s10i181[lbproc=128] + m01s12i181[lbproc=128]
 	+ m01s12i381[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
 notes = Obtained by Solver plus Advection plus Conservations Corrections
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5109,7 +5109,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5122,7 +5122,7 @@ expression = (m01s14i181[lbproc=128] + m01s01i181[lbproc=128]
 	+ m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s35i029[lbproc=128])
 	/ ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5131,7 +5131,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i189[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5140,7 +5140,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s01i161[lbproc=128] + m01s02i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5150,7 +5150,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon AEmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5159,7 +5159,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i233[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5169,7 +5169,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon AEmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5178,7 +5178,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i233[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5191,7 +5191,7 @@ expression = (m01s03i181[lbproc=128] - m01s03i189[lbproc=128]
 	+ m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128]
 	- m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5207,7 +5207,7 @@ expression = (m01s03i181[lbproc=128] + m01s04i141[lbproc=128]
 	- m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128])
 	/ ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -5216,7 +5216,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tob
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -5225,7 +5225,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tos
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -5234,7 +5234,7 @@ component = ocean
 dimension = time
 expression = area_mean(tos, areacello)
 mip_table_id = Oday Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -5243,7 +5243,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tossq
 mip_table_id = Oday Omon OPday OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC2
 
@@ -5252,7 +5252,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i219[lblev=1, lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = 1e-5 m
 
@@ -5262,7 +5262,7 @@ dimension = longitude latitude time
 expression = m01s03i539[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon
 positive = up
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5271,8 +5271,8 @@ component = chemistry
 dimension = longitude latitude time
 expression = trop_o3col(m01s34i001[lbproc=128]
 	* m01s50i063[lbproc=128] * m01s50i062[lbproc=128])
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>,
-	Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (University of Cambridge),
+	Mohit Dalvi (Met Office)
 status = ok
 mip_table_id = AERmon AEmon
 units = 1.0e-5 m
@@ -5282,7 +5282,7 @@ component = atmos-physics boundary-layer
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128]
 mip_table_id = Amon Eday APday APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -5291,7 +5291,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon mon day 6hr
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>,
+reviewer = Ron Kahana (Met Office),
 	Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = K
@@ -5308,7 +5308,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i011[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -5318,7 +5318,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128]
 	/ m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5328,7 +5328,7 @@ dimension = longitude latitude p10 time
 expression = m01s30i201[blev=P10, lbproc=128]
 	/ m01s30i301[blev=P10, lbproc=128]
 mip_table_id = AERday GCAmon AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5376,7 +5376,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128]
 	/ m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5409,7 +5409,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i201[blev=PLEV27, lbproc=128]
 	/ m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -5506,7 +5506,7 @@ expression = m01s03i209[lbproc=128]
 mip_table_id = 6hrPlev E3hr AP6hr APday APmon AP3hr
 status = ok
 units = m s-1
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 
 [umo]
 comment = ${COMMON:ocean_zstar_comment}
@@ -5514,7 +5514,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(umo, mask_3D_U)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -5524,7 +5524,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(uo, mask_3D_U)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -5537,7 +5537,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i428[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -5546,7 +5546,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i014[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -5557,7 +5557,7 @@ dimension = latitude plev39 time
 expression = zonal_apply_heaviside(m01s30i314[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APmonZ APdayZ
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-2
 
@@ -5573,7 +5573,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s06i247[blev=PLEV19, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 
@@ -5582,7 +5582,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i012[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -5591,7 +5591,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i022[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -5601,7 +5601,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128]
 	/ m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5656,7 +5656,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128]
 	/ m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5689,7 +5689,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i202[blev=PLEV27, lbproc=128]
 	/ m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -5786,7 +5786,7 @@ expression = m01s03i210[lbproc=128]
 mip_table_id = 6hrPlev E3hr AP3hr AP6hr APday APmon
 status = ok
 units = m s-1
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 
 [vmo]
 comment = ${COMMON:ocean_zstar_comment}
@@ -5794,7 +5794,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vmo, mask_3D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -5808,7 +5808,7 @@ expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	+ m01s51i059[blev=PLEV39, lbproc=192])
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ ACmonZ
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -5818,7 +5818,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vo, mask_3D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -5828,7 +5828,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = volcello(thkcello, areacello)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -5837,7 +5837,7 @@ component = ocean
 dimension = time
 expression = scvoltot
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -5846,7 +5846,7 @@ component = atmos-physics
 dimension = longitude latitude pl700 time1
 expression = vortmean(m01s30i457[blev=600 700 850, lbproc=0])
 mip_table_id = 6hrPlevPt AP6hrPt
-reviewer = Malcolm Roberts <malcolm.roberts@metoffice.gov.uk>
+reviewer = Malcolm Roberts (Met Office)
 status = ok
 units = s-1
 
@@ -5859,7 +5859,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i429[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -5868,7 +5868,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i024[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon APmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -5879,7 +5879,7 @@ dimension = latitude plev39 time
 expression = mask_vtem(m01s30i310[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APmonZ APdayZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -5888,7 +5888,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s00i150[lbproc=128]
 mip_table_id = AERmon AEmonLev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -6034,7 +6034,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i298[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6107,7 +6107,7 @@ dimension = longitude latitude plev4 time
 expression = m01s30i298[blev=PLEV4, lbproc=128]
 	/ m01s30i304[blev=PLEV4, lbproc=128]
 mip_table_id = 6hrPlev AP6hr
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6131,7 +6131,7 @@ dimension = longitude latitude p500 time
 expression = m01s30i298[blev=P500, lbproc=128]
 	/ m01s30i304[blev=P500, lbproc=128]
 mip_table_id = CFday GCAmon APday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6162,7 +6162,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i298[blev=PLEV7H, lbproc=0]
 	/ m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = E3hrPt AP3hrPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -6204,7 +6204,7 @@ expression = m01s04i231[lbproc=128] + m01s04i232[lbproc=128]
 	+ m01s05i283[lbproc=128] + m01s05i284[lbproc=128] + m01s05i285[lbproc=128]
 	+ m01s05i286[lbproc=128]
 mip_table_id = AERmon CresAERday AEmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -6213,7 +6213,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s08i242[lbproc=128] * MOLECULAR_MASS_OF_CH4 / ATOMIC_MASS_OF_C
 mip_table_id = Emon LPmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = ug m-2 s-1
 
@@ -6222,7 +6222,7 @@ component = carbon
 dimension = longitude latitude typewetla time
 expression = m01s08i248[lbproc=128] * m01s03i395[lbproc=128]
 mip_table_id = Emon LPmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = 1
 
@@ -6231,7 +6231,7 @@ component = ocean
 dimension = longitude latitude time
 expression = -1 * (sowaflup + sowflisf)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -6241,7 +6241,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wmo, mask_3D_T)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -6251,7 +6251,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wo, mask_3D_T)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -6267,8 +6267,8 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i249[lbproc=128]
 mip_table_id = Eday Emon LPday LPmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -6278,7 +6278,7 @@ dimension = latitude plev39 time
 expression = mask_polar_column_zonal_means(
 	m01s30i311[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APdayZ APmonZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -6295,7 +6295,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = zfull
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6305,7 +6305,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6315,7 +6315,7 @@ dimension = longitude latitude p10 time
 expression = m01s30i297[blev=P10, lbproc=128]
 	/ m01s30i304[blev=P10, lbproc=128]
 mip_table_id = AERday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6325,7 +6325,7 @@ dimension = longitude latitude p100 time
 expression = m01s30i297[blev=P100, lbproc=128]
 	/ m01s30i304[blev=P100, lbproc=128]
 mip_table_id = AERday AEday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -6335,7 +6335,7 @@ dimension = longitude latitude p1000 time
 expression = m01s30i297[blev=P1000, lbproc=128]
 	/ m01s30i304[blev=P1000, lbproc=128]
 mip_table_id = GCAmon GCday 6hrPlev AERday AP6hr APday mon day 6hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6360,7 +6360,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i297[blev=PLEV27, lbproc=128]
 	/ m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -6386,7 +6386,7 @@ dimension = longitude latitude p500 time
 expression = m01s30i297[blev=P500, lbproc=128]
 	/ m01s30i304[blev=P500, lbproc=128]
 mip_table_id = AERday GCAmon GCday AEday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -6411,7 +6411,7 @@ dimension = longitude latitude plev7h time1
 expression = m01s30i297[blev=PLEV7H, lbproc=0]
 	/ m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt Prim3hrPt AP6hrPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -6443,7 +6443,7 @@ component = ocean
 dimension = longitude latitude olevhalf time
 expression = zhalf
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6453,7 +6453,7 @@ dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = GCAmon Eday APday
 units = m
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 
 [zos]
@@ -6461,7 +6461,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zos
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6470,7 +6470,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zossq
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -6482,7 +6482,7 @@ dimension = time
 expression = calc_zostoga(thetao, thkcello, areacello,
 	zfullo_0, so_0, rho_0_mean, deptho_0_mean)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6491,6 +6491,6 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i453[lbproc=128] + m01s00i033[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m

--- a/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadrem_cp4a/data/HadREM-CP4A_mappings.cfg
@@ -6,7 +6,7 @@
 # 'model to MIP mapping'. Please see the 'User Guide' for more
 # information.
 # This list follows the same order as the "CP4A variables to be
-# CMORised" spreadsheet, contact joshua.macholl@metoffice.gov.uk
+# CMORised" spreadsheet, contact Joshua Macholl>
 
 [DEFAULT]
 positive = None
@@ -2249,7 +2249,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Eday Emon LPday LPmon mon day
 reviewer = Ron Kahana (Met Office),
-	Eleanor Burke <eleanor.burke@metoffice.gov.uk
+	Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -5292,7 +5292,7 @@ dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Eday Lmon LPday LPmon mon day 6hr
 reviewer = Ron Kahana (Met Office),
-	Eleanor Burke <eleanor.burke@metoffice.gov.uk
+	Eleanor Burke (Met Office)
 status = ok
 units = K
 

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_3hr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_3hr_mappings.cfg
@@ -15,21 +15,21 @@ status = embargoed
 [huss]
 dimension = longitude latitude height2m time1
 expression = m01s03i237[lbproc=0]
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = 1
 
 [mrsos]
 dimension = longitude latitude sdepth1 time1
 expression = m01s08i223[blev=0.05, lbproc=0]
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -37,22 +37,22 @@ units = Pa
 component = atmos-physics
 dimension = longitude latitude height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = K
 
 [uas]
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
 [vas]
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_6hrLev_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_6hrLev_mappings.cfg
@@ -18,7 +18,7 @@ uva_native_levels = Note that the vertical levels for this variable correspond
 [ec550aer]
 dimension = longitude latitude alevel lambda550nm time1
 expression = m01s02i530[lbplev=3, lbproc=0] + m01s02i540[lbplev=3, lbproc=0]
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-1
 positive = None
@@ -27,8 +27,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = 1
 positive = None
@@ -37,8 +37,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i408[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -47,8 +47,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -57,8 +57,8 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s30i111[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = K
 positive = None
@@ -69,8 +69,8 @@ comment = Note that the vertical levels for this variable correspond
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i002[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -81,8 +81,8 @@ comment = Note that the vertical levels for this variable correspond
 component = atmos-physics
 dimension = longitude latitude alevel time1
 expression = m01s00i003[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>,
-	Jeremy Walton <jeremy.walton@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office),
+	Jeremy Walton (Met Office)
 status = ok
 units = m s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_6hrPlevPt_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_6hrPlevPt_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [psl]
 dimension = longitude latitude time1
 expression = m01s16i222[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -29,7 +29,7 @@ positive = None
 dimension = longitude latitude plev3 time1
 expression = m01s30i294[blev=PLEV3, lbproc=0]
 	/ m01s30i304[blev=PLEV3, lbproc=0]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -44,7 +44,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -53,7 +53,7 @@ positive = None
 dimension = longitude latitude plev3 time1
 expression = m01s30i201[blev=PLEV3, lbproc=0]
 	/ m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -62,7 +62,7 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -71,7 +71,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -80,7 +80,7 @@ positive = None
 dimension = longitude latitude plev3 time1
 expression = m01s30i202[blev=PLEV3, lbproc=0]
 	/ m01s30i301[blev=PLEV3, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -89,7 +89,7 @@ positive = None
 component = atmos-physics
 dimension = longitude latitude height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -97,7 +97,7 @@ positive = None
 [zg500]
 dimension = longitude latitude p500 time1
 expression = m01s30i297[blev=P500, lbproc=0] / m01s30i304[blev=P500, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_AERday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_AERday_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [toz]
 dimension = longitude latitude time
 expression = m01s50i219[lblev=1, lbproc=128]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = 1e-5 m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_AERmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_AERmonZ_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s51i009[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -23,8 +23,8 @@ positive = None
 [hcl]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL)
 	* m01s51i992[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>,
-	Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Guang Zeng (NIWA),
+	Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 positive = None
@@ -32,7 +32,7 @@ positive = None
 [hno3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3)
 	* m01s51i007[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -40,7 +40,7 @@ positive = None
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s51i049[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -48,7 +48,7 @@ positive = None
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s51i001[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 positive = None
@@ -56,7 +56,7 @@ positive = None
 [oh]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH)
 	* m01s51i081[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
@@ -64,7 +64,7 @@ positive = None
 [ta]
 expression = m01s30i294[blev=PLEV39, lbproc=192]
 	/ m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -72,7 +72,7 @@ positive = None
 [ua]
 expression = m01s30i201[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -80,7 +80,7 @@ positive = None
 [va]
 expression = m01s30i202[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -88,7 +88,7 @@ positive = None
 [zg]
 expression = m01s30i297[blev=PLEV39, lbproc=192]
 	/ m01s30i304[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_AERmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_AERmon_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 [ch4]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4)
 	* m01s34i009[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
@@ -23,7 +23,7 @@ positive = None
 [n2o]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O)
 	* m01s34i049[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
@@ -31,28 +31,28 @@ positive = None
 [o3]
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3)
 	* m01s34i001[lbproc=128]
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 positive = None
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_APday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_APday_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None
@@ -25,7 +25,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 positive = None
@@ -34,7 +34,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -42,7 +42,7 @@ positive = None
 [sfcWindmax]
 dimension = longitude latitude height10m time
 expression = m01s03i230[lbproc=8192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -50,7 +50,7 @@ positive = None
 [tasmax]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=8192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -58,7 +58,7 @@ positive = None
 [tasmin]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=4096]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -67,7 +67,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -76,7 +76,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -85,7 +85,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 positive = None
@@ -94,7 +94,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i297[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_APmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_APmon_mappings.cfg
@@ -17,7 +17,7 @@ dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_Amon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_Amon_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128]
 	/ m01s30i304[blev=PLEV19, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_CF3hr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_CF3hr_mappings.cfg
@@ -21,7 +21,7 @@ positive = None
 [clc]
 dimension = longitude latitude alevel time1
 expression = m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -29,7 +29,7 @@ positive = None
 [clic]
 dimension = longitude latitude alevel time1
 expression = m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -37,7 +37,7 @@ positive = None
 [clis]
 dimension = longitude latitude alevel time1
 expression = m01s02i309[lbproc=0] - m01s02i319[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -51,7 +51,7 @@ positive = None
 [cls]
 dimension = longitude latitude alevel time1
 expression = m01s02i312[lbproc=0] + m01s02i313[lbproc=0] - m01s02i317[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -66,7 +66,7 @@ positive = None
 [clwc]
 dimension = longitude latitude alevel time1
 expression = m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -74,7 +74,7 @@ positive = None
 [clws]
 dimension = longitude latitude alevel time1
 expression = m01s02i308[lbproc=0] - m01s02i318[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -149,7 +149,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i228[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -164,7 +164,7 @@ positive = None
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -180,7 +180,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -189,7 +189,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -198,7 +198,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -207,7 +207,7 @@ positive = None
 component = cftables
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 positive = None
@@ -337,7 +337,7 @@ units = Pa
 [ts]
 dimension = longitude latitude time1
 expression = m01s00i024[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_CFday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_CFday_mappings.cfg
@@ -15,42 +15,42 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 positive = None
 
 [ua]
 expression = m01s00i002[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [va]
 expression = m01s00i003[lbproc=128]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-1
 positive = None
 
 [wap]
 expression = m01s30i008[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = Pa s-1
 positive = None
 
 [zg]
 expression = m01s16i201[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_CFmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_CFmon_mappings.cfg
@@ -15,14 +15,14 @@ status = embargoed
 
 [hus]
 expression = m01s00i010[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 positive = None
 
 [ta]
 expression = m01s30i111[lbproc=128]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_CFsubhr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_CFsubhr_mappings.cfg
@@ -22,7 +22,7 @@ rld_rldcs = Physically, the radiation scheme used in this model ignores any
 [ci]
 dimension = site time1
 expression = m01s05i269[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -30,7 +30,7 @@ positive = None
 [cl]
 dimension = alevel site time1
 expression = m01s02i261[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -38,7 +38,7 @@ positive = None
 [cli]
 dimension = alevel site time1
 expression = m01s02i309[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg kg-1
 positive = None
@@ -46,7 +46,7 @@ positive = None
 [clivi]
 dimension = site time1
 expression = m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -54,7 +54,7 @@ positive = None
 [clt]
 dimension = site time1
 expression = m01s02i204[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -62,7 +62,7 @@ positive = None
 [clw]
 dimension = alevel site time1
 expression = m01s02i308[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg kg-1
 positive = None
@@ -70,7 +70,7 @@ positive = None
 [clwvi]
 dimension = site time1
 expression = m01s02i391[lbproc=0] + m01s02i392[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -78,7 +78,7 @@ positive = None
 [evspsbl]
 dimension = site time1
 expression = m01s03i223[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -88,7 +88,7 @@ comment = Includes both evaporation and sublimation.
 dimension = site time1
 expression = m01s03i234[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -96,14 +96,14 @@ units = W m-2
 dimension = site time1
 expression = m01s03i217[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
 [hur]
 dimension = alevel site time1
 expression = m01s30i113[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = %
 positive = None
@@ -111,7 +111,7 @@ positive = None
 [hurs]
 dimension = site height2m time1
 expression = m01s03i245[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = %
 positive = None
@@ -120,7 +120,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s00i010[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -128,7 +128,7 @@ positive = None
 [huss]
 dimension = site height2m time1
 expression = m01s03i237[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -140,14 +140,14 @@ component = cftables
 dimension = alevhalf site time1
 expression = (m01s05i250[lbproc=0] - m01s05i251[lbproc=0]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 positive = up
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>, William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [pfull]
 dimension = alevel site time1
 expression = m01s00i408[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -155,7 +155,7 @@ positive = None
 [phalf]
 dimension = alevhalf site time1
 expression = m01s00i407[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -163,7 +163,7 @@ positive = None
 [pr]
 dimension = site time1
 expression = m01s05i216[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -171,7 +171,7 @@ positive = None
 [prc]
 dimension = site time1
 expression = m01s05i205[lbproc=0] + m01s05i206[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -179,7 +179,7 @@ positive = None
 [prsn]
 dimension = site time1
 expression = m01s05i215[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -187,7 +187,7 @@ positive = None
 [prw]
 dimension = site time1
 expression = m01s30i461[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2
 positive = None
@@ -195,7 +195,7 @@ positive = None
 [ps]
 dimension = site time1
 expression = m01s00i409[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -203,7 +203,7 @@ positive = None
 [psl]
 dimension = site time1
 expression = m01s16i222[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -218,7 +218,7 @@ comment = Physically, the radiation scheme used in this model ignores any
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i218[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -232,7 +232,7 @@ comment = Physically, the radiation scheme used in this model ignores any
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i220[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -240,7 +240,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i207[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -248,7 +248,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i208[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -256,7 +256,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i207[lbproc=0] - m01s02i201[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -265,7 +265,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i217[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -274,7 +274,7 @@ component = cftables
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i219[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -283,7 +283,7 @@ component = cftables
 dimension = site time1
 expression = m01s02i205[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -291,7 +291,7 @@ units = W m-2
 dimension = site time1
 expression = m01s02i206[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -299,7 +299,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i218[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -307,7 +307,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i220[lbproc=0])
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -315,7 +315,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i235[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -323,7 +323,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i210[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -331,7 +331,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i207[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -339,7 +339,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i217[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -347,7 +347,7 @@ units = W m-2
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i219[lbproc=0])
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -356,7 +356,7 @@ component = cftables
 dimension = site time1
 expression = m01s01i235[lbproc=0] - m01s01i201[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -364,7 +364,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i211[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -372,7 +372,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i208[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -380,7 +380,7 @@ units = W m-2
 dimension = site time1
 expression = m01s01i209[lbproc=0]
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -395,14 +395,14 @@ component = boundary-layer
 dimension = site time1
 expression = m01s03i298[lbproc=0]
 positive = None
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = kg m-2 s-1
 
 [sci]
 dimension = site time1
 expression = m01s05i270[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = 1
 positive = None
@@ -412,7 +412,7 @@ comment = This is the mean of the speed, not the speed computed from the mean u
 	and v components of wind.
 dimension = site height10m time1
 expression = m01s03i230[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -421,7 +421,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s30i111[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 positive = None
@@ -429,7 +429,7 @@ positive = None
 [tas]
 dimension = site height2m time1
 expression = m01s03i236[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 positive = None
@@ -438,7 +438,7 @@ positive = None
 dimension = site time1
 expression = m01s03i460[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
@@ -446,14 +446,14 @@ units = Pa
 dimension = site time1
 expression = m01s03i461[lbproc=0]
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa
 
 [tnhus]
 dimension = alevel site time1
 expression = m01s30i182[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -462,7 +462,7 @@ positive = None
 dimension = alevel site time1
 expression = (m01s12i182[lbproc=0] + m01s12i382[lbproc=0])
 	/ ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -470,7 +470,7 @@ positive = None
 [tnhusc]
 dimension = alevel site time1
 expression = m01s05i162[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -481,7 +481,7 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
 	+ m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
 	+ m01s04i982[lbproc=0] + m01s05i182[lbproc=0] + m01s16i162[lbproc=0]
 	+ m01s16i182[lbproc=0] + m01s35i025[lbproc=0] ) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -492,7 +492,7 @@ expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0]
 	+ m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0]
 	+ m01s05i182[lbproc=0] - m01s05i162[lbproc=0] + m01s16i162[lbproc=0]
 	+ m01s16i182[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = s-1
 positive = None
@@ -500,7 +500,7 @@ positive = None
 [tnt]
 dimension = alevel site time1
 expression = m01s30i181[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -516,7 +516,7 @@ positive = None
 [tntc]
 dimension = alevel site time1
 expression = m01s05i161[lbproc=0] / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -535,7 +535,7 @@ positive = None
 [tntr]
 dimension = alevel site time1
 expression = (m01s01i161[lbproc=0] + m01s02i161[lbproc=0]) / ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -547,7 +547,7 @@ expression = (m01s03i181[lbproc=0] + m01s04i141[lbproc=0]
 	+ m01s01i181[lbproc=0] - m01s01i161[lbproc=0] + m01s02i181[lbproc=0]
 	- m01s02i161[lbproc=0] + m01s05i181[lbproc=0] - m01s05i161[lbproc=0])
 	/ ATMOS_TIMESTEP
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K s-1
 positive = None
@@ -555,7 +555,7 @@ positive = None
 [ts]
 dimension = site time1
 expression = m01s00i024[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = K
 positive = None
@@ -564,7 +564,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s00i002[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -572,7 +572,7 @@ positive = None
 [uas]
 dimension = site height10m time1
 expression = m01s03i209[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -581,7 +581,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s00i003[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -589,7 +589,7 @@ positive = None
 [vas]
 dimension = site height10m time1
 expression = m01s03i210[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -598,7 +598,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s30i008[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = Pa s-1
 positive = None
@@ -607,7 +607,7 @@ positive = None
 component = cftables
 dimension = alevel site time1
 expression = m01s16i201[lbproc=0]
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_E3hrPt_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_E3hrPt_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [cfadDbze94]
 dimension = longitude latitude alt40 dbze time1
 expression = m01s02i372[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -22,7 +22,7 @@ positive = None
 [cfadLidarsr532]
 dimension = longitude latitude alt40 scatratio time1
 expression = m01s02i370[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -38,7 +38,7 @@ positive = None
 component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i371[lbproc=0] / m01s02i325[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -47,7 +47,7 @@ positive = None
 component = cloud
 dimension = longitude latitude p220 time1
 expression = m01s02i346[blev=P220, lbproc=0] / m01s02i323[blev=P220, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -55,7 +55,7 @@ positive = None
 [clisccp]
 dimension = longitude latitude plev7c tau time1
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -65,7 +65,7 @@ comment = CALIPSO Low Level Cloud Fraction
 component = cloud
 dimension = longitude latitude p840 time1
 expression = m01s02i344[blev=P840, lbproc=0] / m01s02i321[blev=P840, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -74,7 +74,7 @@ positive = None
 component = cloud
 dimension = longitude latitude p560 time1
 expression = m01s02i345[blev=P560, lbproc=0] / m01s02i322[blev=P560, lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -82,7 +82,7 @@ positive = None
 [clmisr]
 dimension = longitude latitude alt16 tau time1
 expression = fix_clmisr_height(m01s02i360[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -91,7 +91,7 @@ positive = None
 component = cloud
 dimension = longitude latitude time1
 expression = m01s02i347[lbproc=0] / m01s02i324[lbproc=0]
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -99,7 +99,7 @@ positive = None
 [hus]
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 positive = None
@@ -114,7 +114,7 @@ positive = None
 [jpdftaureicemodis]
 dimension = longitude latitude plev7c effectRadIc tau time1
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -122,7 +122,7 @@ positive = None
 [jpdftaureliqmodis]
 dimension = longitude latitude plev7c effectRadLi tau time1
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=0], m01s02i330[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -144,7 +144,7 @@ positive = None
 [parasolRefl]
 dimension = longitude latitude sza5 time1
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=0])
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 positive = None
@@ -152,7 +152,7 @@ positive = None
 [ps]
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 positive = None
@@ -214,7 +214,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -223,7 +223,7 @@ positive = None
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0]
 	/ m01s30i301[blev=PLEV7H, lbproc=0]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_E3hr_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_E3hr_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 component = carbon
 dimension = longitude latitude time
 expression = m01s03i261[lbproc=128]
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_EdayZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_EdayZ_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 dimension = latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 positive = None
@@ -24,7 +24,7 @@ positive = None
 dimension = latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -33,7 +33,7 @@ positive = None
 dimension = latitude plev39 time
 expression = m01s30i201[blev=PLEV39, lbproc=192]
 	/ m01s30i301[blev=PLEV39, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -41,7 +41,7 @@ positive = None
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 positive = None
@@ -49,7 +49,7 @@ positive = None
 [utendogw]
 dimension = latitude plev39 time
 expression = m01s06i247[blev=PLEV39, lbproc=192]
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 positive = None
@@ -58,7 +58,7 @@ positive = None
 dimension = latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=192]
 	/ m01s30i301[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -67,7 +67,7 @@ positive = None
 dimension = latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=192]
 	/ m01s30i304[blev=PLEV19, lbproc=192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_Eday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_Eday_mappings.cfg
@@ -16,13 +16,13 @@ status = embargoed
 [hfls]
 expression = land_class_mean(m01s03i330[lbproc=128], m01s03i317[lbproc=128],
     land_class='all')
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 
 [hfss]
 expression = land_class_mean(m01s03i290[lbproc=128], m01s03i317[lbproc=128],
     land_class='all')
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 
 [lai]

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_EmonZ_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_EmonZ_mappings.cfg
@@ -14,7 +14,7 @@ status = embargoed
 [utendnogw]
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-2
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_Emon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_Emon_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 dimension = longitude latitude plev7h time
 expression = m01s30i295[blev=PLEV7H, lbproc=128]
 	/ m01s30i304[blev=PLEV7H, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 positive = None
@@ -25,7 +25,7 @@ comment = Monthly mean orography (needed if land ice has time varying
 	altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None
@@ -33,7 +33,7 @@ positive = None
 [wap]
 dimension = longitude latitude alevel time
 expression = m01s30i008[lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_GA7mon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_GA7mon_mappings.cfg
@@ -13,14 +13,14 @@ status = Internal
 [pr]
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = kg m-2 s-1
 positive = None
 
 [ts]
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128, lbtim=122]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = K
 positive = None
 
@@ -28,7 +28,7 @@ positive = None
 dimension = longitude latitude plev17 time
 expression = m01s30i201[blev=PLEV17, lbproc=128]
 	/ m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = m s-1
 positive = None
 
@@ -36,7 +36,7 @@ positive = None
 dimension = longitude latitude plev17 time
 expression = m01s30i202[blev=PLEV17, lbproc=128]
 	/ m01s30i301[blev=PLEV17, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 units = m s-1
 positive = None
 

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_LImon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_LImon_mappings.cfg
@@ -14,7 +14,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s08i578[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [hflsIs]
@@ -26,7 +26,7 @@ expression = land_class_mean(m01s03i330[lbproc=128],
 	land_class='iceElev')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [hfssIs]
@@ -38,7 +38,7 @@ expression = land_class_mean(m01s03i290[lbproc=128],
 	land_class='iceElev')
 notes = UM, postproc to select area
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [litemptopIs]
@@ -49,7 +49,7 @@ expression = land_class_mean(m01s08i576[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
 notes = HadGEM3_variable_mapping:m01s08i225: UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [mrroIs]
@@ -60,7 +60,7 @@ expression = land_class_mean(m01s08i583[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
 notes = UM: ISMIP snowpack runoff definition not necessarily the same as UM.
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [rldsIs]
@@ -72,7 +72,7 @@ expression = land_class_mean(m01s03i384[lbproc=128],
 	land_class='iceElev')
 notes = UM
 positive = down
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [rlusIs]
@@ -83,7 +83,7 @@ expression = land_class_mean(m01s03i383[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
 positive = up
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = W m-2
 
 [sblIs]
@@ -94,7 +94,7 @@ expression = land_class_mean(m01s03i331[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [sftgif]
@@ -104,7 +104,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128],
 	land_class='iceElev')
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = %
 
 [snicefreezIs]
@@ -115,7 +115,7 @@ expression = land_class_mean(m01s08i580[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snicemIs]
@@ -126,7 +126,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
 notes = UM MO_priority:1:
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [snmIs]
@@ -137,7 +137,7 @@ expression = land_class_mean(m01s08i579[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = kg m-2 s-1
 
 [tasIs]
@@ -148,7 +148,7 @@ expression = land_class_mean(m01s03i328[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 
 [tsIs]
@@ -159,6 +159,6 @@ expression = land_class_mean(m01s03i316[lbproc=128],
 	m01s03i317[lbproc=128],
 	land_class='iceElev')
 notes = UM
-reviewer = Robin Smith <robin.smith@ncas.ac.uk>
+reviewer = Robin Smith (NCAS)
 units = K
 

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_LPmon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_LPmon_mappings.cfg
@@ -16,7 +16,7 @@ comment = Monthly mean orography (needed if land ice has time varying
 	altitude).
 dimension = longitude latitude time
 expression = m01s00i033[lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_Omon_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_Omon_mappings.cfg
@@ -18,7 +18,7 @@ comment = Computed as the total mass of liquid water falling as liquid rain
 	portion of the grid cell.
 dimension = longitude latitude time
 expression = pr
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None
@@ -26,7 +26,7 @@ positive = None
 [prsn]
 dimension = longitude latitude time
 expression = prsn
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_SIday_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_SIday_mappings.cfg
@@ -15,7 +15,7 @@ status = embargoed
 [siconc]
 dimension = longitude latitude typesi time
 expression = aice
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = 1
 

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_day_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_day_mappings.cfg
@@ -16,7 +16,7 @@ component = atmos-physics
 dimension = longitude latitude plev8 time
 expression = m01s30i296[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = %
 positive = None
@@ -25,7 +25,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i295[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 positive = None
@@ -34,7 +34,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i294[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -42,7 +42,7 @@ positive = None
 [sfcWindmax]
 dimension = longitude latitude height10m time
 expression = m01s03i230[lbproc=8192]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -50,7 +50,7 @@ positive = None
 [tasmax]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=8192]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -58,7 +58,7 @@ positive = None
 [tasmin]
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=4096]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 positive = None
@@ -67,7 +67,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i201[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -76,7 +76,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i202[blev=PLEV8, lbproc=128]
 	/ m01s30i301[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 positive = None
@@ -85,7 +85,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i298[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 positive = None
@@ -94,7 +94,7 @@ positive = None
 dimension = longitude latitude plev8 time
 expression = m01s30i297[blev=PLEV8, lbproc=128]
 	/ m01s30i304[blev=PLEV8, lbproc=128]
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 positive = None

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_mappings.cfg
@@ -51,7 +51,7 @@ dimension = longitude latitude lambda550nm time
 expression = m01s02i240[lbplev=3, lbproc=128] + m01s02i241[lbplev=3, lbproc=128] + m01s02i242[lbplev=3, lbproc=128] + m01s02i243[lbplev=3, lbproc=128] + m01s02i585[lbplev=3, lbproc=128]
 mip_table_id = AERmon
 notes = Assuming CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -61,7 +61,7 @@ component = aerosol
 dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i508[lbproc=0] / m01s01i507[lbproc=0], m01s02i508[lbproc=0] / m01s02i507[lbproc=0], minval= '-1.0', maxval= '1.0')
 mip_table_id = E3hrPt
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -71,7 +71,7 @@ component = aerosol
 dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i506[lbproc=0], m01s02i506[lbproc=0], swmask= m01s01i200[lbproc=0], minval= '0', maxval= '10')
 mip_table_id = E3hrPt
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -81,7 +81,7 @@ component = aerosol
 dimension = longitude latitude alevel spectband time1
 expression = combine_sw_lw(m01s01i507[lbproc=0] / m01s01i506[lbproc=0], m01s02i507[lbproc=0] / m01s02i506[lbproc=0], minval='0.0', maxval='1.0')
 mip_table_id = E3hrPt
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = 1
 
@@ -91,7 +91,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = agessc
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = yr
 
@@ -100,7 +100,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = div_by_area(m01s50i063[lbproc=128])
 mip_table_id = AERmon
-reviewer = Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Mohit Dalvi (Met Office)
 status = ok
 units = kg m-2
 
@@ -123,7 +123,7 @@ component = cftables
 dimension = longitude latitude time
 expression = fix_packing_division(m01s02i331[lbproc=128], m01s02i334[lbproc=128])
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -132,7 +132,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = areacella(m01s00i505)
 mip_table_id = fx APfx mon day 6hr 3hr 1hr
-reviewer = Alistair Sellar <alistair.sellar@metoffice.gov.uk>
+reviewer = Alistair Sellar (Met Office)
 status = ok
 units = m2
 
@@ -141,7 +141,7 @@ component = ocean
 dimension = longitude latitude
 expression = areacello
 mip_table_id = Ofx OPfx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -150,7 +150,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i054[lbproc=128]
 mip_table_id = Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = s m-1
 
@@ -160,7 +160,7 @@ dimension = longitude latitude typebare time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='bareSoil')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -170,7 +170,7 @@ component = ocean
 dimension = longitude latitude
 expression = basin
 mip_table_id = Ofx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1
 
@@ -180,7 +180,7 @@ dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T + ZMI_E3T + ZME_E3T + DET_E3T)
 	* FE_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -191,7 +191,7 @@ expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]
 	+ ZMI_E3T[depth=0] + ZME_E3T[depth=0]
 	+ DET_E3T[depth=0]) * FE_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -200,7 +200,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = AERmon 6hrPlev
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -209,7 +209,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = MOLECULAR_MASS_OF_AIR * ((m01s51i045[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BROMINE) + (m01s51i047[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRCL) + (m01s51i048[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRONO2) + (m01s51i052[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HBR) + (m01s51i053[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HOBR) + (m01s51i994[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRO)) / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -219,7 +219,7 @@ dimension = longitude latitude olevel time
 expression = PDS_E3T / thkcello
 mip_table_id = Omon
 notes = AXY: mostly a units thing; overlooking fast detritus Si
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -228,7 +228,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = PDS_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -238,7 +238,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C2H6) * m01s34i014[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -248,7 +248,7 @@ dimension = longitude latitude typec3pft time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='c3')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -258,7 +258,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C3H8) * m01s34i018[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -268,7 +268,7 @@ dimension = longitude latitude typec4pft time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='c4')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -279,8 +279,8 @@ expression = m01s19i002[lbtim_ia=240,lbproc=128] + m01s19i016[lbtim_ia=240,lbpro
 	+ m01s19i032[lbtim_ia=240,lbproc=128] + m01s19i033[lbtim_ia=240,lbproc=128]
 	+ m01s19i034[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -289,8 +289,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i026[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -300,8 +300,8 @@ dimension = longitude latitude time
 expression = m01s19i032[lbtim_ia=240,lbproc=128] + m01s19i033[lbtim_ia=240,lbproc=128]
 	+ m01s19i034[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -310,8 +310,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i030[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -320,8 +320,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i016[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -331,7 +331,7 @@ dimension = longitude latitude time
 expression = m01s19i021[lbtim_ia=240,lbproc=128] + m01s19i022[lbtim_ia=240,lbproc=128]
 	+ m01s19i023[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2
 
@@ -340,7 +340,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i024[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2
 
@@ -349,8 +349,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i028[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -359,8 +359,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i002[lbtim_ia=240,lbproc=128]
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -370,8 +370,8 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='grass')
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -381,7 +381,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -391,7 +391,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -401,7 +401,7 @@ component = cloud
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128], m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -411,7 +411,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s01i241[lbproc=128] / m01s01i223[lbproc=128]
 mip_table_id = AERmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -420,7 +420,7 @@ component = cloud
 dimension = longitude latitude alt40 dbze time
 expression = m01s02i372[lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -429,7 +429,7 @@ component = cloud
 dimension = longitude latitude alt40 scatratio time
 expression = m01s02i370[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -439,7 +439,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CFC11_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = umol m-3
 
@@ -448,7 +448,7 @@ component = chemistry
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i055[lbproc=128], MOLECULAR_MASS_OF_CFC11)
 mip_table_id = Amon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -458,7 +458,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CFC12_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = umol m-3
 
@@ -467,7 +467,7 @@ component = chemistry
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i056[lbproc=128], MOLECULAR_MASS_OF_CFC12)
 mip_table_id = Amon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -476,7 +476,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH3COCH3) * m01s34i022[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -485,7 +485,7 @@ component = chemistry
 dimension = longitude latitude plev19 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4) * m01s51i009[blev=PLEV19, lbproc=128] / m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -494,7 +494,7 @@ component = chemistry
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i009[lbproc=128], MOLECULAR_MASS_OF_CH4)
 mip_table_id = Amon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -505,7 +505,7 @@ dimension = longitude latitude alevel time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, (m01s38i201[lbproc=128] + m01s38i202[lbproc=128] + m01s38i203[lbproc=128] + m01s38i285[lbproc=128] + m01s38i286[lbproc=128] + m01s38i288[lbproc=128] + m01s38i289[lbproc=128]), areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -515,7 +515,7 @@ dimension = longitude latitude alevel time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s50i150[lbproc=128], areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -524,7 +524,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (CHN_E3T + CHD_E3T) / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -533,7 +533,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CHD_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -542,7 +542,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = CHD_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -551,7 +551,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CHN_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -560,7 +560,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = CHN_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -573,7 +573,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (CHN_E3T[depth=0] + CHD_E3T[depth=0]) / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-3
 
@@ -582,7 +582,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i269[lbproc=128]
 mip_table_id = Amon
-reviewer = Mark Webb <mark.webb@metoffice.gov.uk>
+reviewer = Mark Webb (Met Office)
 status = ok
 units = 1
 
@@ -591,7 +591,7 @@ component = cftables cloud
 dimension = longitude latitude alevel time
 expression = m01s02i261[lbproc=128]
 mip_table_id = Amon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -601,7 +601,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i317[lbproc=128]
 mip_table_id = CFmon
 notes = Using convective cores in this model configuration.
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -610,7 +610,7 @@ component = cftables
 dimension = longitude latitude alt40 time
 expression = m01s02i371[lbproc=128] / m01s02i325[lbproc=128]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -619,7 +619,7 @@ component = cloud
 dimension = longitude latitude alt40 time1
 expression = m01s02i374[lbproc=0] / m01s02i325[lbproc=0]
 mip_table_id = E3hrPt
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -650,7 +650,7 @@ dimension = longitude latitude time
 expression = m01s01i280[lbproc=128] / m01s01i281[lbproc=128]
 mip_table_id = Emon Eday
 notes = Calculated at daylight grids only.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-2
 
@@ -659,7 +659,7 @@ component = cftables
 dimension = longitude latitude p220 time
 expression = m01s02i346[lbproc=128, blev=P220] / m01s02i323[lbproc=128, blev=P220]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -669,7 +669,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i309[lbproc=128]
 mip_table_id = Amon CFday
 notes = When McICA is used with convective cores, the large-scale diagnostics contain all condensate. No need to add convective because the convection diagnostics contain zeroes.
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -678,7 +678,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i319[lbproc=128]
 mip_table_id = CFmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -687,7 +687,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i453[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -705,7 +705,7 @@ dimension = longitude latitude plev7c tau time
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=128],
 	m01s02i330[lbproc=128])
 mip_table_id = CFmon CFday APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -714,7 +714,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i392[lbproc=128]
 mip_table_id = Amon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -723,7 +723,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i396[lbproc=128]
 mip_table_id = Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -732,7 +732,7 @@ component = cftables
 dimension = longitude latitude p840 time
 expression = m01s02i344[lbproc=128, blev=P840] / m01s02i321[lbproc=128, blev=P840]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -742,7 +742,7 @@ dimension = longitude latitude p560 time
 expression = m01s02i345[lbproc=128, blev=P560]
 	/ m01s02i322[lbproc=128, blev=P560]
 mip_table_id = CFday CFmon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -751,7 +751,7 @@ component = cloud
 dimension = longitude latitude alt16 tau time
 expression = fix_clmisr_height(m01s02i360[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -761,7 +761,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i312[lbproc=128] + m01s02i313[lbproc=128]
 	- m01s02i317[lbproc=128]
 mip_table_id = CFmon APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -770,7 +770,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i204[lbproc=128]
 mip_table_id = Amon 3hr day
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -779,7 +779,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i347[lbproc=128] / m01s02i324[lbproc=128]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -788,7 +788,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i334[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -797,7 +797,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i451[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -807,7 +807,7 @@ dimension = longitude latitude alevel time
 expression = m01s02i308[lbproc=128]
 mip_table_id = Amon CFday
 notes = When McICA is used with convective cores, the large-scale diagnostics contain all condensate. No need to add convective because the convection diagnostics contain zeroes.
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg kg-1
 
@@ -816,7 +816,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i318[lbproc=128]
 mip_table_id = CFmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -825,7 +825,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i452[lbproc=128] / m01s02i330[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -842,7 +842,7 @@ component = cftables cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128] + m01s02i392[lbproc=128]
 mip_table_id = Amon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -851,7 +851,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i395[lbproc=128] + m01s02i396[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -860,7 +860,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = MOLECULAR_MASS_OF_AIR * ((m01s51i041[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CHLORINE) + (m01s51i042[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CLOX) + (2 * m01s51i043[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CL2O2) + (m01s51i044[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_OCLO) + (m01s51i047[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRCL) + (m01s51i051[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HOCL) + (m01s51i054[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CLONO2) + (m01s51i992[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HCL)) / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -869,7 +869,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO) * m01s34i010[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -879,7 +879,7 @@ dimension = longitude latitude alevel time
 expression = m01s00i252[lbproc=128]
 	* (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO2)
 mip_table_id = AERmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = mol mol-1
 
@@ -889,7 +889,7 @@ dimension = longitude latitude alevel time
 expression = m01s00i252[lbproc=128]
 mip_table_id = Emon
 notes = Available from emissions-driven runs only.
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg kg-1
 
@@ -899,7 +899,7 @@ component = carbon
 dimension = time
 expression = m01s30i465[lbproc=128]
 mip_table_id = Amon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg
 
@@ -910,7 +910,7 @@ expression = m01s00i252[lblev=1, lbproc=128]
 	* (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO2)
 mip_table_id = Emon
 notes = Available from emissions-driven runs only.
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = mol mol-1
 
@@ -921,7 +921,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CO33
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -934,7 +934,7 @@ expression = CO33 / CO3SATARAG3
 mip_table_id = Omon
 notes = AXY: think this needs calculating; but should it be?;
 	MEDUSA ignores aragonite.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -952,7 +952,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = CO33 / CO3SATCALC3
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -968,7 +968,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i332[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = AERmon AERday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -981,7 +981,7 @@ expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP
 	* (m01s38i507[lbproc=128] + m01s38i510[lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-3
 
@@ -994,7 +994,7 @@ expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP
 	+ m01s38i506[lbproc=128] + m01s38i507[lbproc=128] + m01s38i508[lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-3
 
@@ -1003,7 +1003,7 @@ component = dust
 dimension = longitude latitude alevel time
 expression = m01s17i257[lbproc=128]
 mip_table_id = Emon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -1014,7 +1014,7 @@ dimension = longitude latitude alevel time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i504[lbproc=128]
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-3
 
@@ -1024,8 +1024,8 @@ dimension = longitude latitude time typecrop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
 	land_class='crop')
 mip_table_id = Lmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1035,7 +1035,7 @@ dimension = longitude latitude time typec3crop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
 	land_class='c3Crop')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1045,7 +1045,7 @@ dimension = longitude latitude time typec4crop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
 	land_class='c4Crop')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -1054,7 +1054,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i209[lbproc=128]
 mip_table_id = Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -1064,7 +1064,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s03i440[lbproc=128]
 mip_table_id = Emon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1073,7 +1073,7 @@ component = ocean
 dimension = longitude latitude
 expression = deptho
 mip_table_id = Ofx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -1084,7 +1084,7 @@ expression = DTC_E3T / thkcello
 mip_table_id = Omon
 notes = AXY: partly a units thing, but need to modify code to produce
 	combined slow- and fast-sinking detritus.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1100,7 +1100,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = FER_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1109,7 +1109,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = FER_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1141,7 +1141,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = DIC_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -1157,7 +1157,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i071[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_DMS)
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -1166,7 +1166,7 @@ component = obgc
 dimension = longitude latitude time
 expression = DMS_SURF
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = nmol L-1
 
@@ -1175,7 +1175,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = OCN_PCO2 - ATM_PCO2
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = uatm
 
@@ -1187,8 +1187,8 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C,
 	+ m01s38i222[lbproc=128] + m01s38i223[lbproc=128],
 	sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>,
-	Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Nicolas Bellouin (University of Reading),
+	Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -1199,7 +1199,7 @@ dimension = longitude latitude time
 expression = m01s03i441[lbproc=128] + m01s03i442[lbproc=128] + m01s03i443[lbproc=128] + m01s03i444[lbproc=128] + m01s03i445[lbproc=128] + m01s03i446[lbproc=128] + m01s03i451[lbproc=128] + m01s03i452[lbproc=128] + m01s03i453[lbproc=128] + m01s03i454[lbproc=128] + m01s03i455[lbproc=128] + m01s03i456[lbproc=128]
 mip_table_id = AERmon
 notes = Assumes CLASSIC dust.
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1208,7 +1208,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_O3, m01s50i131[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = g m-2 s-1
 
@@ -1221,7 +1221,7 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C * CONV_C_ORGM,
 	+ m01s38i227[lbproc=128] + m01s38i228[lbproc=128],
 	sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -1231,7 +1231,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO2,
 	m01s50i154[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -1243,7 +1243,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
 	+ m01s38i217[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -1254,7 +1254,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL,
 	m01s38i218[lbproc=128] + m01s38i219[lbproc=128],
 	sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -1263,7 +1263,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1272,7 +1272,7 @@ component = aerosol
 dimension = longitude latitude alevel lambda550nm time
 expression = m01s02i530[lbplev=3, lbproc=128] + m01s02i540[lbplev=3, lbproc=128]
 mip_table_id = Emon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = m-1
 
@@ -1281,7 +1281,7 @@ component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C, m01s38i207[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -1291,7 +1291,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (m01s03i495[lbproc=128] + m01s03i496[lbproc=128]) * m01s00i505
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>, Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -1300,7 +1300,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i158[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -1309,7 +1309,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i214[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = kg m-2 s-1
 
@@ -1320,7 +1320,7 @@ dimension = longitude latitude time
 expression = m01s03i401[lbproc=128] + m01s03i402[lbproc=128] + m01s03i403[lbproc=128] + m01s03i404[lbproc=128] + m01s03i405[lbproc=128] + m01s03i406[lbproc=128]
 mip_table_id = AERmon
 notes = Assumes CLASSIC dust.
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1330,7 +1330,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_ISOPRENE / (5.0 * ATOMIC_MASS_OF_C)) * (m01s03i495[lbproc=128] * m01s00i505)
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>, Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Guang Zeng (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -1339,7 +1339,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i081[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol s-1
 
@@ -1349,7 +1349,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = achem_emdrywet(1.0, m01s50i172[lbproc=128], cube2d=m01s50i156[lbproc=128], sumlev='True')
 mip_table_id = AERmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -1362,7 +1362,7 @@ expression = achem_emdrywet( ATOMIC_MASS_OF_C * CONV_C_ORGM,
 	+ m01s38i302[lbproc=128] + m01s38i303[lbproc=128] + m01s38i304[lbproc=128]
 	+ m01s38i305[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -1373,7 +1373,7 @@ expression = achem_emdrywet(1.0,
 	m01s50i217[lbproc=128], cube2d=(m01s50i215[lbproc=128]
 	+ m01s50i216[lbproc=128]), sumlev='True')
 mip_table_id = AERmon AEmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = kg m-2 s-1
 
@@ -1383,7 +1383,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s38i201[lbproc=128] + m01s38i202[lbproc=128] + m01s38i203[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -1392,7 +1392,7 @@ component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL, m01s38i204[lbproc=128] + m01s38i205[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -1401,7 +1401,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = ((m01s50i159[lbproc=128] / MOLECULAR_MASS_OF_HCHO) + (m01s50i160[lbproc=128] * (2.0 / MOLECULAR_MASS_OF_C2H6)) + (m01s50i161[lbproc=128] * (3.0 / MOLECULAR_MASS_OF_C3H8)) + (m01s50i162[lbproc=128] * (3.0 / MOLECULAR_MASS_OF_ME2CO)) + (m01s50i163[lbproc=128] * (2.0 / MOLECULAR_MASS_OF_MECHO)) + (m01s50i212[lbproc=128] / MOLECULAR_MASS_OF_MEOH) + (m01s50i300[lbproc=128] * (5.0 / MOLECULAR_MASS_OF_ISOPRENE)) + (m01s50i301[lbproc=128] * (10.0 / MOLECULAR_MASS_OF_MONOTERPENE))) * ATOMIC_MASS_OF_C
 mip_table_id = AERmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = kg m-2 s-1
 
@@ -1418,7 +1418,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epC100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1428,7 +1428,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epCALC100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1438,7 +1438,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epN100 * FE_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1447,7 +1447,7 @@ component = atmos-physics
 dimension = latitude plev39 time
 expression = scale_epflux(m01s30i312[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -1457,7 +1457,7 @@ dimension = latitude plev39 time
 expression = scale_epflux(m01s30i313[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ
 positive = up
-reviewer = Scott Osprey <Scott.Osprey@physics.ox.ac.uk>
+reviewer = Scott Osprey (University of Oxford)
 status = ok
 units = m3 s-2
 
@@ -1467,7 +1467,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epN100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1478,7 +1478,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epN100 * P_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1488,7 +1488,7 @@ component = obgc
 dimension = longitude latitude depth100m time
 expression = epSI100
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1497,7 +1497,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i296[lbproc=128]
 mip_table_id = Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1506,7 +1506,7 @@ component = ocean
 dimension = longitude latitude time
 expression = correct_evaporation(evs, sowaflup - (evs - (ficeberg + friver + prsn + pr + fsitherm) ), areacello)
 mip_table_id = Omon
-reviewer = Dave Storkey <dave.storkey@metoffice.gov.uk>
+reviewer = Dave Storkey (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1515,7 +1515,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i223[lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>, Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1524,7 +1524,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i334[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1533,7 +1533,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i296[lbproc=128] + m01s03i298[lbproc=128] - m01s03i539[lbproc=128]
 mip_table_id = Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1542,7 +1542,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
 mip_table_id = Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1554,7 +1554,7 @@ dimension = longitude latitude olevel time
 expression = EXPC3
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1566,7 +1566,7 @@ dimension = longitude latitude olevel time
 expression = FD_CAL3
 mip_table_id = Emon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1580,7 +1580,7 @@ mip_table_id = Emon
 notes = AXY: already post-processable, but would be better if sinking fluxes
 	are done more systematically; see earlier remarks.
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1594,7 +1594,7 @@ mip_table_id = Emon
 notes = AXY: already post-processable, but would be better if sinking fluxes
 	are done more systematically; see earlier remarks.
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1608,7 +1608,7 @@ dimension = longitude latitude olevel time
 expression = EXPN3 * P_TO_N_RATIO
 mip_table_id = Emon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1620,7 +1620,7 @@ dimension = longitude latitude olevel time
 expression = FD_SIL3
 mip_table_id = Emon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -1629,7 +1629,7 @@ component = land-use
 dimension = longitude latitude time
 expression = (m01s19i044[lbtim_ia=240,lbproc=128])/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1639,8 +1639,8 @@ dimension = longitude latitude time
 expression = m01s19i113[lbtim_ia=240,lbproc=128]
 	/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1652,8 +1652,8 @@ expression = (m01s19i036[lbtim_ia=240,lbproc=128]
 	+ m01s19i038[lbtim_ia=240,lbproc=128])
 	/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1663,7 +1663,7 @@ dimension = longitude latitude time
 expression = m01s19i044[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1673,8 +1673,8 @@ dimension = longitude latitude time
 expression = m01s19i044[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1686,7 +1686,7 @@ expression = (m01s19i039[lbtim_ia=240,lbproc=128]
 	+ m01s19i041[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1696,8 +1696,8 @@ dimension = longitude latitude time
 expression = (m01s19i120[lbtim_ia=240,lbproc=128] + m01s19i122[lbtim_ia=240,lbproc=128])
 	/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1706,7 +1706,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i122[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1715,8 +1715,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i124[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1725,8 +1725,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i126[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1735,8 +1735,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i117[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1745,8 +1745,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i117[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1755,8 +1755,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i114[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1765,8 +1765,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i118[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1776,8 +1776,8 @@ dimension = longitude latitude time
 expression = (m01s19i181[lbtim_ia=240,lbproc=128] - m01s19i171[lbtim_ia=240,lbproc=128])
 	/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1787,7 +1787,7 @@ dimension = longitude latitude time
 expression = (m01s19i160[lbtim_ia=240,lbproc=128] - m01s19i113[lbtim_ia=240,lbproc=128])
 	/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1796,7 +1796,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i042[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1805,8 +1805,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i005[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1815,7 +1815,7 @@ component = obgc
 dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_ALK_E3T, thkcello)
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 s-1
 
@@ -1824,7 +1824,7 @@ component = obgc
 dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_DiC_E3T, thkcello)
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 s-1
 
@@ -1833,7 +1833,7 @@ component = obgc
 dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_FER_E3T, thkcello)
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 s-1
 
@@ -1842,7 +1842,7 @@ component = obgc
 dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_DIN_E3T, thkcello)
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 s-1
 
@@ -1854,7 +1854,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_DIN_E3T, thkcello)
 	* P_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 s-1
 
@@ -1865,7 +1865,7 @@ component = obgc
 dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(SMS_SIL_E3T, thkcello)
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 s-1
 
@@ -1879,7 +1879,7 @@ expression = m01s00i251[lbproc=128]
 	+ mdi_to_zero(m01s19i044[lbtim_ia=240,lbproc=128])) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Amon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1890,7 +1890,7 @@ expression = m01s00i251[lbproc=128]
 	* (ATOMIC_MASS_OF_C / MOLECULAR_MASS_OF_CO2)
 mip_table_id = Amon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1911,7 +1911,7 @@ notes = For emissions driven runs. The land fraction use here is being sampled
 	every 6 hours rather than being a true time average. However, this appears
 	to be a constant field so there is no impact for current model configurations.
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -1945,7 +1945,7 @@ component = obgc
 dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(TOT_DIN_E3T, thkcello)
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 s-1
 
@@ -1957,7 +1957,7 @@ dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(TOT_DIN_E3T, thkcello)
 	* P_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 s-1
 
@@ -1968,7 +1968,7 @@ component = obgc
 dimension = longitude latitude olayer100m time
 expression = sum_over_upper_100m(TOT_SIL_E3T, thkcello)
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 s-1
 
@@ -1979,7 +1979,7 @@ dimension = longitude latitude time
 expression = qtrCFC11
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mol m-2 s-1
 
@@ -1990,7 +1990,7 @@ dimension = longitude latitude time
 expression = qtrCFC12
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mol m-2 s-1
 
@@ -2000,8 +2000,8 @@ dimension = longitude latitude time depth0m
 expression = CO2FLUX * ATOMIC_MASS_OF_C
 mip_table_id = Omon
 positive = down
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andrew Yool <axy@noc.ac.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andrew Yool (NOC)
 status = ok
 units = mg m-2 d-1
 
@@ -2012,7 +2012,7 @@ dimension = longitude latitude depth0m time
 expression = calc_fgdms(m01s00i505, m01s50i214[lbproc=128] / MOLECULAR_MASS_OF_DMS )
 mip_table_id = Omon
 positive = up
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = kmol m-2 s-1
 
@@ -2022,7 +2022,7 @@ dimension = longitude latitude time depth0m
 expression = O2FLUX
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2033,7 +2033,7 @@ dimension = longitude latitude time
 expression = qtrSF6
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mol m-2 s-1
 
@@ -2043,7 +2043,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(ficeberg, -1*vowflisf)
 mip_table_id = Omon
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2059,7 +2059,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = div_by_area(m01s50i082[lbproc=128])
 mip_table_id = Emon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>, Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (Met Office)
 status = ok
 units = m-2 min-1
 
@@ -2068,7 +2068,7 @@ component = land-use
 dimension = longitude latitude landUse time
 expression = land_use_tile_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = %
 
@@ -2077,7 +2077,7 @@ component = obgc
 dimension = longitude latitude time
 expression = IBEN_CA
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2086,7 +2086,7 @@ component = ocean
 dimension = longitude latitude time
 expression = friver
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2095,7 +2095,7 @@ component = obgc
 dimension = longitude latitude time
 expression = IBEN_C
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2105,7 +2105,7 @@ dimension = longitude latitude time depth0m
 expression = AEOLIAN + BENTHIC
 mip_table_id = Omon
 positive = down
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2114,7 +2114,7 @@ component = seaice
 dimension = longitude latitude time
 expression = fsitherm
 mip_table_id = Omon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2123,7 +2123,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i183[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2134,8 +2134,8 @@ expression = land_class_mean(
 	m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2146,7 +2146,7 @@ expression = land_use_tile_mean(
 	m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2157,8 +2157,8 @@ expression = land_class_mean(
 	m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2169,8 +2169,8 @@ expression = land_class_mean(
 	m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -2180,7 +2180,7 @@ dimension = longitude latitude typenatgr time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
 	land_class='grass')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2190,7 +2190,7 @@ dimension = longitude latitude typec3pft typenatgr time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
 	m01s03i395[lbproc=128], land_class='c3Grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2200,7 +2200,7 @@ dimension = longitude latitude typec4pft typenatgr time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
 	m01s03i395[lbproc=128], land_class='c4Grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -2211,7 +2211,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (MIGRAZP3 + MEGRAZP3) * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -2227,7 +2227,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCHO) * m01s34i011[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2236,7 +2236,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL) * m01s34i992[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2248,7 +2248,7 @@ expression = combine_cubes_to_basin_coord(hfbasin_global, hfbasin_atlantic,
 	hfbasin_indopacific, mask_global=global_ocean_1D_V,
 	mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon OPmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -2258,7 +2258,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpadv_global, hfbasinpadv_atlantic, hfbasinpadv_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -2268,7 +2268,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpmadv_global, hfbasinpmadv_atlantic, hfbasinpmadv_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -2278,7 +2278,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpmdiff_global, hfbasinpmdiff_atlantic, hfbasinpmdiff_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -2288,7 +2288,7 @@ dimension = longitude latitude time
 expression = hfds
 mip_table_id = Omon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2306,7 +2306,7 @@ dimension = longitude latitude time
 expression = hfevapds
 mip_table_id = Omon
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2316,7 +2316,7 @@ dimension = longitude latitude
 expression = hfgeou
 mip_table_id = Ofx
 positive = up
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2326,7 +2326,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(-1*berg_latent_heat_flux, vohflisf)
 mip_table_id = Omon
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -2336,7 +2336,7 @@ dimension = longitude latitude time
 expression = m01s03i234[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -2346,7 +2346,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i330[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -2356,7 +2356,7 @@ dimension = longitude latitude time
 expression = hfrainds
 mip_table_id = Omon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -2366,7 +2366,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(hflx_rnf, -1*vohfcisf)
 mip_table_id = Omon
-reviewer = Pierre Mathiot <pierre.mathiot@metoffice.gov.uk>
+reviewer = Pierre Mathiot (Met Office)
 status = ok
 units = W m-2
 
@@ -2383,7 +2383,7 @@ dimension = longitude latitude time
 expression = m01s03i217[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = up
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = W m-2
 
@@ -2393,7 +2393,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i290[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -2402,7 +2402,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfx, mask_2D_U)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -2411,7 +2411,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mask_copy(hfy, mask_2D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W
 
@@ -2420,7 +2420,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3) * m01s34i007[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2429,7 +2429,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HO2) * m01s51i082[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol mol-1
 
@@ -2439,7 +2439,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfovgyre_global, hfovgyre_atlantic, hfovgyre_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -2449,7 +2449,7 @@ component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfovovrt_global, hfovovrt_atlantic, hfovovrt_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = PW
 
@@ -2458,7 +2458,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i113[lbproc=128]
 mip_table_id = CFday CFmon APdayLev APmonLev
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = %
 
@@ -2586,7 +2586,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i245[lbproc=128]
 mip_table_id = Amon day 6hrPlev
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = %
 
@@ -2618,7 +2618,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -2677,7 +2677,7 @@ dimension = longitude latitude plev27 time
 expression = m01s30i295[blev=PLEV27, lbproc=128]
 	/ m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -2750,7 +2750,7 @@ component = atmos-physics
 dimension = longitude latitude plev7h time1
 expression = m01s30i295[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -2759,7 +2759,7 @@ component = atmos-physics
 dimension = longitude latitude p850 time
 expression = m01s30i295[blev=P850, lbproc=128] / m01s30i304[blev=P850, lbproc=128]
 mip_table_id = GCAmon GCday Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1
 
@@ -2775,7 +2775,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i237[lbproc=128]
 mip_table_id = Amon day
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = 1
 
@@ -2784,7 +2784,7 @@ component = land-use
 dimension = longitude latitude height2m landUse time
 expression = land_use_tile_mean(m01s03i329[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = 1
 
@@ -2793,7 +2793,7 @@ component = obgc
 dimension = longitude latitude time
 expression = INTDISSIC * ATOMIC_MASS_OF_C
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-2
 
@@ -2802,7 +2802,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (PRN + PRD) * FE_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2811,7 +2811,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PRN + PRD
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2822,7 +2822,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (PRN + PRD) * P_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2831,7 +2831,7 @@ component = obgc
 dimension = longitude latitude time
 expression = OPAL
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2840,7 +2840,7 @@ component = obgc
 dimension = longitude latitude time
 expression = FASTCA
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2851,7 +2851,7 @@ expression = (((INT_PN + INT_PD) * C_TO_N_RATIO)
 	+ ((INT_ZMI + INT_ZME) * C_TO_N_RATIO_ZOO)
 	+ INT_DTC) * ATOMIC_MASS_OF_C
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mg m-2
 
@@ -2860,7 +2860,7 @@ component = obgc
 dimension = longitude latitude time
 expression = (PRN + PRD) * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2869,7 +2869,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PRD * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2878,7 +2878,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PRN * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-2 d-1
 
@@ -2894,7 +2894,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i462[lbproc=128]
 mip_table_id = Emon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -2910,7 +2910,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i463[lbproc=128]
 mip_table_id = Emon
-reviewer = Jeff Ridley <jeff.ridley@metoffice.gov.uk>
+reviewer = Jeff Ridley (Met Office)
 status = ok
 units = kg m-1 s-1
 
@@ -2919,7 +2919,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_ISOPRENE) * m01s34i027[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -2928,7 +2928,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i229[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -2937,7 +2937,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = m01s52i245[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -2946,7 +2946,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = m01s52i246[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -2955,7 +2955,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadIc tau time
 expression = jpdftaure_divide_by_mask(m01s02i469[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -2964,7 +2964,7 @@ component = cloud
 dimension = longitude latitude plev7c effectRadLi tau time
 expression = jpdftaure_divide_by_mask(m01s02i468[lbproc=128], m01s02i330[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -2975,7 +2975,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i014[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='veg')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = 1
 
@@ -2984,7 +2984,7 @@ component = land-use
 dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s19i014[lbtim_ia=240,lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = 1
 
@@ -2993,7 +2993,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PD_FELIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -3002,7 +3002,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PN_FELIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -3011,7 +3011,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PD_JLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -3020,7 +3020,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PN_JLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -3029,7 +3029,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PD_NLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -3038,7 +3038,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PN_NLIM
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -3048,7 +3048,7 @@ dimension = longitude latitude time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i525[lbproc=128]
 mip_table_id = Eday
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -3057,7 +3057,7 @@ component = dust
 dimension = longitude latitude time
 expression = calc_loaddust(m01s17i257[lbproc=128], m01s50i255[lbproc=128])
 mip_table_id = Emon Eday APday APmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -3067,7 +3067,7 @@ dimension = longitude latitude time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i531[lbproc=128]
 mip_table_id = Eday
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -3079,7 +3079,7 @@ expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4)
 	* m01s38i520[lbproc=128]
 mip_table_id = Eday Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -3089,7 +3089,7 @@ dimension = longitude latitude time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i539[lbproc=128]
 mip_table_id = Eday Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2
 
@@ -3099,7 +3099,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i247[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -3109,7 +3109,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i071[lbproc=128] / m01s50i255[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -3118,7 +3118,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2
 
@@ -3128,7 +3128,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = masscello
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2
 
@@ -3137,7 +3137,7 @@ component = ocean
 dimension = time
 expression = scvoltot * SEAWATER_DENSITY
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg
 
@@ -3146,7 +3146,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=8192]
 mip_table_id = AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -3155,7 +3155,7 @@ dimension = longitude latitude alevhalf time
 expression = (m01s05i250[lbproc=128] - m01s05i251[lbproc=128]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = Amon CFday
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3164,7 +3164,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i251[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon
 positive = down
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3173,7 +3173,7 @@ dimension = longitude latitude alevhalf time
 expression = m01s05i250[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
 mip_table_id = CFmon
 positive = up
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3183,7 +3183,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = (m01s51i150[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = AERmonZ
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = yr
 
@@ -3192,7 +3192,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=4096]
 mip_table_id = AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -3201,7 +3201,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotst
 mip_table_id = Omon Eday
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -3210,7 +3210,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmax
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -3219,7 +3219,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstmin
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -3228,7 +3228,7 @@ component = ocean
 dimension = longitude latitude time
 expression = mlotstsq
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -3238,7 +3238,7 @@ dimension = longitude latitude alevel time
 expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP * m01s38i545[lbproc=128]
 mip_table_id = AERmon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -3248,7 +3248,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i105[lbproc=128] + m01s34i109[lbproc=128] + m01s34i115[lbproc=128] + m01s34i120[lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -3257,7 +3257,7 @@ component = dust
 dimension = longitude latitude alevel time
 expression = m01s00i431[lbproc=128] + m01s00i432[lbproc=128] + m01s00i433[lbproc=128] + m01s00i434[lbproc=128] + m01s00i435[lbproc=128] + m01s00i436[lbproc=128]
 mip_table_id = AERmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = kg kg-1
 
@@ -3267,7 +3267,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i106[lbproc=128] + m01s34i110[lbproc=128] + m01s34i116[lbproc=128] + m01s34i121[lbproc=128] + m01s34i126[lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -3276,7 +3276,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4) * (m01s34i102[lbproc=128] + m01s34i104[lbproc=128] + m01s34i108[lbproc=128] + m01s34i114[lbproc=128])
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -3285,7 +3285,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i111[lbproc=128] + m01s34i117[lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg kg-1
 
@@ -3294,7 +3294,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128] * m01s08i230[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Lmon
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -3317,7 +3317,7 @@ component = land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128] * m01s08i229[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
 mip_table_id = Emon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -3326,7 +3326,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128] + m01s08i235[lbproc=128]
 mip_table_id = 3hr day Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3335,7 +3335,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i235[lbproc=128]
 mip_table_id = GCLmon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3344,7 +3344,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128]
 mip_table_id = Lmon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3353,7 +3353,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i230[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -3362,7 +3362,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i229[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -3371,7 +3371,7 @@ component = land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128])
 mip_table_id = day Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -3381,7 +3381,7 @@ component = land
 dimension = longitude latitude
 expression = mask_zeros(m01s00i041 * FRESHWATER_DENSITY)
 mip_table_id = fx
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = kg m-2
 
@@ -3390,7 +3390,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>, Eleanor Burke <eleanor.burke@metoffice.gov.uk
+reviewer = Ron Kahana (Met Office), Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = kg m-2
 
@@ -3399,7 +3399,7 @@ component = land
 dimension = longitude latitude sdepth1 time
 expression = m01s08i223[blev=0.05, lbproc=128]
 mip_table_id = day Lmon
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2
 
@@ -3409,7 +3409,7 @@ component = ocean
 dimension = longitude latitude time
 expression = ocean_quasi_barotropic_streamfunc(umo_vint, areacello, cube_mask=mask_2D_T)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -3419,7 +3419,7 @@ component = ocean
 dimension = latitude basin olevel time
 expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfglo, zomsfatl, zomsfipc, mask_global=global_ocean_2D_V, mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -3429,7 +3429,7 @@ component = ocean
 dimension = latitude basin olevel time
 expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfeivglo, zomsfeivatl, zomsfeivipc, mask_global=global_ocean_2D_V, mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = sverdrup kg m-3
 
@@ -3438,7 +3438,7 @@ component = chemistry
 dimension = longitude latitude plev19 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O) * m01s51i049[blev=PLEV19, lbproc=128] / m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3447,7 +3447,7 @@ component = chemistry
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i049[lbproc=128], MOLECULAR_MASS_OF_N2O)
 mip_table_id = Amon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = 1
 
@@ -3456,8 +3456,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i147[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -3468,7 +3468,7 @@ expression = land_class_mean(m01s19i132[lbtim_ia=240,lbproc=128], m01s19i013[lbt
 	land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
 	m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -3477,8 +3477,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i146[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -3489,7 +3489,7 @@ expression = land_class_mean(m01s19i133[lbtim_ia=240,lbproc=128], m01s19i013[lbt
 	land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
 	m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -3498,8 +3498,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i145[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -3510,7 +3510,7 @@ expression = land_class_mean(m01s19i131[lbtim_ia=240,lbproc=128], m01s19i013[lbt
 	land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],
 	m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -3519,8 +3519,8 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s19i137[lbtim_ia=240,lbproc=128]
 mip_table_id = Emon
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2
 
@@ -3534,8 +3534,8 @@ expression = (m01s19i102[lbtim_ia=240,lbproc=128]
 	/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = down
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3547,7 +3547,7 @@ expression = (m01s19i102[lbtim_ia=240,lbproc=128] - m01s19i053[lbtim_ia=240,lbpr
 	/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Emon
 positive = down
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3556,7 +3556,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO) * m01s34i002[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3565,7 +3565,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2) * m01s34i996[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3576,7 +3576,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = DIN_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -3587,7 +3587,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = DIN_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -3608,7 +3608,7 @@ expression = MOLECULAR_MASS_OF_AIR
 	+ (m01s51i996[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO2))
 	/ m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = AERmonZ
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>
+reviewer = Luke Abraham (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3618,7 +3618,7 @@ dimension = longitude latitude time
 expression = m01s19i102[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = down
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3629,7 +3629,7 @@ expression = land_class_mean(
 	m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3640,7 +3640,7 @@ expression = land_use_tile_mean(
 	m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3651,7 +3651,7 @@ expression = land_class_mean(
 	m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3662,7 +3662,7 @@ expression = land_class_mean(
 	m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3671,7 +3671,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = OXY_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -3688,7 +3688,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = OXY_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -3699,7 +3699,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = O2SAT3
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -3710,7 +3710,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = O2SAT3[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -3719,7 +3719,7 @@ component = chemistry
 dimension = longitude latitude plev19 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s51i001[blev=PLEV19, lbproc=128] / m01s51i999[blev=PLEV19, lbproc=128]
 mip_table_id = Amon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3728,7 +3728,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (m01s50i011[lbproc=128] + m01s50i013[lbproc=128] + m01s50i014[lbproc=128] + m01s50i015[lbproc=128]) / m01s50i255[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -3737,7 +3737,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (m01s50i001[lbproc=128] + m01s50i003[lbproc=128] + m01s50i103[lbproc=128]) / m01s50i255[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = mol m-3 s-1
 
@@ -3747,7 +3747,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(obvfsq, mask_3D_T)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = s-2
 
@@ -3757,7 +3757,7 @@ component = aerosol
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=2, lbproc=128] + m01s02i300[lbplev=2, lbproc=128] + m01s02i301[lbplev=2, lbproc=128] + m01s02i302[lbplev=2, lbproc=128] + m01s02i303[lbplev=2, lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -3767,7 +3767,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=2, lbproc=128]
 mip_table_id = Emon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -3776,7 +3776,7 @@ component = aerosol
 dimension = longitude latitude lambda550nm time
 expression = m01s02i285[lbplev=3, lbproc=128] + m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128] + m01s02i302[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERmon AERday
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -3786,7 +3786,7 @@ component = aerosol
 dimension = longitude latitude lambda550nm time
 expression = m01s02i251[lbplev=3, lbproc=128] + m01s02i252[lbplev=3, lbproc=128] + m01s02i253[lbplev=3, lbproc=128] + m01s02i254[lbplev=3, lbproc=128]
 mip_table_id = Emon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -3795,7 +3795,7 @@ component = dust
 dimension = longitude latitude lambda550nm time
 expression = m01s02i285[lbplev=3, lbproc=128]
 mip_table_id = AERmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -3805,7 +3805,7 @@ component = aerosol
 dimension = longitude latitude lambda550nm time
 expression = m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -3815,7 +3815,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=5, lbproc=128]
 mip_table_id = Emon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = 1
 
@@ -3825,7 +3825,7 @@ component = aerosol
 dimension = longitude latitude time
 expression = m01s02i285[lbplev=5, lbproc=128] + m01s02i300[lbplev=5, lbproc=128] + m01s02i301[lbplev=5, lbproc=128] + m01s02i302[lbplev=5, lbproc=128] + m01s02i303[lbplev=5, lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = 1
 
@@ -3834,7 +3834,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH) * m01s34i081[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3844,7 +3844,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempdiff
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -3854,7 +3854,7 @@ component = ocean
 dimension = longitude latitude time
 expression = opottempmint
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC kg m-2
 
@@ -3864,7 +3864,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemppmdiff
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -3874,7 +3874,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottempadvect
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -3884,7 +3884,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = opottemptend
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -3893,7 +3893,7 @@ component = atmos-physics
 dimension = longitude latitude
 expression = m01s00i033
 mip_table_id = fx
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -3903,7 +3903,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltdiff
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3913,7 +3913,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltpmdiff
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3923,7 +3923,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osaltadvect
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3933,7 +3933,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = osalttend
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -3942,7 +3942,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_PAN) * m01s34i017[lbproc=128]
 mip_table_id = AERmon
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -3951,7 +3951,7 @@ component = cftables
 dimension = longitude latitude sza5 time
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=128])
 mip_table_id = Eday Emon APday APmon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = 1
 
@@ -3962,8 +3962,8 @@ dimension = longitude latitude time typepasture
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
 	land_class='pasture')
 mip_table_id = Lmon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -3973,7 +3973,7 @@ dimension = longitude latitude time typec3pastures
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
 	land_class='c3Pasture')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -3983,7 +3983,7 @@ dimension = longitude latitude time typec4pastures
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128],
 	land_class='c4Pasture')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -3992,7 +3992,7 @@ component = ocean
 dimension = longitude latitude time
 expression = pbo
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = dbar
 
@@ -4001,7 +4001,7 @@ component = cftables
 dimension = longitude latitude time
 expression = m01s02i333[lbproc=128] / m01s02i334[lbproc=128]
 mip_table_id = CFmon CFday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -4010,7 +4010,7 @@ component = atmos-physics cftables
 dimension = longitude latitude alevel time
 expression = m01s00i408[lbproc=128]
 mip_table_id = AERmon CFday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -4021,7 +4021,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PH3
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = 1
 
@@ -4032,7 +4032,7 @@ component = aerosol cftables
 dimension = longitude latitude alevhalf time
 expression = m01s00i407[lbproc=128]
 mip_table_id = AERmon CFday APdayLev AEmonLev
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = Pa
 
@@ -4041,7 +4041,7 @@ component = obgc
 dimension = longitude latitude time
 expression = PH3[depth=0]
 mip_table_id = Omon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = 1
 
@@ -4050,7 +4050,7 @@ component = chemistry
 dimension = longitude latitude alevel time
 expression = m01s50i228[lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = s-1
 
@@ -4059,7 +4059,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * C_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4072,7 +4072,7 @@ dimension = longitude latitude time
 expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0])
 	* C_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4081,7 +4081,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PHD_E3T * C_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4097,7 +4097,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * FE_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4106,7 +4106,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PHN_E3T * C_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4115,7 +4115,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4124,7 +4124,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]) / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4135,7 +4135,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * P_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4154,7 +4154,7 @@ dimension = longitude latitude time depth0m
 expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0])
 	* P_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4163,7 +4163,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = PDS_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4184,7 +4184,7 @@ mip_table_id = Omon
 notes = AXY: phosphate not in model; and not a good idea to estimate it by
 	converting DIN to DIP using fixed N:P ratio; though this is not a
 	terrible idea.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4203,7 +4203,7 @@ expression = (PHN_E3T + PHD_E3T + ZMI_E3T + ZME_E3T + DET_E3T) / thkcello
 mip_table_id = Omon
 notes = AXY: partly a units thing, but need to modify code to produce
 	combined slow- and fast-sinking detritus.
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4214,7 +4214,7 @@ expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]
 	+ ZMI_E3T[depth=0] + ZME_E3T[depth=0]
 	+ DET_E3T[depth=0]) / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4226,7 +4226,7 @@ dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T + ZMI_E3T + ZME_E3T + DET_E3T)
 	* P_TO_N_RATIO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4239,7 +4239,7 @@ expression = (PHN_E3T[depth=0] + PHD_E3T[depth=0]
 	+ ZMI_E3T[depth=0] + ZME_E3T[depth=0] + DET_E3T[depth=0])
 	* P_TO_N_RATIO / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -4250,7 +4250,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = TPP3 * C_TO_N_RATIO
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -4261,7 +4261,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = TPPD3 * C_TO_N_RATIO
 mip_table_id = Emon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -4272,7 +4272,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (TPP3 - TPPD3) * C_TO_N_RATIO
 mip_table_id = Emon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3 d-1
 
@@ -4281,7 +4281,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128]
 mip_table_id = 3hr 6hrPlev Amon E1hr day CresAERday AP1hr AP3hr AP6hr APday APmon mon 1hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -4291,7 +4291,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128] + m01s05i206[lbproc=128]
 mip_table_id = Amon 3hr E1hr day
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -4301,7 +4301,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s05i227[lbproc=0]
 mip_table_id = CF3hr
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4310,7 +4310,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i223[lbproc=0]
 mip_table_id = CF3hr
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4319,7 +4319,7 @@ component = cftables
 dimension = longitude latitude alevhalf time1
 expression = m01s04i222[lbproc=0]
 mip_table_id = CF3hr
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4328,7 +4328,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i214[lbproc=128]
 mip_table_id = E3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4337,7 +4337,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128]
 mip_table_id = E3hr Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4346,7 +4346,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i215[lbproc=128]
 mip_table_id = Amon 3hr day
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 valid_min = 0.0
@@ -4356,7 +4356,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s05i206[lbproc=128]
 mip_table_id = E3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4365,7 +4365,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i461[lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = kg m-2
 
@@ -4374,7 +4374,7 @@ component = atmos-physics cftables
 dimension = longitude latitude time
 expression = m01s00i409[lbproc=128]
 mip_table_id = Amon AERhr CFmon AERmon Emon CFday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -4383,7 +4383,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s16i222[lbproc=128]
 mip_table_id = 6hrPlev Amon day APmon AP6hr APday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -4392,7 +4392,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i451[lbproc=128]
 mip_table_id = AERmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = Pa
 
@@ -4402,8 +4402,8 @@ dimension = longitude latitude time
 expression = m01s19i185[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4414,7 +4414,7 @@ expression = land_class_mean(
 	m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4425,7 +4425,7 @@ expression = land_use_tile_mean(
 	m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4436,7 +4436,7 @@ expression = land_class_mean(
 	m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4447,7 +4447,7 @@ expression = land_class_mean(
 	m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR),
 	m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4457,7 +4457,7 @@ component = cloud
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128], m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
 mip_table_id = Eday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -4466,7 +4466,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -4475,7 +4475,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -4484,7 +4484,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -4493,7 +4493,7 @@ component = cloud
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
 mip_table_id = Emon
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m
 
@@ -4502,7 +4502,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s01i245[lbproc=128] / m01s01i246[lbproc=128]
 mip_table_id = AERmon AEmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -4512,7 +4512,7 @@ component = cloud
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128], m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128] + m01s02i396[lbproc=128]))
 mip_table_id = Eday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = um
 
@@ -4522,7 +4522,7 @@ dimension = longitude latitude typeresidual time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='residual')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -4532,8 +4532,8 @@ dimension = longitude latitude time
 expression = m01s19i053[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
 mip_table_id = Lmon
 positive = up
-reviewer = Spencer Liddicoat <spencer.liddicoat@metoffice.gov.uk>,
-	Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Spencer Liddicoat (Met Office),
+	Andy Wiltshire (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -4544,7 +4544,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i218[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -4554,7 +4554,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i522[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -4565,7 +4565,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i220[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -4575,7 +4575,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i524[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -4586,7 +4586,7 @@ dimension = longitude latitude time
 expression = m01s02i207[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4597,7 +4597,7 @@ dimension = longitude latitude time
 expression = m01s02i208[lbproc=128]
 mip_table_id = Amon 3hr CFday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4607,7 +4607,7 @@ dimension = longitude latitude time
 expression = m01s02i201[lbproc=128] - (m01s03i332[lbproc=128] - m01s02i205[lbproc=128])
 mip_table_id = Emon Eday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4617,7 +4617,7 @@ dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i217[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -4627,7 +4627,7 @@ dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i521[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -4637,7 +4637,7 @@ dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i219[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -4647,7 +4647,7 @@ dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i523[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <william.ingram@metoffice.gov.uk>
+reviewer = William Ingram (Met Office)
 status = ok
 units = W m-2
 
@@ -4658,7 +4658,7 @@ dimension = longitude latitude time
 expression = m01s02i207[lbproc=128] - m01s02i201[lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4668,7 +4668,7 @@ dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i383[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -4678,7 +4678,7 @@ dimension = longitude latitude time
 expression = m01s03i332[lbproc=128]
 mip_table_id = Amon day
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4688,7 +4688,7 @@ dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i521[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4699,7 +4699,7 @@ expression = remove_altitude_coords(m01s02i517[lblev=86, lbproc=128])
 	+ m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon AEmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -4709,7 +4709,7 @@ dimension = longitude latitude time
 expression = m01s02i206[lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = Amon CFday
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4719,7 +4719,7 @@ dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i523[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4729,7 +4729,7 @@ dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i519[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
 mip_table_id = AERmon
 positive = up
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = W m-2
 
@@ -4740,7 +4740,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i218[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4750,7 +4750,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i522[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4761,7 +4761,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i220[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4771,7 +4771,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i524[lbproc=128])
 mip_table_id = CFmon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4806,7 +4806,7 @@ dimension = longitude latitude olevel time
 expression = rsdo
 mip_table_id = Omon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = W m-2
 
@@ -4816,7 +4816,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = rsdoabsorb
 mip_table_id = Emon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = W m-2
 
@@ -4827,7 +4827,7 @@ dimension = longitude latitude time
 expression = m01s01i235[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4838,7 +4838,7 @@ dimension = longitude latitude time
 expression = m01s01i210[lbproc=128]
 mip_table_id = Amon 3hr CFday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4872,7 +4872,7 @@ dimension = longitude latitude time
 expression = m01s01i216[lbproc=128]
 mip_table_id = 3hr Emon Eday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4882,7 +4882,7 @@ dimension = longitude latitude time
 expression = m01s01i207[lbproc=128]
 mip_table_id = Amon CFday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4892,7 +4892,7 @@ dimension = longitude latitude time
 expression = m01s01i201[lbproc=128]
 mip_table_id = Emon Eday
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4903,7 +4903,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i217[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4913,7 +4913,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i521[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4924,7 +4924,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i219[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4934,7 +4934,7 @@ dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i523[lbproc=128])
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4969,7 +4969,7 @@ dimension = longitude latitude time
 expression = m01s01i235[lbproc=128] - m01s01i201[lbproc=128]
 mip_table_id = Amon 3hr day
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -4980,7 +4980,7 @@ expression = land_use_tile_mean_difference(m01s01i235[lbproc=128],
 	m01s03i382[lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
 positive = up
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = W m-2
 
@@ -4990,7 +4990,7 @@ dimension = longitude latitude time
 expression = m01s01i211[lbproc=128]
 mip_table_id = Amon 3hr CFday
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -5025,7 +5025,7 @@ dimension = longitude latitude time
 expression = m01s01i208[lbproc=128]
 mip_table_id = Amon CFday
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -5035,7 +5035,7 @@ dimension = longitude latitude time
 expression = m01s01i521[lblev=86, lbproc=128]
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -5045,7 +5045,7 @@ dimension = longitude latitude time
 expression = m01s01i517[lblev=86, lbproc=128]
 mip_table_id = AERmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -5055,7 +5055,7 @@ dimension = longitude latitude time
 expression = m01s01i209[lbproc=128]
 mip_table_id = Amon E3hr CFday
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -5065,7 +5065,7 @@ dimension = longitude latitude time
 expression = m01s01i523[lblev=86, lbproc=128]
 mip_table_id = CFmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -5075,7 +5075,7 @@ dimension = longitude latitude time
 expression = m01s01i519[lblev=86, lbproc=128]
 mip_table_id = AERmon
 positive = up
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -5085,7 +5085,7 @@ dimension = longitude latitude time
 expression = m01s01i207[lbproc=128] - m01s01i208[lbproc=128] - m01s03i332[lbproc=128]
 mip_table_id = Amon
 positive = down
-reviewer = William Ingram <ingram@atm.ox.ac.uk>
+reviewer = William Ingram (University of Oxford)
 status = ok
 units = W m-2
 
@@ -5101,7 +5101,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i331[lbproc=128], m01s03i317[lbproc=128], land_class='all')
 mip_table_id = LImon Eday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5110,7 +5110,7 @@ component = cloud
 dimension = longitude latitude time
 expression = m01s05i270[lbproc=128]
 mip_table_id = Amon
-reviewer = Rachel Stratton <rachel.stratton@metoffice.gov.uk>
+reviewer = Rachel Stratton (Met Office)
 status = ok
 units = 1
 
@@ -5120,7 +5120,7 @@ component = cloud
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128], m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128] + m01s02i396[lbproc=128]))
 mip_table_id = Eday
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = cm-3
 
@@ -5129,7 +5129,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s17i257[lblev=1, lbproc=128]
 mip_table_id = Emon APmon
-reviewer = Stephanie Woodward <stephanie.woodward@metoffice.gov.uk>
+reviewer = Stephanie Woodward (Met Office)
 status = ok
 units = ug m-3
 
@@ -5144,7 +5144,7 @@ expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4)
 	+ m01s38i488[lblev=1, lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-3
 
@@ -5156,7 +5156,7 @@ expression = SECONDS_IN_HOUR / ATMOS_TIMESTEP
 	+ m01s38i499[lblev=1, lbproc=128])
 mip_table_id = Emon
 notes = ${COMMON:scale_factor_notes}
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-3
 
@@ -5166,7 +5166,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = SF6_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = umol m-3
 
@@ -5176,7 +5176,7 @@ dimension = longitude latitude height10m time
 expression = m01s03i230[lbproc=128]
 mip_table_id = Amon E3hr day 6hrPlev
 notes = An arbitrary choice between 'B-grid' or 'C-grid' but it would seem sensible to use the same throughout.
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -5200,7 +5200,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2) * m01s34i996[lblev=1, lbproc=128]
 mip_table_id = AERhr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -5209,7 +5209,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s34i001[lblev=1, lbproc=128]
 mip_table_id = AERhr
-reviewer = Steven Turnock <steven.turnock@metoffice.gov.uk>
+reviewer = Steven Turnock (Met Office)
 status = ok
 units = mol mol-1
 
@@ -5218,7 +5218,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s34i001[lblev=1, lbproc=8192]
 mip_table_id = AERday
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -5235,7 +5235,7 @@ component = land
 dimension = longitude latitude typeland
 expression = m01s00i505
 mip_table_id = fx
-reviewer = Rich Ellis <rjel@ceh.ac.uk>
+reviewer = Rich Ellis (CEH)
 status = ok
 units = 1
 
@@ -5244,7 +5244,7 @@ component = ocean
 dimension = longitude latitude typesea
 expression = sftof
 mip_table_id = Ofx
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = %
 
@@ -5254,7 +5254,7 @@ dimension = longitude latitude typeshrub time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='shrub')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -5263,7 +5263,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = SIL_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -5272,7 +5272,7 @@ component = seaice
 dimension = longitude latitude time
 expression = iage * SECONDS_IN_DAY * DAYS_IN_YEAR
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s
 
@@ -5281,7 +5281,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sicompstren
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-1
 
@@ -5290,7 +5290,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -5299,7 +5299,7 @@ component = seaice
 dimension = longitude latitude typesi time
 expression = m01s00i031[lbproc=128]
 mip_table_id = SImon SIday
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -5308,7 +5308,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcdyn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -5317,7 +5317,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidconcth
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = s-1
 
@@ -5326,7 +5326,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtd * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5336,7 +5336,7 @@ dimension = longitude latitude time
 expression = -1 * evap_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5345,7 +5345,7 @@ component = seaice
 dimension = longitude latitude time
 expression = congel * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5354,7 +5354,7 @@ component = seaice
 dimension = longitude latitude time
 expression = frazil * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5363,7 +5363,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltl * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5372,7 +5372,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltb * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5381,7 +5381,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * meltt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5390,7 +5390,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5399,7 +5399,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvidtt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5408,7 +5408,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstranx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -5417,7 +5417,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sidmasstrany
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg s-1
 
@@ -5426,7 +5426,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i538[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -5435,7 +5435,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sifb
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -5445,7 +5445,7 @@ dimension = longitude latitude time
 expression = siflcondbot
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -5455,7 +5455,7 @@ dimension = longitude latitude time
 expression = siflcondtop
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -5464,7 +5464,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ((meltt + meltb + meltl - congel - frazil) * ICE_DENSITY + melts * SNOW_DENSITY) / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [siflfwdrain]
@@ -5472,7 +5472,7 @@ component = seaice
 dimension = longitude latitude time
 expression = (meltt * ICE_DENSITY + melts * SNOW_DENSITY) / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sifllatstop]
@@ -5489,7 +5489,7 @@ dimension = longitude latitude time
 expression = m01s02i501[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = down
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -5499,7 +5499,7 @@ dimension = longitude latitude time
 expression = m01s03i531[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon
 positive = up
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = W m-2
 
@@ -5548,7 +5548,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecoriolx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -5557,7 +5557,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcecorioly
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -5566,7 +5566,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstrx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -5575,7 +5575,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforceintstry
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -5584,7 +5584,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetiltx
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -5593,7 +5593,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siforcetilty
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = N m-2
 
@@ -5602,7 +5602,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sihc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -5611,7 +5611,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -5620,7 +5620,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = snowfracn
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -5629,7 +5629,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vsnon / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -5638,7 +5638,7 @@ component = seaice
 dimension = longitude latitude iceband time
 expression = vicen / aicen
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -5647,7 +5647,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi * ICE_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -5657,7 +5657,7 @@ component = seaice
 dimension = longitude latitude typemp time
 expression = apond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -5667,7 +5667,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hpond_ai / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -5677,7 +5677,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ipond_ai / apond_ai
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -5686,7 +5686,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = SIL_E3T[depth=0] / thkcello[depth=0]
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -5695,7 +5695,7 @@ component = seaice
 dimension = longitude latitude time
 expression = rain_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 units = kg m-2 s-1
 
 [sirdgconc]
@@ -5703,7 +5703,7 @@ component = seaice
 dimension = longitude latitude typesirdg time
 expression = ardg
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -5720,7 +5720,7 @@ dimension = longitude latitude time
 expression = sisaltmass
 mip_table_id = SImon
 notes = The interpretation of this variable in CICE is not obvious as CICE has two simultaneous salinity profiles (when prognostic salinity is not being used).
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -5729,7 +5729,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snowfrac / aice
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -5738,7 +5738,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnhc
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = J m-2
 
@@ -5747,7 +5747,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hs * SNOW_DENSITY
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2
 
@@ -5756,7 +5756,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sisnthick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -5765,7 +5765,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sispeed
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -5806,7 +5806,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sitempbot
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -5815,7 +5815,7 @@ component = seaice
 dimension = longitude latitude time
 expression = m01s03i535[lbproc=128] / m01s00i031[lbproc=128]
 mip_table_id = SImon SIday
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = K
 
@@ -5824,7 +5824,7 @@ component = seaice
 dimension = longitude latitude time
 expression = sithick
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -5833,7 +5833,7 @@ component = seaice
 dimension = longitude latitude time
 expression = ice_present
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = 1
 
@@ -5842,7 +5842,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siu
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -5851,7 +5851,7 @@ component = seaice
 dimension = longitude latitude time
 expression = siv
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m s-1
 
@@ -5860,7 +5860,7 @@ component = seaice
 dimension = longitude latitude time
 expression = hi
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = m
 
@@ -5870,7 +5870,7 @@ component = ocean
 dimension = latitude basin time
 expression = 1.026 * combine_cubes_to_basin_coord(sltbasin_global, sltbasin_atlantic, sltbasin_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = EmonZ
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -5880,7 +5880,7 @@ component = ocean
 dimension = latitude basin time
 expression = 1.026 * combine_cubes_to_basin_coord(sltovgyre_global, sltovgyre_atlantic, sltovgyre_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -5890,7 +5890,7 @@ component = ocean
 dimension = latitude basin time
 expression = 1.026 * combine_cubes_to_basin_coord(sltovovrt_global, sltovovrt_atlantic, sltovovrt_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = Tg s-1
 
@@ -5900,7 +5900,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = snc_calc(m01s08i236[lbproc=128], m01s03i317[lbproc=128], m01s03i395[lbproc=128])
 mip_table_id = day LImon
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = %
 
@@ -5910,7 +5910,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i376[lbproc=128], m01s03i317[lbproc=128], land_class='all')
 mip_table_id = LImon Eday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = m
 
@@ -5919,7 +5919,7 @@ component = seaice
 dimension = longitude latitude time
 expression = dvsdtd * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5928,7 +5928,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * melts * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5937,7 +5937,7 @@ component = seaice
 dimension = longitude latitude time
 expression = -1 * snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5946,7 +5946,7 @@ component = seaice
 dimension = longitude latitude time
 expression = snow_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
 mip_table_id = SImon
-reviewer = Alex West <alex.west@metoffice.gov.uk>
+reviewer = Alex West (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5955,7 +5955,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i237[lbproc=128], m01s03i317[lbproc=128], land_class='all')
 mip_table_id = LImon Eday
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -5965,7 +5965,7 @@ component = snow-permafrost
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i236[lbproc=128], m01s03i317[lbproc=128], land_class='all')
 mip_table_id = day LImon
-reviewer = Eleanor Burke <eleanor.burke@metoffice.gov.uk>
+reviewer = Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -5975,7 +5975,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = so
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -5984,7 +5984,7 @@ component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i072[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_SO2)
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = mol mol-1
 
@@ -5993,7 +5993,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sob
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -6002,7 +6002,7 @@ component = ocean
 dimension = time
 expression = soga
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -6019,7 +6019,7 @@ component = ocean
 dimension = longitude latitude time
 expression = somint
 mip_table_id = Emon
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = 1e-3 kg m-2
 
@@ -6028,7 +6028,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sos
 mip_table_id = Oday Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -6037,7 +6037,7 @@ component = ocean
 dimension = time
 expression = area_mean(sos, areacello)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-3
 
@@ -6046,7 +6046,7 @@ component = ocean
 dimension = longitude latitude time
 expression = sossq
 mip_table_id = Oday Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = 1e-6
 
@@ -6055,7 +6055,7 @@ component = obgc
 dimension = longitude latitude time depth0m
 expression = OCN_PCO2
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = uatm
 
@@ -6064,7 +6064,7 @@ component = snow-permafrost
 dimension = longitude latitude landUse time
 expression = land_use_tile_mean( m01s08i236[lbproc=128] / FRESHWATER_DENSITY, m01s03i317[lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = m
 
@@ -6073,7 +6073,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i044[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = 1e5 K2
 
@@ -6083,7 +6083,7 @@ dimension = longitude latitude time
 expression = t20d
 mip_table_id = Emon Eday
 notes = PMIP variables: Variable will be output with a time dimension and with cell_methods for time.
-reviewer = Tim Graham <tim.graham@metoffice.gov.uk>
+reviewer = Tim Graham (Met Office)
 status = ok
 units = m
 
@@ -6092,7 +6092,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -6150,7 +6150,7 @@ component = atmos-physics
 dimension = longitude latitude plev27 time
 expression = m01s30i294[blev=PLEV27, lbproc=128] / m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -6187,7 +6187,7 @@ component = atmos-physics
 dimension = longitude latitude p500 time
 expression = m01s30i294[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
 mip_table_id = GCAmon GCday Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -6211,7 +6211,7 @@ dimension = longitude latitude p700 time
 expression = m01s30i294[blev=P700, lbproc=128]
 	/ m01s30i304[blev=P700, lbproc=128]
 mip_table_id = CFday GCAmon GCday APday mon day 6hr
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
@@ -6220,7 +6220,7 @@ component = atmos-physics
 dimension = longitude latitude plev7h time1
 expression = m01s30i294[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt E3hrPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = K
 
@@ -6229,7 +6229,7 @@ component = atmos-physics
 dimension = longitude latitude p850 time
 expression = m01s30i294[blev=P850, lbproc=128] / m01s30i304[blev=P850, lbproc=128]
 mip_table_id = GCAmon GCday Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -6245,7 +6245,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = ALK_E3T / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -6261,7 +6261,7 @@ component = boundary-layer
 dimension = longitude latitude height2m time
 expression = m01s03i236[lbproc=128]
 mip_table_id = 6hrPlev Amon day CresAERday Cres1HrMn AP6hr APday APmon mon 1hr
-reviewer = Martin Andrews <martin.andrews@metoffice.gov.uk>
+reviewer = Martin Andrews (Met Office)
 status = ok
 units = K
 
@@ -6270,7 +6270,7 @@ component = land-use
 dimension = longitude latitude height2m landUse time
 expression = land_use_tile_mean(m01s03i328[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = K
 
@@ -6279,7 +6279,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=8192])
 mip_table_id = Amon CresAERday APmon mon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -6288,7 +6288,7 @@ component = atmos-physics
 dimension = longitude latitude height2m time
 expression = mon_mean_from_day(m01s03i236[lbproc=4096])
 mip_table_id = Amon
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -6306,7 +6306,7 @@ dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Amon Eday
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -6316,7 +6316,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauuo, mask_2D_U)
 mip_table_id = Omon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -6325,7 +6325,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
 mip_table_id = Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -6336,7 +6336,7 @@ dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Amon Eday
 positive = down
-reviewer = Dan Copsey <dan.copsey@metoffice.gov.uk>
+reviewer = Dan Copsey (Met Office)
 status = ok
 units = Pa
 
@@ -6346,7 +6346,7 @@ dimension = longitude latitude time
 expression = mask_copy(tauvo, mask_2D_V)
 mip_table_id = Omon
 positive = down
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = N m-2
 
@@ -6355,7 +6355,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
 mip_table_id = Eday
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = Pa
 
@@ -6371,7 +6371,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s03i316[lbplev=8, lbproc=128]
 mip_table_id = Eday LPday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = K
 
@@ -6381,7 +6381,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thetao
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -6390,7 +6390,7 @@ component = ocean
 dimension = time
 expression = thetaoga
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -6399,7 +6399,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao, thkcello)
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -6408,7 +6408,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<2025], thkcello[depth<2025])
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -6417,7 +6417,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<300], thkcello[depth<300])
 mip_table_id = Emon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -6426,7 +6426,7 @@ component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao[depth<735], thkcello[depth<735])
 mip_table_id = Emon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -6436,7 +6436,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = thkcello
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -6445,7 +6445,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i182[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -6455,7 +6455,7 @@ dimension = longitude latitude alevel time
 expression = (m01s12i182[lbproc=128] + m01s12i382[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
 notes = Obtained by advection plus solver
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -6464,7 +6464,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i162[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -6474,7 +6474,7 @@ dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s04i982[lbproc=128] + m01s05i182[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128] + m01s35i025[lbproc=128] ) / ATMOS_TIMESTEP
 mip_table_id = CFmon
 notes = Methane Oxidation added.
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -6483,7 +6483,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i190[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -6492,7 +6492,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] - m01s03i190[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -6502,7 +6502,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = s-1
 
@@ -6525,7 +6525,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s30i181[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6535,7 +6535,7 @@ dimension = longitude latitude alevel time
 expression = (m01s10i181[lbproc=128] + m01s12i181[lbproc=128] + m01s12i381[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
 notes = Obtained by Solver plus Advection plus Conservations Corrections
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6544,7 +6544,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s05i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6553,7 +6553,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s14i181[lbproc=128] + m01s01i181[lbproc=128] + m01s02i181[lbproc=128] + m01s03i181[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s05i181[lbproc=128] + m01s06i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s35i029[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6562,7 +6562,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s03i189[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6571,7 +6571,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s01i161[lbproc=128] + m01s02i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon APmonLev
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6581,7 +6581,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6590,7 +6590,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s02i233[lbproc=128]
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6600,7 +6600,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i161[lbproc=128] / ATMOS_TIMESTEP
 mip_table_id = AERmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6609,7 +6609,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = m01s01i233[lbproc=128]
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6618,7 +6618,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s03i181[lbproc=128] - m01s03i189[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s01i181[lbproc=128] - m01s01i161[lbproc=128] + m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = Emon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6628,7 +6628,7 @@ component = cftables
 dimension = longitude latitude alevel time
 expression = (m01s03i181[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s01i181[lbproc=128] - m01s01i161[lbproc=128] + m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
 mip_table_id = CFmon
-reviewer = Yoko Tsushima <yoko.tsushima@metoffice.gov.uk>
+reviewer = Yoko Tsushima (Met Office)
 status = ok
 units = K s-1
 
@@ -6637,7 +6637,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tob
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -6646,7 +6646,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tos
 mip_table_id = Oday Omon OPmon OPday
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -6655,7 +6655,7 @@ component = ocean
 dimension = time
 expression = area_mean(tos, areacello)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC
 
@@ -6664,7 +6664,7 @@ component = ocean
 dimension = longitude latitude time
 expression = tossq
 mip_table_id = Oday Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = degC2
 
@@ -6673,7 +6673,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = m01s50i219[lblev=1, lbproc=128]
 mip_table_id = AERmon
-reviewer = Guang Zeng <guang.zeng@niwa.co.nz>
+reviewer = Guang Zeng (NIWA)
 status = ok
 units = 1e-5 m
 
@@ -6683,7 +6683,7 @@ dimension = longitude latitude time
 expression = m01s03i539[lbproc=128]
 mip_table_id = Lmon Eday
 positive = up
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -6693,7 +6693,7 @@ dimension = longitude latitude typetree time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='tree')
 mip_table_id = Lmon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -6703,7 +6703,7 @@ dimension = longitude latitude typetreebd time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='broadLeafTreeDeciduous')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -6713,7 +6713,7 @@ dimension = longitude latitude typetreebe time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='broadLeafTreeEvergreen')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -6723,7 +6723,7 @@ dimension = longitude latitude typetreend time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='needleLeafTreeDeciduous')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -6733,7 +6733,7 @@ dimension = longitude latitude typetreene time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='needleLeafTreeEvergreen')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -6742,7 +6742,7 @@ component = chemistry
 dimension = longitude latitude time
 expression = trop_o3col(m01s34i001[lbproc=128] * m01s50i063[lbproc=128] * m01s50i062[lbproc=128])
 mip_table_id = AERmon
-reviewer = Luke Abraham <luke.abraham@atm.ch.cam.ac.uk>, Mohit Dalvi <mohit.dalvi@metoffice.gov.uk>
+reviewer = Luke Abraham (Met Office)
 status = ok
 units = 1.0e-5 m
 
@@ -6751,7 +6751,7 @@ component = atmos-physics boundary-layer
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = K
 
@@ -6760,7 +6760,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Lmon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>, Eleanor Burke <eleanor.burke@metoffice.gov.uk
+reviewer = Ron Kahana (Met Office), Eleanor Burke <eleanor.burke@metoffice.gov.uk
 status = ok
 units = K
 
@@ -6769,7 +6769,7 @@ component = land-use
 dimension = longitude latitude landUse time
 expression = land_use_tile_mean(m01s03i316[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
 mip_table_id = Emon
-reviewer = Eddy Robertson <eddy.robertson@metoffice.gov.uk>
+reviewer = Eddy Robertson (Met Office)
 status = ok
 units = K
 
@@ -6785,7 +6785,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i011[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -6794,7 +6794,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128] / m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -6803,7 +6803,7 @@ component = atmos-physics
 dimension = longitude latitude p10 time
 expression = m01s30i201[blev=P10, lbproc=128] / m01s30i301[blev=P10, lbproc=128]
 mip_table_id = GCAmon AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -6862,7 +6862,7 @@ component = atmos-physics
 dimension = longitude latitude plev27 time
 expression = m01s30i201[blev=PLEV27, lbproc=128] / m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -6941,7 +6941,7 @@ component = boundary-layer
 dimension = longitude latitude height10m time
 expression = m01s03i209[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr day AP6hr APday APmon AP3hr
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -6951,7 +6951,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(umo, mask_3D_U)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -6961,7 +6961,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(uo, mask_3D_U)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -6971,7 +6971,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i428[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -6980,7 +6980,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i014[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -6990,7 +6990,7 @@ component = atmos-physics
 dimension = latitude plev39 time
 expression = zonal_apply_heaviside(m01s30i314[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ
-reviewer = Alejandro Bodas-Salcedo <alejandro.bodas@metoffice.gov.uk>
+reviewer = Alejandro Bodas-Salcedo (Met Office)
 status = ok
 units = m s-2
 
@@ -7006,7 +7006,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s06i247[blev=PLEV19, lbproc=128]
 mip_table_id = Emon
-reviewer = Andrew Bushell <andrew.bushell@metoffice.gov.uk>
+reviewer = Andrew Bushell (Met Office)
 status = ok
 units = m s-2
 
@@ -7015,7 +7015,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i012[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -7024,7 +7024,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i022[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 m2 s-2
 
@@ -7033,7 +7033,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128] / m01s30i301[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -7099,7 +7099,7 @@ component = atmos-physics
 dimension = longitude latitude plev27 time
 expression = m01s30i202[blev=PLEV27, lbproc=128] / m01s30i301[blev=PLEV27, lbproc=128]
 mip_table_id = Emon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m s-1
 
@@ -7178,7 +7178,7 @@ component = boundary-layer
 dimension = longitude latitude height10m time
 expression = m01s03i210[lbproc=128]
 mip_table_id = 6hrPlev Amon E3hr day AP3hr AP6hr APday APmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -7188,7 +7188,7 @@ dimension = longitude latitude typeveg time
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128],
 	land_class='veg')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = %
 
@@ -7198,7 +7198,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='veg')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -7208,7 +7208,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='crop')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -7218,7 +7218,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='grass')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -7228,7 +7228,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='pasture')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -7238,7 +7238,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='shrub')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -7248,7 +7248,7 @@ dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128],
 	land_class='tree')
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = m
 
@@ -7258,7 +7258,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vmo, mask_3D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -7268,7 +7268,7 @@ component = chemistry
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * (m01s51i997[blev=PLEV39, lbproc=192] + 3.0 * m01s51i001[blev=PLEV39, lbproc=192] + m01s51i059[blev=PLEV39, lbproc=192]) / m01s51i999[blev=PLEV39, lbproc=192]
 mip_table_id = EmonZ
-reviewer = Alex Archibald <alex.archibald@atm.ch.cam.ac.uk>
+reviewer = Alex Archibald (University of Cambridge)
 status = ok
 units = mol mol-1
 
@@ -7278,7 +7278,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(vo, mask_3D_V)
 mip_table_id = Omon OPmonLev
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -7288,7 +7288,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = volcello(thkcello, areacello)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -7297,7 +7297,7 @@ component = ocean
 dimension = time
 expression = scvoltot
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m3
 
@@ -7306,7 +7306,7 @@ component = atmos-physics
 dimension = longitude latitude pl700 time1
 expression = vortmean(m01s30i457[blev=600 700 850, lbproc=0])
 mip_table_id = 6hrPlevPt AP6hrPt
-reviewer = Malcolm Roberts <malcolm.roberts@metoffice.gov.uk>
+reviewer = Malcolm Roberts (Met Office)
 status = ok
 units = s-1
 
@@ -7316,7 +7316,7 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i429[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m2 s-1
 
@@ -7325,7 +7325,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s30i024[lbproc=128] / m01s30i115[lbproc=128]
 mip_table_id = Emon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = 1e5 K m s-1
 
@@ -7336,7 +7336,7 @@ dimension = latitude plev39 time
 expression = mask_vtem(m01s30i310[blev=PLEV39, lbproc=192],
 	m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ APmonZ APdayZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -7345,7 +7345,7 @@ component = atmos-physics
 dimension = longitude latitude alevel time
 expression = m01s00i150[lbproc=128]
 mip_table_id = AERmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m s-1
 
@@ -7473,7 +7473,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i298[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -7545,7 +7545,7 @@ component = atmos-physics
 dimension = longitude latitude plev4 time
 expression = m01s30i298[blev=PLEV4, lbproc=128] / m01s30i304[blev=PLEV4, lbproc=128]
 mip_table_id = 6hrPlev
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -7568,7 +7568,7 @@ component = cftables
 dimension = longitude latitude p500 time
 expression = m01s30i298[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
 mip_table_id = GCAmon CFday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = Pa s-1
 
@@ -7598,7 +7598,7 @@ component = atmos-physics
 dimension = longitude latitude plev7h time1
 expression = m01s30i298[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = E3hrPt
-reviewer = Rob Chadwick <robin.chadwick@metoffice.gov.uk>
+reviewer = Rob Chadwick (Met Office)
 status = ok
 units = Pa s-1
 
@@ -7633,7 +7633,7 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C,
 	cube2d=(m01s38i906[lbproc=128] + m01s38i912[lbproc=128]
 	+ m01s38i921[lbproc=128]), sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -7642,7 +7642,7 @@ component = dust
 dimension = longitude latitude time
 expression = m01s04i231[lbproc=128] + m01s04i232[lbproc=128] + m01s04i233[lbproc=128] + m01s04i234[lbproc=128] + m01s04i235[lbproc=128] + m01s04i236[lbproc=128] + m01s05i281[lbproc=128] + m01s05i282[lbproc=128] + m01s05i283[lbproc=128] + m01s05i284[lbproc=128] + m01s05i285[lbproc=128] + m01s05i286[lbproc=128]
 mip_table_id = AERmon
-reviewer = Ben Johnson <ben.johnson@metoffice.gov.uk>
+reviewer = Ben Johnson (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -7651,7 +7651,7 @@ component = carbon
 dimension = longitude latitude time
 expression = m01s08i242[lbproc=128] * MOLECULAR_MASS_OF_CH4 / ATOMIC_MASS_OF_C
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = ug m-2 s-1
 
@@ -7660,7 +7660,7 @@ component = carbon
 dimension = longitude latitude typewetla time
 expression = m01s08i248[lbproc=128] * m01s03i395[lbproc=128]
 mip_table_id = Emon
-reviewer = Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Andy Wiltshire (Met Office)
 status = ok
 units = 1
 
@@ -7675,7 +7675,7 @@ expression = achem_emdrywet(ATOMIC_MASS_OF_C * CONV_C_ORGM,
 	cube2d=(m01s38i907[lbproc=128] + m01s38i913[lbproc=128]
 	+ m01s38i922[lbproc=128]), sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -7685,7 +7685,7 @@ dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO2,
 	m01s50i155[lbproc=128], sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -7700,7 +7700,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4,
 	sumlev='True', areadiv='True')
 mip_table_id = AERmon
 notes = ${COMMON:cancelling_notes}
-reviewer = Nicolas Bellouin <n.bellouin@reading.ac.uk>
+reviewer = Nicolas Bellouin (University of Reading)
 status = ok
 units = g m-2 s-1
 
@@ -7713,7 +7713,7 @@ expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL,
 	cube2d=(m01s38i914[lbproc=128] + m01s38i923[lbproc=128]),
 	sumlev='True', areadiv='True')
 mip_table_id = AERmon
-reviewer = Jane Mulcahy <jane.mulcahy@metoffice.gov.uk>
+reviewer = Jane Mulcahy (Met Office)
 status = ok
 units = g m-2 s-1
 
@@ -7722,7 +7722,7 @@ component = ocean
 dimension = longitude latitude time
 expression = -1 * (sowaflup + sowflisf)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg m-2 s-1
 
@@ -7732,7 +7732,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wmo, mask_3D_T)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = kg s-1
 
@@ -7742,7 +7742,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = mask_copy(wo, mask_3D_T)
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m s-1
 
@@ -7758,7 +7758,7 @@ component = land
 dimension = longitude latitude time
 expression = m01s08i249[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Ron Kahana <ron.kahana@metoffice.gov.uk>, Andy Wiltshire <andy.wiltshire@metoffice.gov.uk>
+reviewer = Ron Kahana (Met Office)
 status = ok
 units = m
 
@@ -7767,7 +7767,7 @@ component = atmos-physics
 dimension = latitude plev39 time
 expression = mask_polar_column_zonal_means( m01s30i311[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
 mip_table_id = EdayZ EmonZ
-reviewer = Steven Hardiman <steven.hardiman@metoffice.gov.uk>
+reviewer = Steven Hardiman (Met Office)
 status = ok
 units = m s-1
 
@@ -7784,7 +7784,7 @@ component = ocean
 dimension = longitude latitude olevel time
 expression = zfull
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -7793,7 +7793,7 @@ component = atmos-physics
 dimension = longitude latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
 mip_table_id = Amon Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -7802,7 +7802,7 @@ component = atmos-physics
 dimension = longitude latitude p10 time
 expression = m01s30i297[blev=P10, lbproc=128] / m01s30i304[blev=P10, lbproc=128]
 mip_table_id = AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -7811,7 +7811,7 @@ component = atmos-physics
 dimension = longitude latitude p100 time
 expression = m01s30i297[blev=P100, lbproc=128] / m01s30i304[blev=P100, lbproc=128]
 mip_table_id = AERday
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -7820,7 +7820,7 @@ component = atmos-physics
 dimension = longitude latitude p1000 time
 expression = m01s30i297[blev=P1000, lbproc=128] / m01s30i304[blev=P1000, lbproc=128]
 mip_table_id = GCAmon GCday 6hrPlev AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -7843,7 +7843,7 @@ component = atmos-physics
 dimension = longitude latitude plev27 time
 expression = m01s30i297[blev=PLEV27, lbproc=128] / m01s30i304[blev=PLEV27, lbproc=128]
 mip_table_id = Emon
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -7866,7 +7866,7 @@ component = atmos-physics
 dimension = longitude latitude p500 time
 expression = m01s30i297[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
 mip_table_id = GCAmon GCday AERday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -7889,7 +7889,7 @@ component = atmos-physics
 dimension = longitude latitude plev7h time1
 expression = m01s30i297[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
 mip_table_id = 6hrPlevPt
-reviewer = Matthew Mizielinski <matthew.mizielinski@metoffice.gov.uk>
+reviewer = Matthew Mizielinski (Met Office)
 status = ok
 units = m
 
@@ -7920,7 +7920,7 @@ component = ocean
 dimension = longitude latitude olevhalf time
 expression = zhalf
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -7929,7 +7929,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = ZME_E3T * C_TO_N_RATIO_ZOO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -7945,7 +7945,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = ZMI_E3T * C_TO_N_RATIO_ZOO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -7961,7 +7961,7 @@ component = boundary-layer
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
 mip_table_id = Eday
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m
 
@@ -7978,7 +7978,7 @@ component = obgc
 dimension = longitude latitude olevel time
 expression = (ZMI_E3T + ZME_E3T) * C_TO_N_RATIO_ZOO / thkcello
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = mmol m-3
 
@@ -7994,7 +7994,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zos
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -8003,7 +8003,7 @@ component = ocean
 dimension = longitude latitude time
 expression = zossq
 mip_table_id = Omon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m2
 
@@ -8015,7 +8015,7 @@ dimension = time
 expression = calc_zostoga(thetao, thkcello, areacello,
 	zfullo_0, so_0, rho_0_mean, deptho_0_mean)
 mip_table_id = Omon OPmon
-reviewer = Daley Calvert <daley.calvert@metoffice.gov.uk>
+reviewer = Daley Calvert (Met Office)
 status = ok
 units = m
 
@@ -8024,7 +8024,7 @@ component = obgc
 dimension = longitude latitude time
 expression = ARG_CCD
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = m
 
@@ -8033,7 +8033,7 @@ component = obgc
 dimension = longitude latitude time
 expression = CAL_CCD
 mip_table_id = Omon
-reviewer = Andrew Yool <axy@noc.ac.uk>
+reviewer = Andrew Yool (NOC)
 status = ok
 units = m
 
@@ -8042,6 +8042,6 @@ component = atmos-physics
 dimension = longitude latitude time
 expression = m01s30i453[lbproc=128] + m01s00i033[lbproc=128]
 mip_table_id = AERmon
-reviewer = Gill Martin <gill.martin@metoffice.gov.uk>
+reviewer = Gill Martin (Met Office)
 status = ok
 units = m

--- a/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1/data/UKESM1_mappings.cfg
@@ -3390,7 +3390,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
 mip_table_id = Emon Eday
-reviewer = Ron Kahana (Met Office), Eleanor Burke <eleanor.burke@metoffice.gov.uk
+reviewer = Ron Kahana (Met Office), Eleanor Burke (Met Office)
 status = ok
 units = kg m-2
 
@@ -6760,7 +6760,7 @@ component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
 mip_table_id = Lmon Eday
-reviewer = Ron Kahana (Met Office), Eleanor Burke <eleanor.burke@metoffice.gov.uk
+reviewer = Ron Kahana (Met Office), Eleanor Burke (Met Office)
 status = ok
 units = K
 

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_eday_parasolrefl.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_eday_parasolrefl.py
@@ -29,7 +29,7 @@ class TestCmip6EdayParasolRefl(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                 },
                 request={
                     'ancil_files': os.path.join(ROOT_ANCIL_DIR, 'UKESM1-0-LL', 'qrparm.orog.pp'),

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_eday_parasolrefl.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_eday_parasolrefl.py
@@ -42,7 +42,7 @@ class TestCmip6EdayParasolRefl(AbstractFunctionalTests):
                     'ap6': {'CMIP6_Eday': 'parasolRefl'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['parasolRefl_Eday_UKESM1-0-LL_amip_r1i1p1f1_gn_19790101-19790130.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_soga.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_soga.py
@@ -41,7 +41,7 @@ class TestCmip6OmonSoga(AbstractFunctionalTests):
                     'onm': {'CMIP6_Omon': 'soga'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['soga_Omon_UKESM1-0-LL_amip_r1i1p1f1_gn_185105-185105.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_soga.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_soga.py
@@ -28,7 +28,7 @@ class TestCmip6OmonSoga(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                 },
                 request={
                     'ancil_files': os.path.join(ROOT_ANCIL_DIR, 'UKESM1-0-LL', 'qrparm.orog.pp'),

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thetao.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thetao.py
@@ -43,7 +43,7 @@ class TestCmip6OmonThetao(AbstractFunctionalTests):
                     'onb': {'CMIP6_Omon': 'thetao'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['thetao_Omon_UKESM1-0-LL_amip_r1i1p1f1_197601-197601.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thetao.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thetao.py
@@ -29,7 +29,7 @@ class TestCmip6OmonThetao(AbstractFunctionalTests):
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
                     'calendar': 'noleap',
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>',
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thkcello.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thkcello.py
@@ -46,7 +46,7 @@ class TestCmip6OmonThkcello(AbstractFunctionalTests):
                     'further_info_url': 'https://furtherinfo.es-doc.org/CMIP6.MOHC.HadGEM3-GC31-LL.amip.none.r1i1p1f1'
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['thkcello_Omon_HadGEM3-GC31-LL_amip_r1i1p1f1_198001-198001.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thkcello.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_thkcello.py
@@ -28,7 +28,7 @@ class TestCmip6OmonThkcello(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>',
                     'model_id': 'HadGEM3-GC31-LL',
                 },

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_tos.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_tos.py
@@ -43,7 +43,7 @@ class TestCmip6OmonTos(AbstractFunctionalTests):
                     'onb': {'CMIP6_Omon': 'tos'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['tos_Omon_UKESM1-0-LL_amip_r1i1p1f1_197601-197601.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_tos.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_omon_tos.py
@@ -29,7 +29,7 @@ class TestCmip6OmonTos(AbstractFunctionalTests):
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
                     'calendar': 'noleap',
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>',
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sifllwutop.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sifllwutop.py
@@ -28,7 +28,7 @@ class TestCmip6SImonSifllwutop(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>'
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sifllwutop.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sifllwutop.py
@@ -41,7 +41,7 @@ class TestCmip6SImonSifllwutop(AbstractFunctionalTests):
                     'ap5': {'CMIP6_SImon': 'sifllwutop'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['sifllwutop_SImon_UKESM1-0-LL_amip_r1i1p1f1_185105-185105.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_siitdsnthick.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_siitdsnthick.py
@@ -41,7 +41,7 @@ class TestCmip6SImonSiitdsnthick(AbstractFunctionalTests):
                     'inm': {'CMIP6_SImon': 'siitdsnthick'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['siitdsnthick_SImon_UKESM1-0-LL_amip_r1i1p1f1_185403-185403.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_siitdsnthick.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_siitdsnthick.py
@@ -28,7 +28,7 @@ class TestCmip6SImonSiitdsnthick(AbstractFunctionalTests):
                 },
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>'
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sndmassmelt.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sndmassmelt.py
@@ -40,7 +40,7 @@ class TestCmip6SImonSndmassmelt(AbstractFunctionalTests):
                     'inm': {'CMIP6_SImon': 'sndmassmelt'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['sndmassmelt_SImon_UKESM1-0-LL_amip_r1i1p1f1_185403-185403.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sndmassmelt.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip6/test_cmip6_simon_sndmassmelt.py
@@ -26,7 +26,7 @@ class TestCmip6SImonSndmassmelt(AbstractFunctionalTests):
                     'netcdf_file_action': 'CMOR_REPLACE_3'
                 },
                 cmor_dataset={
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_dir': get_output_dir(test_location),
                     'output_file_template': '<variable_id><table><source_id><experiment_id><variant_label>'
                 },

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_no_mask.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_no_mask.py
@@ -43,7 +43,7 @@ class TestSeasonalOmonTosNoMask(AbstractFunctionalTests):
                     'onb': {'SEASONAL_Omon': 'tos'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['tos_Omon_UKESM1-0-LL_r1i1p1f1_197601-197601.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_no_mask.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_no_mask.py
@@ -29,7 +29,7 @@ class TestSeasonalOmonTosNoMask(AbstractFunctionalTests):
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
                     'calendar': 'noleap',
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><variant_label>',
                 },
                 request={

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_with_mask.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_with_mask.py
@@ -48,7 +48,7 @@ class TestSeasonalOmonTosWithMask(AbstractFunctionalTests):
                     }
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['tos_Omon_UKESM1-0-LL_amip_197601-197601.nc'],
                 }
             )

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_with_mask.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_seasonal/test_seasonal_omon_tos_with_mask.py
@@ -29,7 +29,7 @@ class TestSeasonalOmonTosWithMask(AbstractFunctionalTests):
                 cmor_dataset={
                     'output_dir': get_output_dir(test_location),
                     'calendar': 'noleap',
-                    'contact': 'chris.d.jones@metoffice.gov.uk',
+                    'contact': 'enquiries@metoffice.gov.uk',
                     'output_file_template': '<variable_id><table><source_id><experiment_id>',
                 },
                 request={


### PR DESCRIPTION
This change replaces the email addresses recorded against reviewer names in the mappings files with just their institutions. 
This information is only kept for audit trail purposes

Going forward we will change to including names and github handles.

Note that the changes here were scripted using the regular expression `'(([a-zA-Z0-9. ]+) \<.*@([a-zA-Z0-9\.]+)\>)'` to pick out reviewer name and email domain, which was translated via dictionary to an institution name.

No changes to tests necessary and all tests confirmed as passing.
