### PR TITLE
#722: reformat OSError message to remove undefined variables

### DIFF
--- a/cdds/cdds/extract/process.py
+++ b/cdds/cdds/extract/process.py
@@ -141,8 +141,8 @@ class Process(object):
             success, (status, msg) = create_dir(
                 data_target, STREAMDIR_PERMISSIONS)
         except OSError as exc:
-            msg = ("Problem creating subdirectory {} in directory path {} [{} - [{}:{}]]".format(
-                subdirpath, directory, os.strerror(exc.errno), user, group))
+            msg = ("Problem creating directory path {} [{} - [{}]]".format(data_target, os.strerror(exc.errno),
+                                                                              self.pinfo["user"]))
             status = "failed"
             success = False
         if success and (status == "created" or status == "exists"):


### PR DESCRIPTION
Closes issue #722 

Undefined variables appear to stem from the extraction of some code into a common function create_dir(), both subdirpath and directory are variables used within the create_dir() function but are not returned.

create_dir() takes the arguments 'directory' and 'permissions' hence the undefined "directory" variable can be reassigned as "data_target" (since this is the directory parameter parsed to the create_dir function() as directory). 

subdirpath is used in the else portion of the create_dir() as the path is created on a directory by directory iterative process. It would be difficult to return this in a clean and concise way without editing the function within common directly which may potentially affect other scripts. 
```
def create_dir(directory, permissions):
    if os.path.exists(directory):
        msg = "Directory exists: {}".format(directory)
        status = "exists"
    else:
        subdirpath = ''

        sep = os.sep
        subdirs = [subdir for subdir in directory.split(sep) if subdir]
        for subdir in subdirs:
            subdirpath = "{}{}{}".format(subdirpath, sep, subdir)
            if not os.path.exists(subdirpath):
                os.mkdir(subdirpath, permissions)

        msg = "Directory created : {}".format(directory)
        status = "created"

    return status, msg
```
Hence, I have removed subdir from the logging message entirely and simply provided the user with the full path that was failed to create. This is seemingly a rare error to encounter and it would be possible for the user to navigate through the given directory path to find the specific subdirectory that could not be created. The os.strerror message given in the variable 'msg' in create_streamdir() would also likely provide sufficient detail for debugging.

The "group" parameter has also been removed, this does not appear to be used anywhere else within the script and is not mentioned as a variable in any other functions called within the create_streamdir() function. Because of this,  I am making an assumption that group is not a key piece of information that the user would require for debugging - please confirm if this is the case.