### PR TITLE
#470: condense output query files

### DIFF
--- a/cdds/cdds/extract/common.py
+++ b/cdds/cdds/extract/common.py
@@ -1117,13 +1117,15 @@ def split_stashes_from_constraints(var):
     for x in var:
         for constraint in x["constraint"]:
             copied_constraint = copy(constraint)
-            stash = copied_constraint.pop("stash")
-            hashed_constraint_dict = hash(json.dumps(copied_constraint, sort_keys=True))
 
-            if hashed_constraint_dict not in constraint_dict:
-                constraint_dict[hashed_constraint_dict] = copied_constraint
+            if "stash" in copied_constraint:
+                stash = copied_constraint.pop("stash")
+                hashed_constraint_dict = hash(json.dumps(copied_constraint, sort_keys=True))
 
-            stash_values_dict[hashed_constraint_dict].add(stash)
+                if hashed_constraint_dict not in constraint_dict:
+                    constraint_dict[hashed_constraint_dict] = copied_constraint
+
+                stash_values_dict[hashed_constraint_dict].add(stash)
 
     return constraint_dict, stash_values_dict
 

--- a/cdds/cdds/extract/common.py
+++ b/cdds/cdds/extract/common.py
@@ -1087,7 +1087,7 @@ def get_streamtype(stream: str) -> str:
         return STREAMTYPE_NC
 
 
-def split_stashes_from_constraints(var):
+def split_stashes_from_constraints(constraints_stream):
     """
     Split stash codes from constraints in the given data.
 
@@ -1097,7 +1097,7 @@ def split_stashes_from_constraints(var):
 
     Parameters
     ----------
-    data : list
+    constraints_stream : list
         A list of dictionaries, where each dictionary contains a 'constraint' key
         with a list of constraint specifications.
 
@@ -1114,7 +1114,7 @@ def split_stashes_from_constraints(var):
     constraint_dict = {}
     stash_values_dict = defaultdict(set)
     
-    for x in var:
+    for x in constraints_stream:
         for constraint in x["constraint"]:
             copied_constraint = copy(constraint)
 

--- a/cdds/cdds/extract/common.py
+++ b/cdds/cdds/extract/common.py
@@ -1102,7 +1102,7 @@ def condense_constraints(variable_constraints) ->dict[set]:
 
     Returns
     -------
-    stash_values_dict : collections.defaultdict[set]
+    condensed_constraints : collections.defaultdict[set]
         A defaultdict where the keys are hashed representations of constraints and the 
         values are sets of 'stash' values corresponding to those constraints.
     """

--- a/cdds/cdds/extract/common.py
+++ b/cdds/cdds/extract/common.py
@@ -13,6 +13,7 @@ import subprocess
 import re
 import json
 from copy import copy
+import hashlib
 from collections import defaultdict
 from operator import itemgetter
 from cdds.extract.constants import (NUM_PP_HEADER_LINES, TIME_REGEXP, MAX_MOOSE_LOG_MESSAGE,
@@ -1117,15 +1118,16 @@ def split_stashes_from_constraints(constraints_stream):
     for x in constraints_stream:
         for constraint in x["constraint"]:
             copied_constraint = copy(constraint)
-
+            
             if "stash" in copied_constraint:
                 stash = copied_constraint.pop("stash")
-                hashed_constraint_dict = hash(json.dumps(copied_constraint, sort_keys=True))
+                hashed_constraint_dict = hashlib.md5(json.dumps(copied_constraint, sort_keys=True).encode()).hexdigest()
 
                 if hashed_constraint_dict not in constraint_dict:
                     constraint_dict[hashed_constraint_dict] = copied_constraint
 
                 stash_values_dict[hashed_constraint_dict].add(stash)
+
     return constraint_dict, stash_values_dict
 
 

--- a/cdds/cdds/extract/common.py
+++ b/cdds/cdds/extract/common.py
@@ -12,8 +12,6 @@ import os
 import subprocess
 import re
 import json
-from copy import copy
-import hashlib
 from collections import defaultdict
 from operator import itemgetter
 from cdds.extract.constants import (NUM_PP_HEADER_LINES, TIME_REGEXP, MAX_MOOSE_LOG_MESSAGE,
@@ -1088,9 +1086,9 @@ def get_streamtype(stream: str) -> str:
         return STREAMTYPE_NC
 
 
-def condense_constraints(variable_constraints) ->dict[set]:
+def condense_constraints(variable_constraints) -> dict[set]:
     """
-    Processes a list of dictionaries containing constraints and condenses them by 
+    Processes a list of dictionaries containing constraints and condenses them by
     grouping instances where multiple stash codes correspond to the same constraint
     attributes.
 
@@ -1103,11 +1101,11 @@ def condense_constraints(variable_constraints) ->dict[set]:
     Returns
     -------
     condensed_constraints : collections.defaultdict[set]
-        A defaultdict where the keys are hashed representations of constraints and the 
+        A defaultdict where the keys are hashed representations of constraints and the
         values are sets of 'stash' values corresponding to those constraints.
     """
     condensed_constraints = defaultdict(set)
-    
+
     for variable in variable_constraints:
         for constraint in variable["constraint"]:
             if "stash" in constraint:

--- a/cdds/cdds/extract/common.py
+++ b/cdds/cdds/extract/common.py
@@ -11,6 +11,8 @@ import pwd
 import os
 import subprocess
 import re
+import json
+from copy import copy
 from collections import defaultdict
 from operator import itemgetter
 from cdds.extract.constants import (NUM_PP_HEADER_LINES, TIME_REGEXP, MAX_MOOSE_LOG_MESSAGE,
@@ -1083,3 +1085,81 @@ def get_streamtype(stream: str) -> str:
         return STREAMTYPE_PP
     else:
         return STREAMTYPE_NC
+
+
+def split_stashes_from_constraints(var):
+    """
+    Split stash codes from constraints in the given data.
+
+    This function processes a list of dictionaries containing constraints and separates
+    the 'stash' values from the constraints into their own set. It generates two dictionaries 
+    using the hashes of the constraints dictionaries as keys and removes any duplicate values.
+
+    Parameters
+    ----------
+    data : list
+        A list of dictionaries, where each dictionary contains a 'constraint' key
+        with a list of constraint specifications.
+
+    Returns
+    -------
+    constraint_dict : dict
+        A dictionary where the keys are hashed representations of constraints (excluding 'stash'),
+        and the values are the constraint dictionaries themselves.
+
+    stash_values_dict : collections.defaultdict
+        A defaultdict where the keys are hashed representations of constraints and the values
+        are sets of 'stash' values corresponding to those constraints.
+    """
+    constraint_dict = {}
+    stash_values_dict = defaultdict(set)
+    
+    for x in var:
+        for constraint in x["constraint"]:
+            copied_constraint = copy(constraint)
+            stash = copied_constraint.pop("stash")
+            hashed_constraint_dict = hash(json.dumps(copied_constraint, sort_keys=True))
+
+            if hashed_constraint_dict not in constraint_dict:
+                constraint_dict[hashed_constraint_dict] = copied_constraint
+
+            stash_values_dict[hashed_constraint_dict].add(stash)
+
+    return constraint_dict, stash_values_dict
+
+
+def merge_condensed_stashes(constraint_dict, stash_values_dict):
+    """
+    Merge condensed stash values into constraints.
+
+    This function takes two dictionaries: one containing constraints and another containing
+    sets of stash values associated with those constraints. It merges the stash values into
+    their respective constraints and returns a list of dictionaries with the merged data.
+
+    Parameters
+    ----------
+    constraint_dict : dict
+        A dictionary where the keys are hashed representations of constraints (excluding 'stash'),
+        and the values are the constraint dictionaries themselves.
+
+    stash_values_dict : collections.defaultdict
+        A defaultdict where the keys are hashed representations of constraints and the values
+        are sets of 'stash' values corresponding to those constraints.
+
+    Returns
+    -------
+    final_constraints : list
+        A list of dictionaries, where each dictionary contains a 'constraint' key with the merged
+        constraint and stash values.
+    """
+    condensed_constraints = []
+
+    for key in constraint_dict:
+        if key in stash_values_dict:
+            merged_dict = {
+                **constraint_dict[key], 
+                'stash': list(stash_values_dict[key])
+            }
+            condensed_constraints.append({'constraint': merged_dict})
+
+    return condensed_constraints

--- a/cdds/cdds/extract/common.py
+++ b/cdds/cdds/extract/common.py
@@ -1107,7 +1107,7 @@ def split_stashes_from_constraints(constraints_stream):
         A dictionary where the keys are hashed representations of constraints (excluding 'stash'),
         and the values are the constraint dictionaries themselves.
 
-    stash_values_dict : collections.defaultdict
+    stash_values_dict : collections.defaultdict[set]
         A defaultdict where the keys are hashed representations of constraints and the values
         are sets of 'stash' values corresponding to those constraints.
     """
@@ -1126,7 +1126,6 @@ def split_stashes_from_constraints(constraints_stream):
                     constraint_dict[hashed_constraint_dict] = copied_constraint
 
                 stash_values_dict[hashed_constraint_dict].add(stash)
-
     return constraint_dict, stash_values_dict
 
 

--- a/cdds/cdds/extract/filters.py
+++ b/cdds/cdds/extract/filters.py
@@ -301,7 +301,6 @@ class Filters(object):
                 elif var["status"] in ["ok", "embargoed"]:
                     filter_msg.append(var)
 
-                
             # condense duplicated constraints in stream
             condensed_constraints = condense_constraints(self.mappings.get(stream))
 
@@ -312,7 +311,7 @@ class Filters(object):
                 deserialised_constraint_attributes = json.loads(serialised_constraints)
                 for key, value in deserialised_constraint_attributes.items():
                     if isinstance(value, list):
-                        value ='(' + ', '.join(map(str, value)) + ')'
+                        value = '(' + ', '.join([str(v) for v in value]) + ')'
                     filter_block += (f" {key}={str(value)}\n")
 
                 # format and collate corresponding stash codes

--- a/cdds/cdds/extract/filters.py
+++ b/cdds/cdds/extract/filters.py
@@ -302,10 +302,10 @@ class Filters(object):
                     filter_msg.append(var)
 
                 
-            #condense duplicated constraints
+            # condense duplicated constraints in stream
             condensed_constraints = condense_constraints(self.mappings.get(stream))
 
-            # Generate filter blocks from each constraint and concatenate them
+            # generate filter blocks from each constraint and concatenate them
             for serialised_constraints, corresponding_stashes in condensed_constraints.items():
                 filter_block = "begin\n"
                 # write each constraint to the filter block

--- a/cdds/cdds/tests/test_extract/test_common.py
+++ b/cdds/cdds/tests/test_extract/test_common.py
@@ -336,7 +336,7 @@ class TestChunkByFilesAndTapes(unittest.TestCase):
 
 class TestCondenseStashes(unittest.TestCase):
 
-    @patch('builtins.hash', lambda x: 123456789)
+    # @patch('builtins.hash', lambda x: 123456789)
     def test_split_stashes(self):
         constraint = [
         {
@@ -359,11 +359,12 @@ class TestCondenseStashes(unittest.TestCase):
             "table": "Amon"
         }
     ]
+        expected_hash = "61bb7d83d902471456e88fbcb2fec1d7"
         output_constraint_dict, output_stash_values_dict = split_stashes_from_constraints(constraint)
         self.assertEqual(output_constraint_dict, {
-            123456789: {'lbproc': 128, 'lbtim_ia': 1, 'lbtim_ib': 2}
+            expected_hash: {'lbproc': 128, 'lbtim_ia': 1, 'lbtim_ib': 2}
         })
-        self.assertEqual(output_stash_values_dict, {123456789: {'m01s50i063', 'm01s34i055'}})
+        self.assertEqual(output_stash_values_dict, {expected_hash: {'m01s50i063', 'm01s34i055'}})
 
 
     def test_merge_condensed_stashes(self):

--- a/cdds/cdds/tests/test_extract/test_common.py
+++ b/cdds/cdds/tests/test_extract/test_common.py
@@ -12,7 +12,7 @@ import pytest
 from unittest.mock import patch
 from cdds.extract.common import (
     validate_stash_fields, validate_netcdf, check_moo_cmd, calculate_period, FileContentError,
-    StreamValidationResult, create_dir, build_mass_location, chunk_by_files_and_tapes)
+    StreamValidationResult, create_dir, build_mass_location, chunk_by_files_and_tapes, split_stashes_from_constraints, merge_condensed_stashes)
 from cdds.tests.test_common.common import create_simple_netcdf_file
 from cdds.tests.test_extract.common import break_netcdf_file, init_defaultdict
 from cdds.tests.test_extract.constants import (

--- a/cdds/cdds/tests/test_extract/test_common.py
+++ b/cdds/cdds/tests/test_extract/test_common.py
@@ -373,7 +373,6 @@ class TestCondenseStashes(unittest.TestCase):
 
 
     def test_merge_condensed_stashes(self):
-        # expected_constraint_dict = [{'constraint': {'lbproc': 128, 'lbtim_ia': 1, 'lbtim_ib': 2, 'stash': ['m01s34i055', 'm01s50i063']}}, {'constraint': {'lbproc': 824, 'lbtim_ia': 6, 'lbtim_ib': 1, 'stash': ['m01s50i066', 'm01s34i052']}}]
         expected_constraint_dict = [
             {
             'constraint': {
@@ -393,7 +392,13 @@ class TestCondenseStashes(unittest.TestCase):
             }
         ]
         output_condensed_constraints = merge_condensed_stashes(self.constraint_dict, self.stash_values_dict)
-        breakpoint()
+
+        # Sort stash values in both expected and output for consistent comparison
+        for constraint in expected_constraint_dict:
+            constraint['constraint']['stash'].sort()
+        for constraint in output_condensed_constraints:
+            constraint['constraint']['stash'].sort()
+            
         self.assertEqual(output_condensed_constraints, expected_constraint_dict)
 
 if __name__ == "__main__":

--- a/cdds/cdds/tests/test_extract/test_common.py
+++ b/cdds/cdds/tests/test_extract/test_common.py
@@ -332,50 +332,52 @@ class TestChunkByFilesAndTapes(unittest.TestCase):
             ['t8_file20']
         ]
         self.assertEqual(expected_fileset, chunk_by_files_and_tapes(self.tapes_dict, tape_limit, file_limit))
-    
+
 
 class TestCondenseStashes(unittest.TestCase):
 
     def test_condense_constraints(self):
         constraint = [
-        {
-            "constraint": [
-                {
-                    "lbproc": 128,
-                    "lbtim_ia": 1,
-                    "lbtim_ib": 2,
-                    "stash": "m01s50i063"
-                },
-                {
-                    "lbproc": 128,
-                    "lbtim_ia": 1,
-                    "lbtim_ib": 2,
-                    "stash": "m01s34i055"
-                }
-            ],
-            "name": "cfc11global",
-            "status": "ok",
-            "table": "Amon"
-        }
-    ]
+            {
+                "constraint": [
+                    {
+                        "lbproc": 128,
+                        "lbtim_ia": 1,
+                        "lbtim_ib": 2,
+                        "stash": "m01s50i063"
+                    },
+                    {
+                        "lbproc": 128,
+                        "lbtim_ia": 1,
+                        "lbtim_ib": 2,
+                        "stash": "m01s34i055"
+                    }
+                ],
+                "name": "cfc11global",
+                "status": "ok",
+                "table": "Amon"
+            }
+        ]
         constraint_without_attributes = [
-        {
-            "constraint": [
-                {
-                    "stash": "m01s00i033"
-                }
-            ]
-        }
-    ]
+            {
+                "constraint": [
+                    {
+                        "stash": "m01s00i033"
+                    }
+                ]
+            }
+        ]
         condensed_constraints = condense_constraints(constraint)
         constraint_constraint_without_attributes = condense_constraints(constraint_without_attributes)
-        self.assertEqual(condensed_constraints, 
+        self.assertEqual(
+            condensed_constraints,
             {'{"lbproc": 128, "lbtim_ia": 1, "lbtim_ib": 2}': {'m01s34i055', 'm01s50i063'}}
         )
-        self.assertEqual(constraint_constraint_without_attributes, 
+        self.assertEqual(
+            constraint_constraint_without_attributes,
             {'{}': {'m01s00i033'}}
         )
-                
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cdds/cdds/tests/test_extract/test_common.py
+++ b/cdds/cdds/tests/test_extract/test_common.py
@@ -365,7 +365,6 @@ class TestCondenseStashes(unittest.TestCase):
     @patch('builtins.hash', lambda x: 123456789)
     def test_split_stashes(self):
         output_constraint_dict, output_stash_values_dict = split_stashes_from_constraints(self.constraint)
-        # breakpoint()
         self.assertEqual(output_constraint_dict, {
             123456789: {'lbproc': 128, 'lbtim_ia': 1, 'lbtim_ib': 2}
         })
@@ -400,6 +399,8 @@ class TestCondenseStashes(unittest.TestCase):
             constraint['constraint']['stash'].sort()
             
         self.assertEqual(output_condensed_constraints, expected_constraint_dict)
+
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/cdds/cdds/tests/test_extract/test_common.py
+++ b/cdds/cdds/tests/test_extract/test_common.py
@@ -335,7 +335,10 @@ class TestChunkByFilesAndTapes(unittest.TestCase):
     
 
 class TestCondenseStashes(unittest.TestCase):
-    constraint = [
+
+    @patch('builtins.hash', lambda x: 123456789)
+    def test_split_stashes(self):
+        constraint = [
         {
             "constraint": [
                 {
@@ -356,15 +359,7 @@ class TestCondenseStashes(unittest.TestCase):
             "table": "Amon"
         }
     ]
-
-    constraint_dict = {123456789: {'lbproc': 128, 'lbtim_ia': 1, 'lbtim_ib': 2},
-                       453454464: {'lbproc': 824, 'lbtim_ia': 6, 'lbtim_ib': 1}}
-
-    stash_values_dict = {123456789: {'m01s50i063', 'm01s34i055'}, 453454464: {'m01s50i066', 'm01s34i052'}}
-
-    @patch('builtins.hash', lambda x: 123456789)
-    def test_split_stashes(self):
-        output_constraint_dict, output_stash_values_dict = split_stashes_from_constraints(self.constraint)
+        output_constraint_dict, output_stash_values_dict = split_stashes_from_constraints(constraint)
         self.assertEqual(output_constraint_dict, {
             123456789: {'lbproc': 128, 'lbtim_ia': 1, 'lbtim_ib': 2}
         })
@@ -390,9 +385,13 @@ class TestCondenseStashes(unittest.TestCase):
             }
             }
         ]
-        output_condensed_constraints = merge_condensed_stashes(self.constraint_dict, self.stash_values_dict)
+        constraint_dict = {123456789: {'lbproc': 128, 'lbtim_ia': 1, 'lbtim_ib': 2},
+                        453454464: {'lbproc': 824, 'lbtim_ia': 6, 'lbtim_ib': 1}}
 
-        # Sort stash values in both expected and output for consistent comparison
+        stash_values_dict = {123456789: {'m01s50i063', 'm01s34i055'}, 453454464: {'m01s50i066', 'm01s34i052'}}
+        output_condensed_constraints = merge_condensed_stashes(constraint_dict, stash_values_dict)
+
+        # Sort stash values in both expected and output for consistent list comparison.
         for constraint in expected_constraint_dict:
             constraint['constraint']['stash'].sort()
         for constraint in output_condensed_constraints:

--- a/cdds/cdds/tests/test_extract/test_filters.py
+++ b/cdds/cdds/tests/test_extract/test_filters.py
@@ -310,7 +310,6 @@ class TestFilters(unittest.TestCase):
 
     @patch("cdds.extract.filters.ModelToMip.mass_filters")
     def test_skipping_nc_variables_in_filters(self, mock_mass_filters):
-        self.maxDiff = None
         filters = Filters(var_list=self.VAR_LIST)
         model_to_mip_response = {
             "ap5": [

--- a/cdds/cdds/tests/test_extract/test_filters.py
+++ b/cdds/cdds/tests/test_extract/test_filters.py
@@ -310,6 +310,7 @@ class TestFilters(unittest.TestCase):
 
     @patch("cdds.extract.filters.ModelToMip.mass_filters")
     def test_skipping_nc_variables_in_filters(self, mock_mass_filters):
+        self.maxDiff = None
         filters = Filters(var_list=self.VAR_LIST)
         model_to_mip_response = {
             "ap5": [


### PR DESCRIPTION
Closes issue #470 

To solve the issue, two functions were added to `common.py` to condense the stash codes and constraints from the input stream, these were used in `_format_filter_pp` in `filters.py` with some refactoring around generating the filter blocks for the output moose query file.
