### PR TITLE
#835 Add cfg to excludes for cdds copyright checks

### DIFF
--- a/cdds/cdds/tests/test_copyright_headers.py
+++ b/cdds/cdds/tests/test_copyright_headers.py
@@ -45,7 +45,7 @@ class TestCopyrightHeaders(unittest.TestCase):
 
     def get_copyright_files(self):
         self.exclude_patterns.extend(
-            ['egg-info', 'EGG-INFO', 'dist', '.pyc', 'doctrees', 'cfg', 'html', 'clyc',
+            ['egg-info', 'EGG-INFO', 'dist', '.pyc', 'doctrees', 'cfg', 'html', 'cylc',
              'pylintrc', 'TAGS', 'json', 'todel', 'nfsc', 'txt', 'ini', 'conf', 'workflows']
         )
 

--- a/cdds/cdds/tests/test_copyright_headers.py
+++ b/cdds/cdds/tests/test_copyright_headers.py
@@ -45,7 +45,7 @@ class TestCopyrightHeaders(unittest.TestCase):
 
     def get_copyright_files(self):
         self.exclude_patterns.extend(
-            ['egg-info', 'EGG-INFO', 'dist', '.pyc', 'doctrees', 'html', 'clyc',
+            ['egg-info', 'EGG-INFO', 'dist', '.pyc', 'doctrees', 'cfg', 'html', 'clyc',
              'pylintrc', 'TAGS', 'json', 'todel', 'nfsc', 'txt', 'ini', 'conf', 'workflows']
         )
 


### PR DESCRIPTION
Accidently removed `cfg` from the list of excludes in the `cdds` copyright tests causing failures d6c6b30aade87fc3d9dabe0bb5876353d84389c3. This PR restores that exclude.

I've also only just noticed that the `mip_convert` and `cdds` copyright tests actually diverged at some point, as the `mip_convert` test _does_ check `.cfg` files.  