### PR TITLE
Fix needed to allow datasets *without* a sub_experiment_id to be subm…

### DIFF
--- a/cdds/cdds/deprecated/transfer/constants.py
+++ b/cdds/cdds/deprecated/transfer/constants.py
@@ -2,3 +2,5 @@
 # Please see LICENSE.md for license details.
 
 KNOWN_RABBITMQ_QUEUES = ['CMIP6_available', 'CMIP6_withdrawn', 'CMIP6Plus_available', 'CMIP6Plus_withdrawn']
+
+OPTIONAL_FACETS = ['sub_experiment_id']

--- a/cdds/cdds/deprecated/transfer/drs.py
+++ b/cdds/cdds/deprecated/transfer/drs.py
@@ -6,6 +6,7 @@ import logging
 import re
 
 from cdds.deprecated.transfer import config, state
+from cdds.deprecated.transfer.constants import OPTIONAL_FACETS
 
 
 class DrsException(Exception):
@@ -315,10 +316,14 @@ class DataRefSyntax(object):
         if facet_builder_to_match.state != self.state:
             return False
         facets_to_match_dict = facet_builder_to_match.facets
+
         for attr in facets_to_match_dict:
+            if attr in OPTIONAL_FACETS and attr not in self._facets:
+                continue
             if self._facets[attr] != facets_to_match_dict[attr]:
                 matches = False
                 break
+
         return matches
 
     def is_drs_name(self, name):


### PR DESCRIPTION
…itted

This must have been in CDDS for a while, but most of our submissions have been for DCPP & LESFMIP which have a sub_experiment_id.

This change just skips a comparison for sub_experiment_id and allows it to be unspecified.

Closes #974