### PR TITLE
Issue #575 CLI handle non existent request

### DIFF
--- a/cdds/cdds/tests/test_common/test_request/data/test_request_inheritance_failure.cfg
+++ b/cdds/cdds/tests/test_common/test_request/data/test_request_inheritance_failure.cfg
@@ -1,0 +1,2 @@
+[inheritance]
+template = /this/location/does/not/exist/request.cfg

--- a/cdds/cdds/tests/test_common/test_request/test_request.py
+++ b/cdds/cdds/tests/test_common/test_request/test_request.py
@@ -60,6 +60,16 @@ class TestReadRequest(TestCase):
         self.assertDictEqual(request.inventory.items, expected_test_minimal_inventory())
         self.assertDictEqual(request.conversion.items, expected_test_minimal_conversion())
 
+    def test_read_missing_request_file(self):
+        request_path = os.path.join(self.data_dir, 'non-existent-request-file.cfg')
+        with self.assertRaises(RuntimeError):
+            read_request(request_path)
+
+    def test_read_missing_inheritance_template_in_request_file(self):
+        request_path = os.path.join(self.data_dir, 'test_request_inheritance_failure.cfg')
+        with self.assertRaises(RuntimeError):
+            read_request(request_path)
+
 
 class TestWriteRequest(TestCase):
     def setUp(self) -> None:

--- a/cdds/cdds/validate/request_validations.py
+++ b/cdds/cdds/validate/request_validations.py
@@ -4,12 +4,13 @@
 Module providing functionality to validate request configuration
 """
 import logging
+import os
 
 from configparser import ConfigParser
 from metomi.isodatetime.data import Calendar
 from typing import Tuple, List
 
-from cdds.common.request.request import load_cdds_plugins
+from cdds.common.request.request import load_cdds_plugins, read_request_config
 from cdds.common.request.request import Request
 from cdds.common.request.metadata_section import MetadataSection
 from cdds.common.request.misc_section import MiscSection
@@ -37,18 +38,7 @@ def do_request_validations(request_path: str) -> Tuple[bool, List[str]]:
     valid = True
     messages = []
 
-    interpolation = EnvInterpolation()
-    request_config = ConfigParser(interpolation=interpolation, inline_comment_prefixes=('#',))
-    request_config.optionxform = str   # type: ignore # Preserve case.
-    request_config.read(request_path)
-    if request_config.has_section('inheritance'):
-        template = request_config.get('inheritance', 'template')
-        if template:
-            template_path = expand_path(template)
-            interpolation = EnvInterpolation()
-            request_config = ConfigParser(interpolation=interpolation, inline_comment_prefixes=('#',))
-            request_config.optionxform = str  # type: ignore # Preserve case.
-            request_config.read([template_path, request_path])
+    request_config = read_request_config(request_path)
 
     load_cdds_plugins(request_config)
 

--- a/cdds/cdds/validate/request_validations.py
+++ b/cdds/cdds/validate/request_validations.py
@@ -4,9 +4,7 @@
 Module providing functionality to validate request configuration
 """
 import logging
-import os
 
-from configparser import ConfigParser
 from metomi.isodatetime.data import Calendar
 from typing import Tuple, List
 
@@ -17,9 +15,7 @@ from cdds.common.request.misc_section import MiscSection
 from cdds.common.request.inventory_section import InventorySection
 from cdds.common.request.common_section import CommonSection
 from cdds.common.request.data_section import DataSection
-from cdds.common.configparser.interpolation import EnvInterpolation
 from cdds.common.request.request_validations import validate_request
-from cdds.common.request.request_section import expand_path
 from cdds.common.request.validations.exceptions import CVPathError, CVEntryError
 
 from cdds.common.plugins.plugins import PluginStore


### PR DESCRIPTION
At present if any cdds tool is given a request file that doesn't exist (or the template specified in the `[inheritance]` section does not exist) a cryptic message about mip_era is produced.

This PR includes
* change to code that reads the request config file through refactoring of common code in `cdds.common.request.request.read_request()` and `cdds.validate.request_validations.do_request_validations()` into `read_request_config()`
* Addition of two if statements which will raise `RuntimeError`s if either the request config file or the template it uses are not found
* Two new unit tests to ensure that the `RuntimeError` is raised when paths to request config files don't exist