### PR TITLE
Issue #588: modification to handling of branding information

### DIFF
--- a/mip_convert/mip_convert/configuration/cv_config.py
+++ b/mip_convert/mip_convert/configuration/cv_config.py
@@ -290,6 +290,12 @@ class CVConfig(JSONConfig):
             'Conventions', 'creation_date', 'data_specs_version', 'frequency',
             'mip_era', 'product', 'realm', 'table_id', 'tracking_id',
             'variable_id']
+
+        if 'CMIP7' in self.config['CV']['mip_era']:
+            written_by_cmor += [
+                'area_label', 'branding_suffix', 'horizontal_label',
+                'temporal_label', 'vertical_label']
+
         required = []
         if CVKey.REQUIRED_GLOBAL_ATTRIBUTES in self.config['CV']:
             required = self.config['CV'][CVKey.REQUIRED_GLOBAL_ATTRIBUTES]

--- a/mip_convert/mip_convert/tests/test_configuration/test_cv_config.py
+++ b/mip_convert/mip_convert/tests/test_configuration/test_cv_config.py
@@ -66,6 +66,7 @@ class TestCVConfig(unittest.TestCase):
                 'institution_id': {
                     self.institution_id: self.institution
                 },
+                'mip_era': self.mip_era,
                 'source_id': {
                     self.source_id: {
                         'source': self.source

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip7/test_cmip7_mon_uas_tavg_h10m_hxy_u.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip7/test_cmip7_mon_uas_tavg_h10m_hxy_u.py
@@ -45,7 +45,7 @@ class TestCmip7_uas_tavg_h10m_hxy_u(AbstractFunctionalTests):
             )
         )
 
-    # @pytest.mark.slow
+    @pytest.mark.slow
     def test_cmip7_amon_tasmax(self):
         self.maxDiff = True
         self.check_convert()

--- a/mip_convert/mip_convert/tests/test_functional/utils/configurations.py
+++ b/mip_convert/mip_convert/tests/test_functional/utils/configurations.py
@@ -222,26 +222,19 @@ class ProjectInfo:
                 'variant_label': 'r1i1p1f1',
                 'parent_experiment_id': 'piControl',
                 'parent_mip_era': 'CMIP7',
+                'parent_model_id': 'PCMDI-test-1-0',
                 'parent_time_units': 'days since 1850-01-01',
                 'parent_variant_label': 'r1i1p1f1'
-
             },
             request={
                 'base_date': '1850-01-01T00:00:00',
                 'force_coordinate_rotation': False
             },
             global_attributes={
-                # 'further_info_url': 'https://furtherinfo.es-doc.org/CMIP6.MOHC.UKESM1-0-LL.amip.none.r1i1p1f1',
                 'archive_id': 'WCRP',
-                'area_label': 'u',
                 'branch_time_in_child': "1850-01-01",
                 'branch_time_in_parent': "1860-01-01",
-                'branding_suffix': 'tavg-h2m-hxy-u',
-                'temporal_label': 'tavg',
-                'vertical_label': 'h2m',
-                'horizontal_label': 'hxy',
                 'host_collection': 'CMIP7',
-                'parent_source_id': "PCMDI-test-1-0",
                 'region': "glb",
                 'license_id': 'CC BY 4.0'
             }

--- a/mip_convert/mip_convert/tests/test_save/test_cmor/test_cmor_dataset.py
+++ b/mip_convert/mip_convert/tests/test_save/test_cmor/test_cmor_dataset.py
@@ -139,6 +139,7 @@ class TestDataset(unittest.TestCase):
                 'institution_id': {
                     self.institution_id: self.institution
                 },
+                'mip_era': self.mip_era,
                 'source_id': {
                     self.source_id: {'source': self.source}
                 },


### PR DESCRIPTION
Changes:
* tweak to CVConfig to avoid errors related to checking of the global attributes that will be handled entirely by CMOR
* Updates to tests to (a) remove the branding metadata (b) ensure that the mip_era is available in all tests that work with a dummy version of a CV.

