### PR TITLE
CDDSO-647: Remove fill gaps argument from moo select dry run queries

### DIFF
--- a/cdds/cdds/extract/filters.py
+++ b/cdds/cdds/extract/filters.py
@@ -583,7 +583,10 @@ class Filters(object):
         else:
             simulate = self.simulation
 
-        param_args = ["-i", "-n", filterfile, self.source, self.target]
+        # "-i" option has been removed from the following to avoid an issue with
+        # the moose client where the response with and without this argument
+        # is different.
+        param_args = ["-n", filterfile, self.source, self.target]
         code, cmd_out, command = run_moo_cmd("select", param_args, simulate=simulate, verbose=False)
         status = check_moo_cmd(code, cmd_out)
         return status, cmd_out


### PR DESCRIPTION
… to moo select when sizing PP select queries to avoid inconsistent behaviour

An error was being raised when data on 53 tapes (above the 50 limit) was being requested.  This error was not being returned when dry run moo select commands including the "-i" argument were used when calculating chunk sizes.

I've removed this "-i" argument, which may have some impact on how queries are sized, but will at least mean that queries should be usable without splitting processing into multiple requests.

All tests pass.
