### PR TITLE
#586 cmip7 fix branch point specification

### DIFF
--- a/demonstrator/mip_convert.cfg
+++ b/demonstrator/mip_convert.cfg
@@ -7,7 +7,9 @@ netcdf_file_action = CMOR_REPLACE_4
 
 [cmor_dataset]
 branch_method = standard
-calendar = 360_day  
+branch_date_in_child = 1850-01-01T00:00:00
+branch_date_in_parent = 1860-01-01T00:00:00
+calendar = 360_day
 experiment_id = 1pctCO2
 grid = Native N96 grid; 192 x 144 longitude/latitude
 grid_label = gn
@@ -19,25 +21,19 @@ model_id = PCMDI-test-1-0  # This must be in the <MIP_ERA>_CV.json file in the m
 model_type = AOGCM AER
 nominal_resolution = 250 km
 output_dir = .
-parent_base_date = 1850-01-01
+parent_base_date = 1850-01-01T00:00:00
 parent_experiment_id = piControl
 parent_mip_era = CMIP7
 parent_model_id = PCMDI-test-1-0
 parent_time_units = days since 1850-01-01
 parent_variant_label = r1i1p1f1
-
 #sub_experiment_id = none # No longer needed
-variant_label = r1i1p1f1  
+variant_label = r1i1p1f1
 
 [global_attributes]
-# Work out why this isn't working in the cmor_dataset section
-branch_time_in_child = 1850-01-01
-branch_time_in_parent = 1860-01-01
-
 # New stuff -- should be set by default?
 archive_id = WCRP
 host_collection = CMIP7
-
 # region should be linked to grid and grid_label
 region = glb
 
@@ -49,7 +45,7 @@ deflate_level = 2
 model_output_dir = ./input
 run_bounds = 2000-01-01T00:00:00 2000-06-01T00:00:00
 shuffle = True
-suite_id = suite 
+suite_id = suite
 
 [stream_apm]
 # Note that these two have the same branding suffix

--- a/mip_convert/mip_convert/tests/test_functional/test_functional_cmip7/test_cmip7_mon_uas_tavg_h10m_hxy_u.py
+++ b/mip_convert/mip_convert/tests/test_functional/test_functional_cmip7/test_cmip7_mon_uas_tavg_h10m_hxy_u.py
@@ -38,7 +38,7 @@ class TestCmip7_uas_tavg_h10m_hxy_u(AbstractFunctionalTests):
                     'ap5': {'CMIP7_atmos@mon': 'uas_tavg-h10m-hxy-u'}
                 },
                 other={
-                    'reference_version': 'v1',
+                    'reference_version': 'v2',
                     'filenames': ['uas_atmos_PCMDI-test-1-0_1pctCO2_r1i1p1f1_gn_196002-196003.nc'],
                     'ignore_history': True,
                 }

--- a/mip_convert/mip_convert/tests/test_functional/utils/configurations.py
+++ b/mip_convert/mip_convert/tests/test_functional/utils/configurations.py
@@ -212,6 +212,8 @@ class ProjectInfo:
             cmor_dataset={
                 'grid': 'Native N96 grid; 192 x 144 longitude/latitude',
                 'branch_method': 'standard',
+                'branch_date_in_child': "1850-01-01T00:00:00",
+                'branch_date_in_parent': "1860-01-01T00:00:00",
                 'experiment_id': '1pctCO2',
                 'license': CMIP7_LICENSE,
                 'mip': 'CMIP',
@@ -220,6 +222,7 @@ class ProjectInfo:
                 'model_type': 'AOGCM AER',
                 'nominal_resolution': '250 km',
                 'variant_label': 'r1i1p1f1',
+                'parent_base_date': '1850-01-01T00:00:00',
                 'parent_experiment_id': 'piControl',
                 'parent_mip_era': 'CMIP7',
                 'parent_model_id': 'PCMDI-test-1-0',
@@ -232,8 +235,6 @@ class ProjectInfo:
             },
             global_attributes={
                 'archive_id': 'WCRP',
-                'branch_time_in_child': "1850-01-01",
-                'branch_time_in_parent': "1860-01-01",
                 'host_collection': 'CMIP7',
                 'region': "glb",
             }


### PR DESCRIPTION
This fixes #586 by moving the branch_* attributes into the `cmor_dataset` section and renaming then. Functional test also updated.