### PR TITLE
Issue #905: Update compliance checker and cmor

### DIFF
--- a/cdds/cdds/qc/constants.py
+++ b/cdds/cdds/qc/constants.py
@@ -53,15 +53,8 @@ SUMMARY_STARTED = 0
 SUMMARY_FAILED = 2
 SUMMARY_PASSED = 1
 TIME_TOLERANCE = 1e-5  # Tolerance for time comparisons in days = ~1s
-CMIP6_SKIP_QC_CHECKS = {
-    'check_cell_boundaries_interval': 'Fault in IOOS Compliance Checker #IOOS issue',
-    'check_geographic_region': 'IOOS checker requires string which is not used in CMIP',
-}
-CMIP7_SKIP_QC_CHECKS = {
-    'check_cell_boundaries_interval': 'Fault in IOOS Compliance Checker #IOOS issue',
-    'check_geographic_region': 'IOOS checker requires string which is not used in CMIP',
-}
-CORDEX_SKIP_QC_CHECKS = {
-    'check_cell_boundaries_interval': 'Fault in IOOS Compliance Checker #IOOS issue',
-    'check_geographic_region': 'IOOS checker requires string which is not used in CMIP',
-}
+# These skip checks were used for previous IOOS Compliance Checker errors which are now fixed.
+# Leaving empty implementation in case check skipping needed in future.
+CMIP6_SKIP_QC_CHECKS = {}
+CMIP7_SKIP_QC_CHECKS = {}
+CORDEX_SKIP_QC_CHECKS = {}

--- a/cdds/cdds/qc/constants.py
+++ b/cdds/cdds/qc/constants.py
@@ -5,6 +5,8 @@ be changes by a user and exist for readability and maintainability
 purposes) for the CDDS QC component.
 """
 
+from typing import Any, Dict
+
 COMPONENT = 'qualitycheck'
 DIURNAL_CLIMATOLOGY = '1hrCM'
 DS_TYPE_SINGLE_FILE = 1
@@ -55,6 +57,6 @@ SUMMARY_PASSED = 1
 TIME_TOLERANCE = 1e-5  # Tolerance for time comparisons in days = ~1s
 # These skip checks were used for previous IOOS Compliance Checker errors which are now fixed.
 # Leaving empty implementation in case check skipping needed in future.
-CMIP6_SKIP_QC_CHECKS = {}
-CMIP7_SKIP_QC_CHECKS = {}
-CORDEX_SKIP_QC_CHECKS = {}
+CMIP6_SKIP_QC_CHECKS: Dict[str, Any] = {}
+CMIP7_SKIP_QC_CHECKS: Dict[str, Any] = {}
+CORDEX_SKIP_QC_CHECKS: Dict[str, Any] = {}

--- a/cdds/cdds/qc/runner.py
+++ b/cdds/cdds/qc/runner.py
@@ -642,6 +642,20 @@ class QCRunner(object):
             "contains these attributes": "non-mandatory",
             "Cell Boundaries: Bounds variable vertices_latitude and parent variable latitude have the following "
             "matching attributes ['units'].  It is recommended that only the parent variable of the bounds variable "
-            "contains these attributes": "non-mandatory"
+            "contains these attributes": "non-mandatory",
+            (
+                "the coordinate variable 'latitude' lie outside the bounding box of the "
+                "associated boundary variable 'vertices_latitude'"
+            ): (
+                "Locally ignored: recurring CF checker warning for "
+                "latitude/vertices_latitude on native eORCA1 tripolar grid outputs."
+            ),
+            (
+                "the coordinate variable 'longitude' lie outside the bounding box of the "
+                "associated boundary variable 'vertices_longitude'"
+            ): (
+                "Locally ignored: recurring CF checker warning for "
+                "longitude/vertices_longitude on native eORCA1 tripolar grid outputs."
+            ),
         }
         return msg_dictionary

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -1,4 +1,4 @@
-name: $CDDS_HOME/conda_environments/cdds-3.4_dev-7
+name: $CDDS_HOME/conda_environments/cdds-3.4_dev-8
 channels:
   - conda-forge
   - nodefaults
@@ -7,12 +7,13 @@ dependencies:
   - _python_abi3_support=1.0=hd8ed1ab_2
   - alabaster=0.7.16=pyhd8ed1ab_0
   - antlr-python-runtime=4.11.1=pyhd8ed1ab_0
+  - ast-serialize=0.5.0=py310hd8a072f_1
   - aws-c-auth=0.10.1=ha62d5e7_3
   - aws-c-cal=0.9.13=h2c9d079_1
   - aws-c-common=0.12.6=hb03c661_0
   - aws-c-compression=0.3.2=h8b1a151_0
   - aws-c-http=0.10.13=h4bacb7b_0
-  - aws-c-io=0.26.3=h692f434_1
+  - aws-c-io=0.26.3=hb18f61d_2
   - aws-c-s3=0.12.2=he6ee468_1
   - aws-c-sdkutils=0.2.4=h8b1a151_4
   - aws-checksums=0.2.10=h8b1a151_0
@@ -24,9 +25,9 @@ dependencies:
   - brotli-python=1.2.0=py312hdb49522_1
   - bzip2=1.0.8=hda65f42_9
   - c-ares=1.34.6=hb03c661_0
-  - ca-certificates=2026.4.22=hbd8a1cb_0
+  - ca-certificates=2026.5.20=hbd8a1cb_0
   - cartopy=0.25.0=py312hf79963d_1
-  - certifi=2026.4.22=pyhd8ed1ab_0
+  - certifi=2026.5.20=pyhd8ed1ab_0
   - cf-units=3.2.0=py312hc0a28a1_6
   - cffi=2.0.0=py312h460c074_1
   - cfgv=3.5.0=pyhd8ed1ab_0
@@ -35,20 +36,20 @@ dependencies:
   - click=8.2.1=pyh707e725_0
   - cloudpickle=3.1.2=pyhcf101f3_1
   - cmip7-repack=0.6=pyha804496_0
-  - cmor=3.15.0=np2py312h149c310_0
+  - cmor=3.15.1=np2py312h149c310_0
   - colorama=0.4.6=pyhd8ed1ab_1
-  - compliance-checker=5.4.2=pyhd8ed1ab_0
+  - compliance-checker=6.1.0=pyhd8ed1ab_0
   - contourpy=1.3.3=py312h0a2e395_4
-  - coverage=7.14.0=py312h8a5da7c_0
+  - coverage=7.14.1=py312h8a5da7c_0
   - cpython=3.12.13=py312hd8ed1ab_0
   - cycler=0.12.1=pyhcf101f3_2
   - dask-core=2025.12.0=pyhcf101f3_1
   - debugpy=1.8.19=py312h372c3de_0
-  - distlib=0.4.0=pyhd8ed1ab_0
+  - distlib=0.4.1=pyhcf101f3_1
   - docutils=0.17.1=py312h7900ff3_7
   - esmf=8.9.1=nompi_h0c1e4bb_3
   - exceptiongroup=1.3.1=pyhd8ed1ab_0
-  - filelock=3.29.0=pyhd8ed1ab_0
+  - filelock=3.29.1=pyhd8ed1ab_0
   - fonttools=4.63.0=py312h8a5da7c_0
   - freetype=2.14.3=ha770c72_0
   - fsspec=2026.4.0=pyhd8ed1ab_0
@@ -66,9 +67,9 @@ dependencies:
   - hyperframe=6.1.0=pyhd8ed1ab_0
   - icu=78.3=h33c6efd_0
   - identify=2.6.19=pyhd8ed1ab_0
-  - idna=3.13=pyhcf101f3_0
+  - idna=3.17=pyhcf101f3_0
   - imagesize=2.0.0=pyhd8ed1ab_0
-  - importlib-metadata=8.8.0=pyhcf101f3_0
+  - importlib-metadata=9.0.0=pyhcf101f3_0
   - importlib-resources=7.1.0=pyhd8ed1ab_0
   - importlib_resources=7.1.0=pyhd8ed1ab_0
   - iniconfig=2.3.0=pyhd8ed1ab_0
@@ -79,20 +80,20 @@ dependencies:
   - keyutils=1.6.3=hb9d3cd8_0
   - kiwisolver=1.5.0=py312h0a2e395_0
   - krb5=1.22.2=ha1258a1_0
-  - lcms2=2.19.1=h0c24ade_0
+  - lcms2=2.19.1=h0c24ade_1
   - ld_impl_linux-64=2.45.1=default_hbd61a6d_102
   - lerc=4.1.0=hdb68285_0
   - libaec=1.1.5=h088129d_0
-  - libblas=3.11.0=7_h4a7cf45_openblas
+  - libblas=3.11.0=8_h4a7cf45_openblas
   - libbrotlicommon=1.2.0=hb03c661_1
   - libbrotlidec=1.2.0=hb03c661_1
   - libbrotlienc=1.2.0=hb03c661_1
-  - libcblas=3.11.0=7_h0358290_openblas
+  - libcblas=3.11.0=8_h0358290_openblas
   - libcurl=8.20.0=hcf29cc6_0
   - libdeflate=1.25=h17f619e_0
   - libedit=3.1.20250104=pl5321h7949ede_0
   - libev=4.33=hd590300_2
-  - libexpat=2.8.0=hecca717_0
+  - libexpat=2.8.1=hecca717_0
   - libffi=3.5.2=h3435931_0
   - libfreetype=2.14.3=ha770c72_0
   - libfreetype6=2.14.3=h73754d4_0
@@ -103,7 +104,7 @@ dependencies:
   - libgomp=15.2.0=he0feb66_19
   - libiconv=1.18=h3b78370_2
   - libjpeg-turbo=3.1.4.1=hb03c661_0
-  - liblapack=3.11.0=7_h47877c9_openblas
+  - liblapack=3.11.0=8_h47877c9_openblas
   - liblzma=5.8.3=hb03c661_0
   - libmo_unpack=3.1.2=hf484d3e_1001
   - libnetcdf=4.10.0=nompi_h3c9b436_104
@@ -117,7 +118,7 @@ dependencies:
   - libstdcxx-ng=15.2.0=hdf11a46_19
   - libtiff=4.7.1=h9d88235_1
   - libudunits2=2.2.28=h40f5838_3
-  - libuuid=2.42=h5347b49_0
+  - libuuid=2.42.1=h5347b49_0
   - libwebp-base=1.6.0=hd42ef1d_0
   - libxcb=1.17.0=h8a09558_0
   - libxcrypt=4.4.36=hd590300_1
@@ -127,7 +128,7 @@ dependencies:
   - libzip=1.11.2=h6991a6a_0
   - libzlib=1.3.2=h25fd6f3_2
   - locket=1.0.0=pyhd8ed1ab_0
-  - lxml=6.1.0=py312h63ddcf0_0
+  - lxml=6.1.1=py312h63ddcf0_0
   - lz4-c=1.10.0=h5888daf_1
   - markdown=3.5.2=pyhd8ed1ab_0
   - markdown-it-py=2.2.0=pyhd8ed1ab_0
@@ -149,7 +150,7 @@ dependencies:
   - mkdocstrings-python=1.9.0=pyhd8ed1ab_1
   - mo_pack=0.3.1=py312h4f23490_2
   - munkres=1.1.4=pyhd8ed1ab_1
-  - mypy=1.20.2=py312h4c3975b_0
+  - mypy=2.1.0=py312h574c966_0
   - mypy_extensions=1.1.0=pyha770c72_0
   - myst-parser=0.18.1=pyhd8ed1ab_0
   - nco=5.3.9=he857942_0
@@ -170,31 +171,31 @@ dependencies:
   - pika=1.2.0=pyh44b312d_0
   - pillow=12.2.0=py312h50c33e8_0
   - pip=25.1.1=pyh8b19718_0
-  - platformdirs=4.9.6=pyhcf101f3_0
+  - platformdirs=4.10.0=pyhcf101f3_0
   - pluggy=1.6.0=pyhf9edf01_1
   - pre-commit=4.5.1=pyha770c72_0
   - proj=9.8.1=he0df7b0_0
   - psutil=7.2.2=py312h5253ce2_0
   - pthread-stubs=0.4=hb9d3cd8_1002
   - pyaml=26.2.1=pyhcf101f3_1
-  - pycparser=2.22=pyh29332c3_1
+  - pycparser=3.0=pyhcf101f3_0
   - pyfive=1.1.2=pyhd8ed1ab_0
   - pygeoif=1.6.0=pyhd8ed1ab_0
   - pygments=2.20.0=pyhd8ed1ab_0
   - pymdown-extensions=10.7.1=pyhd8ed1ab_0
   - pyparsing=3.3.2=pyhcf101f3_0
   - pyproj=3.7.2=py312hbc8341d_4
-  - pyshp=3.0.4=pyhd8ed1ab_0
+  - pyshp=3.0.9=pyhd8ed1ab_0
   - pysocks=1.7.1=pyha55dd90_7
   - pytest=9.0.2=pyhcf101f3_0
   - pytest-cov=3.0.0=pyhd8ed1ab_0
   - python=3.12.13=hd63d673_0_cpython
   - python-dateutil=2.9.0.post0=pyhe01879c_2
-  - python-discovery=1.3.1=pyhcf101f3_0
+  - python-discovery=1.4.0=pyhcf101f3_0
   - python-gil=3.12.13=hd8ed1ab_0
   - python-librt=0.11.0=py312h5253ce2_0
   - python-tzdata=2026.2=pyhd8ed1ab_0
-  - python-xxhash=3.6.0=py312h0d868a3_1
+  - python-xxhash=3.7.0=py312h0d868a3_0
   - python_abi=3.12=8_cp312
   - pytz=2026.2=pyhcf101f3_0
   - pyyaml=6.0.3=py312h8a5da7c_1
@@ -204,13 +205,13 @@ dependencies:
   - regex=2024.11.6=py312h66e93f0_0
   - requests=2.34.2=pyhcf101f3_0
   - ruff=0.14.8=h813ae00_0
-  - s2n=1.7.2=hc5a330e_1
+  - s2n=1.7.3=hc5a330e_0
   - scipy=1.15.2=py312ha707e6e_0
   - setuptools=82.0.1=pyh332efcf_0
   - shapely=2.1.2=py312h383787d_2
   - six=1.17.0=pyhe01879c_1
   - snappy=1.2.2=h03e3b7b_1
-  - snowballstemmer=3.0.1=pyhd8ed1ab_0
+  - snowballstemmer=3.1.1=pyhd8ed1ab_0
   - sphinx=4.2.0=pyh6c4a22f_0
   - sphinxcontrib-applehelp=1.0.4=pyhd8ed1ab_0
   - sphinxcontrib-devhelp=1.0.2=py_0
@@ -234,14 +235,14 @@ dependencies:
   - urllib3=2.7.0=pyhd8ed1ab_0
   - validators=0.35.0=pyhd8ed1ab_0
   - verspec=0.1.0=pyh29332c3_2
-  - virtualenv=21.3.3=pyhcf101f3_0
+  - virtualenv=21.4.2=pyhcf101f3_0
   - watchdog=6.0.0=py312h20c3967_3
   - wheel=0.47.0=pyhd8ed1ab_0
   - xorg-libxau=1.0.12=hb03c661_1
   - xorg-libxdmcp=1.1.5=hb03c661_1
   - xxhash=0.8.3=hb47aa4a_0
   - yaml=0.2.5=h280c20c_3
-  - zipp=3.23.1=pyhcf101f3_0
+  - zipp=4.1.0=pyhcf101f3_0
   - zlib-ng=2.3.3=hceb46e0_1
   - zstd=1.5.7=hb78ec9c_6
 variables:

--- a/environment_minimal.yml
+++ b/environment_minimal.yml
@@ -6,8 +6,8 @@ dependencies:
   - cf-units=3.2.0
   - cftime=1.6.5
   - cmip7-repack=0.6
-  - cmor=3.15.0
-  - compliance-checker=5.4.2
+  - cmor=3.15.1
+  - compliance-checker=6.1.0
   - dask-core=2025.12.0
   - debugpy=1.8.19
   - gsw=3.6.19
@@ -27,8 +27,8 @@ dependencies:
   - mo_pack=0.3.1
   - nco=5.3.9
   - numpy=2.4.1
-  - mypy
-  - mypy_extensions
+  - mypy=2.1.0
+  - mypy_extensions=1.1.0
   - myst-parser=0.18.1
   - netcdf4=1.7.4
   - pandas=2.3.3

--- a/setup_env_for_devel
+++ b/setup_env_for_devel
@@ -4,7 +4,7 @@ export CDDS_DIR
 export CDDS_PACKAGES="cdds mip_convert"
 
 CDDS_HOME=$(readlink -f ~cdds)
-DEV_ENV='cdds-3.4_dev-7'
+DEV_ENV='cdds-3.4_dev-8'
 
 if [[ "$(hostname -f)" =~ "spice.sc" ]]; then
     CONDA=/opt/conda/bin/activate


### PR DESCRIPTION
Closes #905 
`nccmp` still can't be added to the environment.ymls due to a dependency conflict involving libnetcdf4, so we'll have to continue installing it manually when doing environment updates.