### PR TITLE
#935: Update used_time in update_directives 

### DIFF
--- a/cdds/cdds/workflows/conversion/bin/update_directives
+++ b/cdds/cdds/workflows/conversion/bin/update_directives
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# (C) British Crown Copyright 2023-2025, Met Office.
+# (C) British Crown Copyright 2023-2026, Met Office.
 """This script generates new directives based on observations of mip_convert task usage.
 These directives are then used in conjuntion with cylc broadcast to update directives of
 future mip_convert tasks.
@@ -12,6 +12,7 @@ import subprocess
 import sqlite3
 from pathlib import Path
 from typing import Dict, List, Union
+from metomi.isodatetime.parsers import TimePointParser
 
 import pandas as pd
 
@@ -68,16 +69,17 @@ class MipConvertTask:
 
     @property
     def used_time(self):
-        regex_time = r"Elapsed \(wall clock\) time \(h:mm:ss or m:ss\): (\d+:\d{2}:\d{2}|\d+:\d{2}.\d+)"
-        time = re.search(regex_time, self.job_err).groups()[0]
-        time_components = time.split(":")
-        if len(time_components) == 2:
-            minutes, seconds = time_components
-            time_in_seconds = int(minutes) * 60 + float(seconds)
-        elif len(time_components):
-            hours, minutes, seconds = time_components
-            time_in_seconds = int(hours) * 3600 + int(minutes) * 60 + float(seconds)
-        return int(time_in_seconds)
+        regex_start_time = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z INFO - started"
+        regex_end_time = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z INFO - succeeded"
+
+        parser = TimePointParser()
+        start_time = parser.parse(re.search(regex_start_time, self.job_err).group().split(" ")[0])
+        end_time = parser.parse(re.search(regex_end_time, self.job_err).group().split(" ")[0])
+        duration = (end_time - start_time)
+
+        time_in_seconds = duration.seconds + (duration.minutes * 60) + (duration.hours * 3600) + (duration.days * 86400)
+
+        return time_in_seconds
 
     @property
     def used_storage(self):


### PR DESCRIPTION
Closes issue #935. This PR is to update the used_time property in the update_directives script to consider the full task time rather than just the wall time. This means that it will take into consideration the time taken to load files when updating cylc directives.