### PR TITLE
#742: allow variable lists to contain comments

### DIFF
--- a/cdds/cdds/prepare/generate.py
+++ b/cdds/cdds/prepare/generate.py
@@ -46,16 +46,25 @@ def get_requested_variables(request: Request):
     list[str]
         A cleaned list of request variables.
     """
+    logger = logging.getLogger(__name__)
     requested_variables = []
 
     with open(request.data.variable_list_file, "r") as fh:
-        for variable in fh.readlines():
+        for (line, variable) in enumerate(fh):
             # Remove all trailing comments.
             if "#" in variable:
                 variable = variable.split("#")[0]
+
+            # Remove any leading or trailing whitespace
             variable = variable.strip()
 
-            # Filter out any blank lines or comments.
+            # Check for whitespace within variables
+            if " " in variable:
+                logger.warning(f"Whitespace found in variable list file on line {line + 1}: '{variable}'. "
+                               f"Proceeding with variable as {variable.replace(' ', '')}.")
+                variable = variable.replace(" ", "")
+
+            # Filter out any blank lines, comments.
             if variable and not variable.startswith("#"):
                 requested_variables.append(variable)
 

--- a/cdds/cdds/tests/test_prepare/test_command_line.py
+++ b/cdds/cdds/tests/test_prepare/test_command_line.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 import unittest
 
 from pathlib import Path
+from textwrap import dedent
 
 from cdds.common.constants import (
     COMPONENT_LIST, INPUT_DATA_DIRECTORY, OUTPUT_DATA_DIRECTORY, LOG_DIRECTORY)
@@ -188,14 +189,19 @@ class TestMainGenerateVariableList(unittest.TestCase):
         self.assertEqual(return_code, 0)
 
     def test_get_requested_variables(self):
-        variables = ("day/uas # this is a test comment\nday/vas\nAmon/pr    \n \n# oops we left some blank lines\n"
-                     "#AERmon/emiso2  # lets comment one out")
+        variables = """  day/uas # this is a test comment
+        day/vas
+        Amo n/ pr
+
+        # oops we left some blank lines
+        #AERmon/emiso2  # lets comment one out")
+        """
         expected = ["day/uas", "day/vas", "Amon/pr"]
         msg = "The requested variable list contains invalid whitespace or comments"
 
         request = simple_request()
         with open(self.variable_list, 'w') as fh:
-            fh.writelines(variables)
+            fh.writelines(dedent(variables))
         request.data.variable_list_file = self.variable_list
 
         requested_variables = get_requested_variables(request)


### PR DESCRIPTION
Closes issue #742.

Allows the variable lists in prepare to tolerate inline and single line comments that use '#' and blank lines within variable lists. 