### PR TITLE
Issue #504: Replace footnotes

### DIFF
--- a/docs/tutorials/add_mapping.md
+++ b/docs/tutorials/add_mapping.md
@@ -62,7 +62,7 @@ The `[variable name]` sections provide the model to MIP mapping corresponding to
 | `expression`                         | The expression required to convert the input variable / input variables to the MIP requested variable.           |        |
 | `mip_table_id`                       | A space-separated list of MIP table identifiers that the model to MIP mapping is valid for.                      |        |
 | `positive`                           | The direction of a vertical energy (heat) flux or surface momentum flux (stress) input; use 'up' or 'down' depending on whether the direction is positive when it is directed upward or downward, respectively. This argument is required for vertical energy and salt fluxes, for flux correction fields, and for surface stress.| *1*   |
-| `status`                             | The status of the MIP requested variable. Valid values are `ok` and `embargoed`.                                 | *2**3* |
+| `status`                             | The status of the MIP requested variable. Valid values are `ok` and `embargoed`.                                 | *2*, *3* |
 | `units`                              | The units of the data of the MIP requested variable i.e., after the `expression` has been applied.               |        |
 
 

--- a/docs/tutorials/add_mapping.md
+++ b/docs/tutorials/add_mapping.md
@@ -61,8 +61,8 @@ The `[variable name]` sections provide the model to MIP mapping corresponding to
 | `dimension`                          | The dimensions of the MIP requested variable.                                                                    |        |
 | `expression`                         | The expression required to convert the input variable / input variables to the MIP requested variable.           |        |
 | `mip_table_id`                       | A space-separated list of MIP table identifiers that the model to MIP mapping is valid for.                      |        |
-| `positive`                           | The direction of a vertical energy (heat) flux or surface momentum flux (stress) input; use 'up' or 'down' depending on whether the direction is positive when it is directed upward or downward, respectively. This argument is required for vertical energy and salt fluxes, for flux correction fields, and for surface stress.| [1]   |
-| `status`                             | The status of the MIP requested variable. Valid values are `ok` and `embargoed`.                                 | [2][3] |
+| `positive`                           | The direction of a vertical energy (heat) flux or surface momentum flux (stress) input; use 'up' or 'down' depending on whether the direction is positive when it is directed upward or downward, respectively. This argument is required for vertical energy and salt fluxes, for flux correction fields, and for surface stress.| *1*   |
+| `status`                             | The status of the MIP requested variable. Valid values are `ok` and `embargoed`.                                 | *2**3* |
 | `units`                              | The units of the data of the MIP requested variable i.e., after the `expression` has been applied.               |        |
 
 

--- a/docs/tutorials/mip_convert.md
+++ b/docs/tutorials/mip_convert.md
@@ -189,7 +189,8 @@ MIP Convert determines:
     
     1. CMOR requires ``branch_time_in_child`` and ``branch_time_in_parent``, which is determined from the options ``base_date`` (see the `request <request_section>` section) / ``parent_base_date`` (the base date of the ``child_experiment_id`` / ``parent_experiment_id``) and ``branch_date_in_child`` / ``branch_date_in_parent`` (the date in the ``child_experiment_id`` / ``parent_experiment_id`` from which the experiment branches) from the `cmor_dataset <cmor_dataset_section>` section in the |user configuration file| by taking the difference (in days) between the ``branch_date_in_child`` / ``branch_date_in_parent`` and the ``base_date`` / ``parent_base_date``. If ``branch_date_in_child`` or ``branch_date_in_parent`` is ``N/A`` then ``branch_time_in_parent`` is set to 0.
     2. Dates should be provided in the form `YYYY-MM-DDThh:mm:ssZ`.
-    3. For a description of each option, please see the [CMIP6 Global Attributes document](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/) See ``parent_source_id`` in the [CMIP6 Global Attributes document](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/).
+    3. For a description of each option, please see the [CMIP6 Global Attributes document](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/).
+    4. See ``parent_source_id`` in the [CMIP6 Global Attributes document](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/).
     
     
 ### **request**

--- a/docs/tutorials/mip_convert.md
+++ b/docs/tutorials/mip_convert.md
@@ -120,7 +120,7 @@ For a description of each option please see the documentation for [cmor_setup()]
 
 ### **cmor_dataset**
 
-The required `cmor_dataset` section contains the following options used for [cmor_data_set_json()](https://cmor.llnl.gov/mydoc_cmor3_api/#cmor_dataset_json)
+The required `cmor_dataset` section contains the following options used for [cmor_data_set_json()](https://cmor.llnl.gov/mydoc_cmor3_api/#cmor_dataset_json) for CMIP6.
 
 |              Option             | Required by        |          Used by   | Notes   |
 |---------------------------------|--------------------|--------------------|---------|
@@ -189,8 +189,7 @@ MIP Convert determines:
     
     1. CMOR requires ``branch_time_in_child`` and ``branch_time_in_parent``, which is determined from the options ``base_date`` (see the `request <request_section>` section) / ``parent_base_date`` (the base date of the ``child_experiment_id`` / ``parent_experiment_id``) and ``branch_date_in_child`` / ``branch_date_in_parent`` (the date in the ``child_experiment_id`` / ``parent_experiment_id`` from which the experiment branches) from the `cmor_dataset <cmor_dataset_section>` section in the |user configuration file| by taking the difference (in days) between the ``branch_date_in_child`` / ``branch_date_in_parent`` and the ``base_date`` / ``parent_base_date``. If ``branch_date_in_child`` or ``branch_date_in_parent`` is ``N/A`` then ``branch_time_in_parent`` is set to 0.
     2. Dates should be provided in the form `YYYY-MM-DDThh:mm:ssZ`.
-    3. For a description of each option, please see the [CMIP6 Global Attributes document](https://docs.google.com/document/d/1h0r8RZr_f3-8egBMMh7aqLwy3snpD6_MrDz1q8n5XUk).
-    4. See ``parent_source_id`` in the [CMIP6 Global Attributes document](https://docs.google.com/document/d/1h0r8RZr_f3-8egBMMh7aqLwy3snpD6_MrDz1q8n5XUk).
+    3. For a description of each option, please see the [CMIP6 Global Attributes document](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/) See ``parent_source_id`` in the [CMIP6 Global Attributes document](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/).
     
     
 ### **request**

--- a/docs/tutorials/mip_convert.md
+++ b/docs/tutorials/mip_convert.md
@@ -148,13 +148,22 @@ The required `cmor_dataset` section contains the following options used for [cmo
 
 **Notes**
 
-1. For a description of each option, please see the [CMIP6 Global Attributes document](https://docs.google.com/document/d/1h0r8RZr_f3-8egBMMh7aqLwy3snpD6_MrDz1q8n5XUk).
-1. See calendars for allowed values.
+1. For a description of each option, please see the [CMIP6 Global Attributes document](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/).
+1. Calendar types allowed are:
+    - standard
+    - gregorian
+    - proleptic_gregorian
+    - noleap
+    - 365_day
+    - 360_day
+    - julian
+    - all_leap
+    - 366_day
 1. It is recommended to use the ``comment`` option to record any perturbed physics details.
-1. See MIP.
-1. See model identifier.
-1. See model type.
-1. See ``outpath`` in the documentation for `cmor_dataset_json`_.
+1. See [activity_id](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/). For more examples see [CMIP6 CV's](https://wcrp-cmip.github.io/CMIP6_CVs/docs/CMIP6_experiment_id.html).
+1. See [source_id](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/). For more examples see [CMIP6 CV's](https://wcrp-cmip.github.io/CMIP6_CVs/docs/CMIP6_source_id_licenses.html).
+1. See [source_type](https://wcrp-cmip.github.io/cmip7-guidance/CMIP6/global_attributes/).
+1. If ``create_subdirectories`` is set to True CMOR will construct the full directory structure used by CMIP, as specified in the DRS (Directory Reference Syntax) information held in the CVs, underneath ``output_dir``. If ``create_directories`` is set to False (as is usual within CDDS) files will be directly written to ``output_dir``.
 
 MIP Convert determines:
 

--- a/docs/tutorials/mip_convert.md
+++ b/docs/tutorials/mip_convert.md
@@ -124,33 +124,33 @@ The required `cmor_dataset` section contains the following options used for [cmo
 
 |              Option             | Required by        |          Used by   | Notes   |
 |---------------------------------|--------------------|--------------------|---------|
-| ``branch_method``               | MIP Convert + CMOR | MIP Convert + CMOR | [1]     |
-| ``calendar``                    | MIP Convert + CMOR | MIP Convert + CMOR | [2]     |
-| ``comment``                     |                    | CMOR               | [1] [3] |
-| ``contact``                     |                    | CMOR               | [1]     |
-| ``experiment_id``               | MIP Convert + CMOR | MIP Convert + CMOR | [1]     |
-| ``grid``                        | CMOR               | CMOR               | [1]     |
-| ``grid_label``                  | CMOR               | CMOR               | [1]     |
-| ``institution_id``              | MIP Convert + CMOR | MIP Convert + CMOR | [1]     |
-| ``license``                     | CMOR               | CMOR               | [1]     |
-| ``mip``                         | CMOR               | CMOR               | [1] [4] |
-| ``mip_era``                     | MIP Convert + CMOR | MIP Convert + CMOR | [1]     |
-| ``model_id``                    | MIP Convert + CMOR | MIP Convert + CMOR | [1] [5] |
-| ``model_type``                  | CMOR               | CMOR               | [1] [6] |
-| ``nominal_resolution``          | CMOR               | CMOR               | [1]     |
-| ``output_dir``                  | MIP Convert + CMOR | MIP Convert + CMOR | [7]     |
+| ``branch_method``               | MIP Convert + CMOR | MIP Convert + CMOR | *1*     |
+| ``calendar``                    | MIP Convert + CMOR | MIP Convert + CMOR | *2*     |
+| ``comment``                     |                    | CMOR               | *1*     |
+| ``contact``                     |                    | CMOR               | *1*     |
+| ``experiment_id``               | MIP Convert + CMOR | MIP Convert + CMOR | *1*     |
+| ``grid``                        | CMOR               | CMOR               | *1*     |
+| ``grid_label``                  | CMOR               | CMOR               | *1*     |
+| ``institution_id``              | MIP Convert + CMOR | MIP Convert + CMOR | *1*     |
+| ``license``                     | CMOR               | CMOR               | *1*     |
+| ``mip``                         | CMOR               | CMOR               | *1*, *4*|
+| ``mip_era``                     | MIP Convert + CMOR | MIP Convert + CMOR | *1*     |
+| ``model_id``                    | MIP Convert + CMOR | MIP Convert + CMOR | *1*, *5*|
+| ``model_type``                  | CMOR               | CMOR               | *1*, *6*|
+| ``nominal_resolution``          | CMOR               | CMOR               | *1*     |
+| ``output_dir``                  | MIP Convert + CMOR | MIP Convert + CMOR | *7*     |
 | ``output_file_template``        |                    | CMOR               |         |
 | ``output_path_template``        |                    | CMOR               |         |
-| ``references``                  |                    | CMOR               | [1]     |
-| ``sub_experiment_id``           | MIP Convert + CMOR | MIP Convert        | [1]     |
-| ``variant_info``                |                    | CMOR               | [1]     |
-| ``variant_label``               | MIP Convert + CMOR | MIP Convert + CMOR | [1]     |
+| ``references``                  |                    | CMOR               | *1*     |
+| ``sub_experiment_id``           | MIP Convert + CMOR | MIP Convert        | *1*     |
+| ``variant_info``                |                    | CMOR               | *1*     |
+| ``variant_label``               | MIP Convert + CMOR | MIP Convert + CMOR | *1*     |
 
 **Notes**
 
-1. For a description of each option, please see the `CMIP6 Global Attributes document`_.
+1. For a description of each option, please see the [CMIP6 Global Attributes document](https://docs.google.com/document/d/1h0r8RZr_f3-8egBMMh7aqLwy3snpD6_MrDz1q8n5XUk).
 1. See calendars for allowed values.
-1. It is recommended to use the ``comment`` to record any perturbed physicsdetails.
+1. It is recommended to use the ``comment`` option to record any perturbed physics details.
 1. See MIP.
 1. See model identifier.
 1. See model type.
@@ -167,14 +167,14 @@ MIP Convert determines:
 
     |              Option             |     Used by     |   Notes   |
     |---------------------------------|-----------------|-----------|
-    | ``branch_date_in_child``        | MIP Convert     | [1][2][3] |
-    | ``branch_date_in_parent``       | MIP Convert     | [1][2][3] |
-    | ``parent_base_date``            | MIP Convert     | [1][2]    |
-    | ``parent_experiment_id``        | CMOR            | [3]       |
-    | ``parent_mip_era``              | CMOR            | [3]       |
-    | ``parent_model_id``             | CMOR            | [3][4]    |
-    | ``parent_time_units``           | CMOR            | [3]       |
-    | ``parent_variant_label``        | CMOR            | [3]       |
+    | ``branch_date_in_child``        | MIP Convert     | *1*,*2*,*3* |
+    | ``branch_date_in_parent``       | MIP Convert     | *1*,*2*,*3* |
+    | ``parent_base_date``            | MIP Convert     | *1*,*2*    |
+    | ``parent_experiment_id``        | CMOR            | *3*       |
+    | ``parent_mip_era``              | CMOR            | *3*       |
+    | ``parent_model_id``             | CMOR            | *3**4*    |
+    | ``parent_time_units``           | CMOR            | *3*       |
+    | ``parent_variant_label``        | CMOR            | *3*       |
     
     **Notes**
     
@@ -191,21 +191,21 @@ The required `request` section contains the following options which are used onl
 | <div style="width:125px">Option</div> | Required | Description                                                                                                                                                                            | Notes  |
 |---------------------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|
 | `ancil_files`                         |          | A space separated list of the full paths to any required ancillary files.                                                                                                              |        |
-| `atmos_timestep`                      |          | The atmospheric model timestep in integer seconds.                                                                                                                                     | [1]    |
-| `base_date`                           | Yes      | The date in the form `YYYY-MM-DDThh:mm:ss`.                                                                                                                                            | [2]    |
+| `atmos_timestep`                      |          | The atmospheric model timestep in integer seconds.                                                                                                                                     | *1*    |
+| `base_date`                           | Yes      | The date in the form `YYYY-MM-DDThh:mm:ss`.                                                                                                                                            | *2*    |
 | `deflate_level`                       |          | The deflation level when writing the output netCDF file from 0 (no compression) to 9 (maximum compression).                                                                            |        |
 | `force_coordinate_rotation`           |          | If set to `True`, output data will be forced to include rotated coordinates and true lat-lon coordinates.                                                                              |        |
-| `hybrid_heights_file`                 |          | A space separated list of the full path to the files containing the information about the hybrid heights.                                                                              | [3]    |
-| `mask_slice`                          | Yes      | Optional slicing expression for masking data in the form of `n:m,i:j`, or `no_mask`                                                                                                    | [4][8] |
-| `model_output_dir`                    | Yes      | The full path to the root directory containing the model output files.                                                                                                                 | [5]    |
+| `hybrid_heights_file`                 |          | A space separated list of the full path to the files containing the information about the hybrid heights.                                                                              | *3*    |
+| `mask_slice`                          | Yes      | Optional slicing expression for masking data in the form of `n:m,i:j`, or `no_mask`                                                                                                    | *4*,*8* |
+| `model_output_dir`                    | Yes      | The full path to the root directory containing the model output files.                                                                                                                 | *5*    |
 | `mip_convert_plugin`                  | Yes      | The id of the MIP convert plugin that should be used.                                                                                                                                  |      |
 | `mip_convert_external_plugin`         |          | The module path to external MIP convert plugin, e.g. `cdds_arise.arise_mip_convert_plugin`.                                                                                            |        |
 | `mip_convert_external_plugin_location`|          | The full path to the external plugin implementation, e.g. `$CDDS_ETC/mapping_plugins/arise`.                                                                                                    |        |
 | `reference_time`                      | Yes      | The reference time used to construct `reftime` and `leadtime` coordinates. Only used if these coordinates are specified corresponding variable entries in the MIP table                |        |
-| `replacement_coordinates_file`        |          | The full path to the netCDF file containing area variables that refer to the horizontal coordinates that should be used to replace the corresponding values in the model output files. | [6]    |
+| `replacement_coordinates_file`        |          | The full path to the netCDF file containing area variables that refer to the horizontal coordinates that should be used to replace the corresponding values in the model output files. | *6*    |
 | `run_bounds`                          | Yes      | The start and end time in the form `<start_time> <end_time>`, where `<start_time>` and `<end_time>` are in the form `YYYY-MM-DDThh:mm:ss`.                                             |        |
 | `shuffle`                             |          | Whether to shuffle when writing the output netCDF file.                                                                                                                                |        |
-| `sites_file`                          |          | The full path to the file containing the information about the sites.                                                                                                                  | [7]    |
+| `sites_file`                          |          | The full path to the file containing the information about the sites.                                                                                                                  | *7*    |
 | `suite_id`                            | Yes      | The suite identifier of the model.                                                                                                                                                     |        |
 
 **Notes**

--- a/docs/tutorials/mip_convert.md
+++ b/docs/tutorials/mip_convert.md
@@ -126,7 +126,7 @@ The required `cmor_dataset` section contains the following options used for [cmo
 |---------------------------------|--------------------|--------------------|---------|
 | ``branch_method``               | MIP Convert + CMOR | MIP Convert + CMOR | *1*     |
 | ``calendar``                    | MIP Convert + CMOR | MIP Convert + CMOR | *2*     |
-| ``comment``                     |                    | CMOR               | *1*     |
+| ``comment``                     |                    | CMOR               | *1*, *3*|
 | ``contact``                     |                    | CMOR               | *1*     |
 | ``experiment_id``               | MIP Convert + CMOR | MIP Convert + CMOR | *1*     |
 | ``grid``                        | CMOR               | CMOR               | *1*     |


### PR DESCRIPTION
Closes #504 

A decision was made with Matt to just change the number formatting in the table notes rather than using tooltips, as some of the options apply to more than one note which might have gotten a bit messy and not been a great use of time.

Have also made a couple of other small changes to the docs on those pages.