### PR TITLE
CDDSO-661 add plugin cfg files to manifest

### DIFF
--- a/mip_convert/MANIFEST.in
+++ b/mip_convert/MANIFEST.in
@@ -5,5 +5,5 @@ include *.md
 include setup.cfg
 include pylintrc
 recursive-include etc *
-recursive-include mip_convert/process *.cfg
+recursive-include mip_convert/ *.cfg
 recursive-include mip_convert/tests *


### PR DESCRIPTION
This PR updates the `MANIFEST.in` in `mip_convert` to include the `.cfg` files used for the plugins.