### PR TITLE
Issue #583: functional version of MIP convert with CMIP7 CVs.

### DIFF
--- a/demonstrator/mip_convert.cfg
+++ b/demonstrator/mip_convert.cfg
@@ -1,0 +1,67 @@
+
+[cmor_setup]
+cmor_log_file = ./cmor.log
+create_subdirectories = 0
+mip_table_dir = ./cmip7-development-mip-tables/development-tables
+netcdf_file_action = CMOR_REPLACE_4
+
+[cmor_dataset]
+branch_method = standard
+calendar = 360_day  
+experiment_id = 1pctCO2
+grid = Native N96 grid; 192 x 144 longitude/latitude
+grid_label = gn
+institution_id = PCMDI
+# License superseded by license_id
+license = CC BY 4.0
+mip = CMIP
+mip_era = CMIP7
+model_id = PCMDI-test-1-0  # This must be in the <MIP_ERA>_CV.json file in the mip_tables directory
+model_type = AOGCM AER
+nominal_resolution = 250 km
+output_dir = .
+parent_base_date = 1850-01-01
+parent_experiment_id = piControl
+parent_mip_era = CMIP7
+parent_model_id = PCMDI-test-1-0
+parent_time_units = days since 1850-01-01
+parent_variant_label = r1i1p1f1
+
+#sub_experiment_id = none # No longer needed
+variant_label = r1i1p1f1  
+
+[global_attributes]
+# Work out why this isn't working in the cmor_dataset section
+branch_time_in_child = 1850-01-01
+branch_time_in_parent = 1860-01-01
+
+# Update to handle license and license_id needed
+license_id = CC BY 4.0
+
+# New stuff -- should be set by default?
+archive_id = WCRP
+host_collection = CMIP7
+
+# variable specific stuff -- need to handle these separately for each variable and
+# it should be trivial to extract from variable name
+
+branding_suffix = tavg-h2m-hxy-u
+temporal_label = tavg
+vertical_label = h2m
+horizontal_label = hxy
+area_label= u
+region = glb
+
+[request]
+# atmos_timestep = 1200  # only required for mappings using ATMOS_TIMESTEP constant
+mip_convert_plugin = HadGEM3GC5  # Set up for this work with bare minimum of mappings
+base_date = 1850-01-01T00:00:00  # used for basis of time units
+deflate_level = 2
+model_output_dir = ./input
+run_bounds = 2000-01-01T00:00:00 2000-06-01T00:00:00
+shuffle = True
+suite_id = suite 
+
+[stream_apm]
+# Note that these two have the same branding suffix
+CMIP7_atmos@mon: uas_tavg-h10m-hxy-u vas_tavg-h10m-hxy-u

--- a/mip_convert/mip_convert/configuration/cv_config.py
+++ b/mip_convert/mip_convert/configuration/cv_config.py
@@ -244,7 +244,11 @@ class CVConfig(JSONConfig):
         sub_experiment_id: str
             The sub-|experiment identifier|.
         """
-        return self._get_value_from_cv(CVKey.SUB_EXPERIMENT_ID, sub_experiment_id)
+        # NEED SOMETHING DIFFERENT HERE FOR TESTS TO PASS
+        if 'sub_experiment_id' in self.config['CV']['required_global_attributes']:
+            return self._get_value_from_cv(CVKey.SUB_EXPERIMENT_ID, sub_experiment_id)
+        else:
+            return None
 
     @property
     def tracking_prefix(self):

--- a/mip_convert/mip_convert/configuration/cv_config.py
+++ b/mip_convert/mip_convert/configuration/cv_config.py
@@ -244,7 +244,6 @@ class CVConfig(JSONConfig):
         sub_experiment_id: str
             The sub-|experiment identifier|.
         """
-        # NEED SOMETHING DIFFERENT HERE FOR TESTS TO PASS
         if 'sub_experiment_id' in self.config['CV']['required_global_attributes']:
             return self._get_value_from_cv(CVKey.SUB_EXPERIMENT_ID, sub_experiment_id)
         else:

--- a/mip_convert/mip_convert/new_variable.py
+++ b/mip_convert/mip_convert/new_variable.py
@@ -942,7 +942,13 @@ class VariableMIPMetadata(object):
                  as specified in the |MIP table|
         :rtype: list
         """
-        return self.variable_info['dimensions'].split()
+        dimensions = self.variable_info['dimensions']
+        if isinstance(dimensions, str):
+            return dimensions.split()
+        elif isinstance(dimensions, list):
+            return dimensions
+        else:
+            raise RuntimeError(f'Dimensions "{dimensions}" not recognised')
 
     @property
     def axes_directions_names(self):

--- a/mip_convert/mip_convert/plugins/hadgem3_gc5/__init__.py
+++ b/mip_convert/mip_convert/plugins/hadgem3_gc5/__init__.py
@@ -1,0 +1,2 @@
+# (C) British Crown Copyright 2024-2025, Met Office.
+# Please see LICENSE.md for license details.

--- a/mip_convert/mip_convert/plugins/hadgem3_gc5/data/HadGEM3GC5_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/hadgem3_gc5/data/HadGEM3GC5_mappings.cfg
@@ -1,0 +1,26 @@
+# (C) British Crown Copyright 2018-2025, Met Office.
+# Please see LICENSE.md for license details.
+#
+# This 'model to MIP mappings' configuration file contains sections
+# for each 'MIP requested variable name' that has a HadGEM3
+# 'model to MIP mapping'. Please see the 'User Guide' for more
+# information.
+
+[DEFAULT]
+positive = None
+reviewer = N/A
+status = embargoed
+
+
+[uas_tavg-h10m-hxy-u]
+dimension = longitude latitude height2m time
+expression = m01s03i209[lbproc=128]
+mip_table_id = atmos
+units = m s-1
+
+[vas_tavg-h10m-hxy-u]
+dimension = longitude latitude height2m time
+expression = m01s03i210[lbproc=128]
+mip_table_id = atmos
+units = m s-1
+

--- a/mip_convert/mip_convert/plugins/hadgem3_gc5/data/__init__.py
+++ b/mip_convert/mip_convert/plugins/hadgem3_gc5/data/__init__.py
@@ -1,0 +1,2 @@
+# (C) British Crown Copyright 2024-2025, Met Office.
+# Please see LICENSE.md for license details.

--- a/mip_convert/mip_convert/plugins/hadgem3_gc5/data/processors.py
+++ b/mip_convert/mip_convert/plugins/hadgem3_gc5/data/processors.py
@@ -1,0 +1,2 @@
+# (C) British Crown Copyright 2025, Met Office.
+# Please see LICENSE.md for license details.

--- a/mip_convert/mip_convert/plugins/hadgem3_gc5/hadgem3_gc5_plugin.py
+++ b/mip_convert/mip_convert/plugins/hadgem3_gc5/hadgem3_gc5_plugin.py
@@ -1,0 +1,42 @@
+# (C) British Crown Copyright 2024-2025, Met Office.
+# Please see LICENSE.md for license details.
+"""
+The :mod:`hadgem3_plugin` module contains the code for the HadGEM3 plugin.
+"""
+import os
+
+from typing import Dict, Any
+
+import iris.cube
+
+from mip_convert.plugins.base.base_plugin import BaseMappingPlugin
+from mip_convert.plugins.base.data.processors import *
+from mip_convert.plugins.hadgem3.data.processors import *
+
+
+class HadGEM3GC5MappingPlugin(BaseMappingPlugin):
+    """
+    Plugin for HadGEM3-GC5 models
+    """
+
+    def __init__(self):
+        data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+        super(HadGEM3GC5MappingPlugin, self).__init__('HadGEM3GC5', data_dir)
+
+        self.input_variables: Dict[str, iris.cube.Cube] = {}
+
+    def evaluate_expression(self, expression: Any, input_variables: Dict[str, iris.cube.Cube]) -> iris.cube.Cube:
+        """
+        Update the iris Cube containing in the input variables list by evaluating the given expression.
+
+        :param expression: Expression to be evaluated
+        :type expression: Any
+        :param input_variables: The input variables required to produce the
+            MIP requested variable in the form {input_variable_name: cube}.
+        :type input_variables: Dict[str, Cube]
+        :return: The updated iris Cube
+        :rtype: Cube
+        """
+        # TODO: Remove assign to class variable after refactoring mipconvert.mipconvert.new_variable line 793
+        self.input_variables = input_variables
+        return eval(expression)

--- a/mip_convert/mip_convert/plugins/plugin_loader.py
+++ b/mip_convert/mip_convert/plugins/plugin_loader.py
@@ -15,13 +15,15 @@ from mip_convert.plugins.hadgem3.hadgem3_plugin import HadGEM3MappingPlugin
 from mip_convert.plugins.ukesm1.ukesm1_plugin import UKESM1MappingPlugin
 from mip_convert.plugins.hadrem_cp4a.hadrem_cp4a_plugin import HadREM_CP4AMappingPlugin
 from mip_convert.plugins.hadrem3.hadrem3_plugin import HadREM3MappingPlugin
+from mip_convert.plugins.hadgem3_gc5.hadgem3_gc5_plugin import HadGEM3GC5MappingPlugin
 from mip_convert.plugins.exceptions import PluginLoadError
 
 
 INTERNAL_PLUGINS: List[MappingPlugin] = [HadGEM3MappingPlugin(),
                                          UKESM1MappingPlugin(),
                                          HadREM3MappingPlugin(),
-                                         HadREM_CP4AMappingPlugin()]
+                                         HadREM_CP4AMappingPlugin(),
+                                         HadGEM3GC5MappingPlugin()]
 
 
 def load_mapping_plugin(plugin_id: str, plugin_module_path: str = None, plugin_location: str = None) -> None:

--- a/mip_convert/mip_convert/request.py
+++ b/mip_convert/mip_convert/request.py
@@ -111,6 +111,11 @@ def convert(parameters):
         model_to_mip_mappings = mapping_plugin.load_model_to_mip_mapping(mip_table_name)
 
         # Read and validate the 'MIP table'.
+        # Handle CMIP7 style references:
+        if "@" in mip_table_name:
+            mip_table_name, frequency = mip_table_name.split("@")
+        else:
+            frequency = None
         mip_table_name_json = mip_table_name + '.json'
         mip_table = get_mip_table(user_config.inpath, mip_table_name_json)
 
@@ -119,7 +124,7 @@ def convert(parameters):
             try:
                 produce_mip_requested_variable(variable_name, stream_id, substream, mip_table, user_config,
                                                site_information, hybrid_height_information, replacement_coordinates,
-                                               model_to_mip_mappings, filenames)
+                                               model_to_mip_mappings, filenames, frequency)
             except Exception as error:
                 total_number_of_variables_with_errors += 1
                 message = 'Unable to produce MIP requested variable "{}" for "{}": {}'

--- a/mip_convert/mip_convert/requested_variables.py
+++ b/mip_convert/mip_convert/requested_variables.py
@@ -57,7 +57,7 @@ def get_requested_variables(
 def produce_mip_requested_variable(
         variable_name: str, stream_id: str, substream: str, mip_table: MIPConfig, user_config: UserConfig,
         site_information: SitesConfig, hybrid_height_information: HybridHeightConfig, replacement_coordinates: CubeList,
-        model_to_mip_mappings: ModelToMIPMappingConfig, filenames: List[str]) -> None:
+        model_to_mip_mappings: ModelToMIPMappingConfig, filenames: List[str], frequency: str) -> None:
     """
     Produce the |output netCDF files| for the |MIP requested variable|.
 
@@ -85,6 +85,8 @@ def produce_mip_requested_variable(
         The filenames (including the full path) of the files required
         to produce the |output netCDF files| for the
         |MIP requested variable|.
+    frequency: str or None
+        The frequency at which to procude the specified variable.
     """
     # Retrieve the logger.
     logger = logging.getLogger(__name__)
@@ -115,6 +117,9 @@ def produce_mip_requested_variable(
 
     # Create the CMOR saver.
     saver = cmor_lite.get_saver(mip_table.name, variable_name)
+    # set the frequency to use if needed
+    if frequency:
+        saver.cmor.set_frequency(frequency)
 
     # Process the data by performing the appropriate 'model to MIP mapping', then save the 'MIP output variable'
     # to an 'output netCDF file'.

--- a/mip_convert/mip_convert/save/cmor/cmor_dataset.py
+++ b/mip_convert/mip_convert/save/cmor/cmor_dataset.py
@@ -152,7 +152,10 @@ class Dataset(object):
         self._items.update({'history': self._user_config.history})
         # Add whether CMIP6 validation should be performed.
         if not self._relaxed_cmor:
-            self._items.update({'_cmip6_option': 'CMIP6'})
+            if self._items['mip_era'].startswith('CMIP7'):
+                self._items.update({'_cmip7_option': 'CMIP7'})
+            else:
+                self._items.update({'_cmip6_option': 'CMIP6'})
         # Add the items that can be determined from the 'variant_label'.
         self._items.update(self._items_from_variant_label)
         # Add the items that can be determined from the CV file.
@@ -192,7 +195,7 @@ class Dataset(object):
         FILES_TO_REMOVE.append(filename)
         # log CMOR JSON file content
         logger = logging.getLogger(__name__)
-        logger.debug('CMOR json file content: {}'.format(json.dumps(self.items)))
+        logger.debug('CMOR json file content: {}'.format(json.dumps(self.items, indent=2, sort_keys=True)))
         return filename
 
     @property

--- a/mip_convert/mip_convert/save/cmor/cmor_wrapper.py
+++ b/mip_convert/mip_convert/save/cmor/cmor_wrapper.py
@@ -113,3 +113,7 @@ class CmorWrapper(ObjectWithLogger):
     def zfactor(self, *args, **kwargs):
         self._debug_on_args('zfactor', args, kwargs)
         cmor.zfactor(*args, **kwargs)
+
+    def set_frequency(self, frequency, **kwargs):
+        self._debug_on_args('frequency', frequency, kwargs)
+        cmor.cmor.set_cur_dataset_attribute('frequency', frequency)

--- a/mip_convert/mip_convert/save/mip_config.py
+++ b/mip_convert/mip_convert/save/mip_config.py
@@ -193,7 +193,13 @@ class MipVar(object):
         """
         returns a list of dimension entry names for this variable
         """
-        return self.parsed['dimensions'].split()
+        dimensions = self.parsed['dimensions']
+        if isinstance(dimensions, str):
+            return dimensions.split()
+        elif isinstance(dimensions, list):
+            return dimensions
+        else:
+            raise RuntimeError(f'Dimensions "{dimensions}" not recognised')
 
 
 class MipAxis(object):

--- a/mip_convert/mip_convert/tests/test_save/test_cmor/test_cmor_dataset.py
+++ b/mip_convert/mip_convert/tests/test_save/test_cmor/test_cmor_dataset.py
@@ -114,7 +114,7 @@ class TestDataset(unittest.TestCase):
         self.parent_activity_id = 'CMIP'
         self.required_global_attributes = [
             'activity_id', 'branch_method', 'experiment', 'experiment_id', 'institution_id',
-            'source', 'source_type', 'variant_label'
+            'source', 'source_type', 'sub_experiment_id', 'sub_experiment', 'variant_label'
         ]
         self.required_source_type = ['AOGCM', 'BGC']
         self.source = 'Long description of model'


### PR DESCRIPTION
A couple of tests related to the handling of sub_experiment_id are failing, but all functional tests pass.

demonstrator directory to be deleted once we have a cmip7 functional test

    * New mappings plugin for HadGEM3GC5 to separate mappings for branded variables
    * Changes to add a call to cmor wrapper to clearly set the frequency
    * Changes needed to interpret new MIP tables correctly
    * Example mip_convert config file

    The CMIP7_CV.json file being used is slightly modified relative to the
    one in github as it has additional entries for "mip_era" and
    "parent_mip_era" which have been missed.