### PR TITLE
#910: Update extract validate partition to cpu-long

### DIFF
--- a/cdds/cdds/workflows/conversion/flow.cylc
+++ b/cdds/cdds/workflows/conversion/flow.cylc
@@ -311,11 +311,11 @@ mkdir -p {{ BASE_OUTPUT }}
         [[[directives]]]
             --mem = {{ MEMORY_QC }}
             --ntasks = 1
-            {% if PLATFORM == 'AZURE' %}
-                --partition = cpu-long
-            {% elif PLATFORM == 'JASMIN' %}
-                --qos = long
-            {% endif %}
+        {% if PLATFORM == 'AZURE' %}
+            --partition = cpu-long
+        {% elif PLATFORM == 'JASMIN' %}
+            --qos = long
+        {% endif %}
     {% endif %}
 
     {% if RUN_QC %}

--- a/cdds/cdds/workflows/conversion/flow.cylc
+++ b/cdds/cdds/workflows/conversion/flow.cylc
@@ -310,6 +310,7 @@ mkdir -p {{ BASE_OUTPUT }}
         [[[directives]]]
             --mem = {{ MEMORY_QC }}
             --ntasks = 1
+            --partition = cpu-long
     {% endif %}
 
     {% if RUN_QC %}

--- a/cdds/cdds/workflows/conversion/flow.cylc
+++ b/cdds/cdds/workflows/conversion/flow.cylc
@@ -311,7 +311,11 @@ mkdir -p {{ BASE_OUTPUT }}
         [[[directives]]]
             --mem = {{ MEMORY_QC }}
             --ntasks = 1
-            --partition = cpu-long
+            {% if PLATFORM == 'AZURE' %}
+                --partition = cpu-long
+            {% elif PLATFORM == 'JASMIN' %}
+                --qos = long
+            {% endif %}
     {% endif %}
 
     {% if RUN_QC %}

--- a/cdds/cdds/workflows/conversion/flow.cylc
+++ b/cdds/cdds/workflows/conversion/flow.cylc
@@ -304,7 +304,7 @@ mkdir -p {{ BASE_OUTPUT }}
     {% if RUN_EXTRACT_VALIDATION %}
     [[validate_extract_{{ STREAM }}]]
         inherit = {{ PLATFORM }}
-        execution time limit = P1D
+        execution time limit = P2D
         [[[environment]]]
             ROSE_TASK_APP = validate_extract
             STREAM = {{ STREAM }}

--- a/cdds/cdds/workflows/conversion/flow.cylc
+++ b/cdds/cdds/workflows/conversion/flow.cylc
@@ -304,6 +304,7 @@ mkdir -p {{ BASE_OUTPUT }}
     {% if RUN_EXTRACT_VALIDATION %}
     [[validate_extract_{{ STREAM }}]]
         inherit = {{ PLATFORM }}
+        execution time limit = P1D
         [[[environment]]]
             ROSE_TASK_APP = validate_extract
             STREAM = {{ STREAM }}


### PR DESCRIPTION
Closes issue #910 

When extracting large data sets with the moo get option, extract validate is terminated before it is able to complete stash checks. Updating the partition to cpu-long allows validate to exceed the typical 6 hour wall time limit so that it is able to fully complete.