### PR TITLE
Correct repack.py mypy err

### DIFF
--- a/cdds/cdds/convert/repack.py
+++ b/cdds/cdds/convert/repack.py
@@ -206,10 +206,10 @@ def repack_files(nc_files: List[Path]) -> None:
 
         if failure_exception:
             logger.critical(f"Files failed: {failure_count}")
-            for exc in failure_exception:
+            for exception in failure_exception:
                 # Remove unnecessary "NO INPUT FILES CHECKED" from exception before logging.
-                exc.args = (exc.args[0].split("\n")[0],)
-                logger.debug(exc)
+                exception.args = (exception.args[0].split("\n")[0],)
+                logger.debug(exception)
             raise failure_exception[-1]  # Raise the last exception for visibility
 
 


### PR DESCRIPTION
To fix the mypy errors caused by code introduced in https://github.com/MetOffice/CDDS/pull/788

Error was:
```
cdds/cdds/convert/repack.py:209: error: Assignment to variable "exc" outside except: block  [misc]
cdds/cdds/convert/repack.py:211: error: Trying to read deleted variable "exc"  [misc]
cdds/cdds/convert/repack.py:212: error: Trying to read deleted variable "exc"  [misc]
```
Those errors no longer occur after changing `exc` to `exception`