### PR TITLE
#553: remove last remnants of grp import that was used to set group permissions

### DIFF
--- a/cdds/cdds/common/__init__.py
+++ b/cdds/cdds/common/__init__.py
@@ -5,16 +5,13 @@ The :mod:`common` module contains common library functions used by
 other packages.
 """
 import copy
-import grp
 import hashlib
 import json
 import logging
 import os
-import platform
 import re
 import subprocess
 import sys
-import time
 from collections import defaultdict
 from datetime import datetime
 from packaging.version import parse as parse_version

--- a/cdds/cdds/common/paths/file_system.py
+++ b/cdds/cdds/common/paths/file_system.py
@@ -3,7 +3,6 @@
 """
 Module to modify and manage the UNIX file system
 """
-import grp
 import logging
 import os
 


### PR DESCRIPTION
This is just a quick removal of some unused imports, the grp import was used for ownership change originally.

I don't believe that this has any impact on functionality of CDDS.