### PR TITLE
Add comments and issue numbers to CMIP7 mappings

### DIFF
--- a/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_aerosol_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_aerosol_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the aerosol realm
 
 [abs550aer_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda550nm
 expression = m01s02i240[lbplev=3, lbproc=128] + m01s02i241[lbplev=3, lbproc=128] + m01s02i242[lbplev=3, lbproc=128] + m01s02i243[lbplev=3, lbproc=128] + m01s02i585[lbplev=3, lbproc=128]
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[239]
 
 [abs550dust_tavg-u-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time lambda550nm
 expression = m01s02i585[lbplev=3, lbproc=128]
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[241]
 
 [airmass_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = div_by_area(m01s50i063[lbproc=128])
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[246]
 
 [ccldncl_tavg-u-hxy-ccl]
-comment = 
 component = aerosol atmos atmosChem
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128], m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
@@ -47,9 +46,9 @@ positive =
 reviewer = none
 status = embargoed
 units = cm-3
+# Issue number(s):[858, 707]
 
 [cdnc_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s01i241[lbproc=128] / m01s01i223[lbproc=128]
@@ -58,9 +57,9 @@ positive =
 reviewer = none
 status = embargoed
 units = cm-3
+# Issue number(s):[258]
 
 [cheaqpso4_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, (m01s38i201[lbproc=128] + m01s38i202[lbproc=128] + m01s38i203[lbproc=128] + m01s38i285[lbproc=128] + m01s38i286[lbproc=128] + m01s38i288[lbproc=128] + m01s38i289[lbproc=128]), areadiv='True')
@@ -69,9 +68,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[264]
 
 [chegpso4_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s50i150[lbproc=128], areadiv='True')
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[266]
 
 [chepsoa_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet( ATOMIC_MASS_OF_C * CONV_C_ORGM, m01s38i301[lbproc=128] + m01s38i302[lbproc=128] + m01s38i303[lbproc=128] + m01s38i304[lbproc=128] + m01s38i305[lbproc=128], sumlev='True', areadiv='True')
@@ -91,9 +90,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[270]
 
 [cod_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s02i332[lbproc=128] / m01s02i334[lbproc=128]
@@ -102,9 +101,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[274, 200]
 
 [conccn_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s38i504[lbproc=128]+m01s38i505[lbproc=128]+m01s38i506[lbproc=128]+m01s38i507[lbproc=128]+m01s38i508[lbproc=128]
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-3
+# Issue number(s):[275]
 
 [conccn_tpt-u-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1
 expression = m01s38i504[lbproc=0]+m01s38i505[lbproc=0]+m01s38i506[lbproc=0]+m01s38i507[lbproc=0]+m01s38i508[lbproc=0]
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-3
+# Issue number(s):[691]
 
 [depdust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s03i440[lbproc=128]
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[875]
 
 [drydust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s03i441[lbproc=128] + m01s03i442[lbproc=128] + m01s03i443[lbproc=128] + m01s03i444[lbproc=128] + m01s03i445[lbproc=128] + m01s03i446[lbproc=128] + m01s03i451[lbproc=128] + m01s03i452[lbproc=128] + m01s03i453[lbproc=128] + m01s03i454[lbproc=128] + m01s03i455[lbproc=128] + m01s03i456[lbproc=128]
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[279]
 
 [ec550aer_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time lambda550nm
 expression = m01s02i530[lbplev=3, lbproc=128] + m01s02i540[lbplev=3, lbproc=128]
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-1
+# Issue number(s):[877]
 
 [ec550aer_tpt-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time1 lambda550nm
 expression = m01s02i530[lbplev=3, lbproc=0] + m01s02i540[lbplev=3, lbproc=0]
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-1
+# Issue number(s):[146]
 
 [emibc_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C, m01s38i207[lbproc=128], sumlev='True', areadiv='True')
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[306]
 
 [emidms_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s50i214[lbproc=128]
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[317]
 
 [emidust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s03i401[lbproc=128] + m01s03i402[lbproc=128] + m01s03i403[lbproc=128] + m01s03i404[lbproc=128] + m01s03i405[lbproc=128] + m01s03i406[lbproc=128]
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[318]
 
 [emiisop_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_ISOPRENE / (5.0 * ATOMIC_MASS_OF_C)) * (m01s03i495[lbproc=128] * m01s00i505)
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[320]
 
 [emiso2_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(1.0, m01s50i217[lbproc=128], cube2d=(m01s50i215[lbproc=128] + m01s50i216[lbproc=128]), sumlev='True')
@@ -223,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[326]
 
 [emiso4_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s38i201[lbproc=128] + m01s38i202[lbproc=128] + m01s38i203[lbproc=128], sumlev='True', areadiv='True')
@@ -234,9 +233,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[327]
 
 [emiss_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL, m01s38i204[lbproc=128] + m01s38i205[lbproc=128], sumlev='True', areadiv='True')
@@ -245,9 +244,10 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[328]
 
 [h2o_tavg-al-hxy-u]
-comment = 
+comment = This includes water vapour, and the prognostic liquid and ice cloud condensate (qcl + qcf) and rain (qrain) from the large-scale cloud scheme. However, it does not include condensate or precipitation asssociated with the convection scheme.
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s16i207[lbproc=128]+m01s00i272[lbproc=128]
@@ -256,9 +256,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[332]
 
 [lwp_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128]
@@ -267,9 +267,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[345]
 
 [mmraerh2o_tavg-h2m-hxy-u]
-comment = 
+comment = SECONDS_IN_HOUR / ATMOS_TIMESTEP factor is no longer needed - this was due to a bug in the diagnostic that was fixed by https://code.metoffice.gov.uk/trac/um/ticket/4909
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s38i545[lblev=1, lbproc=128])
@@ -278,9 +279,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[206]
 
 [mmraerh2o_tpt-h2m-hs-u]
-comment = 
+comment = SECONDS_IN_HOUR / ATMOS_TIMESTEP factor is no longer needed - this was due to a bug in the diagnostic that was fixed by https://code.metoffice.gov.uk/trac/um/ticket/4909
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s38i545[lbproc=0]
@@ -289,9 +291,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[694]
 
 [mmrbc_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s34i105[lbproc=128] + m01s34i109[lbproc=128] + m01s34i115[lbproc=128] + m01s34i120[lbproc=128]
@@ -300,9 +302,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[348]
 
 [mmrbc_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s34i105[lblev=1, lbproc=128] + m01s34i109[lblev=1, lbproc=128] + m01s34i115[lblev=1, lbproc=128] + m01s34i120[lblev=1, lbproc=128])
@@ -311,9 +313,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[207]
 
 [mmrbc_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s34i105[lbproc=0] + m01s34i109[lbproc=0] + m01s34i115[lbproc=0] + m01s34i120[lbproc=0]
@@ -322,9 +324,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[695]
 
 [mmrdust_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s00i431[lbproc=128] + m01s00i432[lbproc=128] + m01s00i433[lbproc=128] + m01s00i434[lbproc=128] + m01s00i435[lbproc=128] + m01s00i436[lbproc=128]
@@ -333,9 +335,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[349]
 
 [mmrdust_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s00i431[lblev=1, lbproc=128] + m01s00i432[lblev=1, lbproc=128] + m01s00i433[lblev=1, lbproc=128] + m01s00i434[lblev=1, lbproc=128] + m01s00i435[lblev=1, lbproc=128] + m01s00i436[lblev=1, lbproc=128])
@@ -344,9 +346,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[208]
 
 [mmrdust_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s00i431[lbproc=0] + m01s00i432[lbproc=0] + m01s00i433[lbproc=0] + m01s00i434[lbproc=0] + m01s00i435[lbproc=0] + m01s00i436[lbproc=0]
@@ -355,9 +357,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[696]
 
 [mmroa_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s34i106[lbproc=128] + m01s34i110[lbproc=128] + m01s34i116[lbproc=128] + m01s34i121[lbproc=128] + m01s34i126[lbproc=128]
@@ -366,9 +368,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[352]
 
 [mmroa_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s34i106[lblev=1, lbproc=128] + m01s34i110[lblev=1, lbproc=128] + m01s34i116[lblev=1, lbproc=128] + m01s34i121[lblev=1, lbproc=128] + m01s34i126[lblev=1, lbproc=128])
@@ -377,9 +379,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[211]
 
 [mmroa_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s34i106[lbproc=0] + m01s34i110[lbproc=0] + m01s34i116[lbproc=0] + m01s34i121[lbproc=0]
@@ -388,9 +390,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[699]
 
 [mmrpm2p5_tavg-al-hxy-u]
-comment = 
+comment = Dust MMRs are added on separately since the dust scheme is separate to the aerosol scheme used for PM calculation. The first three dust bins and a fraction (PM2PT5_DUST_BIN4_FRACTION=0.194) of the 4th range up to 2.5um in diameter and are used here. Model outputs PM in ug/m3 and so we need to divide by the air density to get ug/kg. However, this lead to inaccuracies since we have use the daily mean air density rather than the instantaneous value.
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (m01s38i561[lbproc=128] / m01s15i271[lbproc=128])*KG_PER_MICROGRAM + m01s00i431[lbproc=128] + m01s00i432[lbproc=128] + m01s00i433[lbproc=128] + m01s00i434[lbproc=128]*PM2PT5_DUST_BIN4_FRACTION
@@ -399,9 +402,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[355]
 
 [mmrso4_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4) * (m01s34i102[lbproc=128] + m01s34i104[lbproc=128] + m01s34i108[lbproc=128] + m01s34i114[lbproc=128])
@@ -410,9 +413,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[356]
 
 [mmrso4_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4) * replace_altitude_with_height2m(m01s34i102[lblev=1, lbproc=128] + m01s34i104[lblev=1, lbproc=128] + m01s34i108[lblev=1, lbproc=128] + m01s34i114[lblev=1, lbproc=128])
@@ -421,9 +424,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[212]
 
 [mmrso4_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4) * (m01s34i102[lbproc=0] + m01s34i104[lbproc=0] + m01s34i108[lbproc=0] + m01s34i114[lbproc=0])
@@ -432,9 +435,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[700]
 
 [mmrss_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s34i111[lbproc=128] + m01s34i117[lbproc=128]
@@ -443,9 +446,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[358]
 
 [mmrss_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s34i111[lblev=1, lbproc=128] + m01s34i117[lblev=1, lbproc=128])
@@ -454,9 +457,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[214]
 
 [mmrss_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s34i111[lbproc=0] + m01s34i117[lbproc=0]
@@ -465,9 +468,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[701]
 
 [od550aer_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda550nm
 expression = m01s02i285[lbplev=3, lbproc=128] + m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128] + m01s02i302[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
@@ -476,9 +479,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[369, 215]
 
 [od550dust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda550nm
 expression = m01s02i285[lbplev=3, lbproc=128]
@@ -487,9 +490,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[374]
 
 [od550lt1aer_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda550nm
 expression = m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
@@ -498,9 +501,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[375]
 
 [od865aer_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda865nm
 expression = m01s02i285[lbplev=5, lbproc=128] + m01s02i300[lbplev=5, lbproc=128] + m01s02i301[lbplev=5, lbproc=128] + m01s02i302[lbplev=5, lbproc=128] + m01s02i303[lbplev=5, lbproc=128]
@@ -509,9 +512,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[381]
 
 [reffclwtop_tavg-u-hxy-cl]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s01i245[lbproc=128] / m01s01i246[lbproc=128]
@@ -520,9 +523,9 @@ positive =
 reviewer = none
 status = embargoed
 units = um
+# Issue number(s):[389]
 
 [rldaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = correct_multilevel_metadata(m01s02i518[llbproc=128])
@@ -531,9 +534,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = MISSING_MODEL_UNITS
+# Issue number(s):[1880]
 
 [rldcsaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = correct_multilevel_metadata(m01s02i520[llbproc=128])
@@ -542,9 +545,10 @@ positive = up
 reviewer = none
 status = embargoed
 units = MISSING_MODEL_UNITS
+# Issue number(s):[1881]
 
 [rluscsaf_tavg-u-hxy-u]
-comment = 
+comment = Ticket https://code.metoffice.gov.uk/trac/UKESM/ticket/172 explains why the TOA correction for the changes in surface temperature due to the boundary layer scheme between radiation time steps can be used for the surface LW upwards flux here. This was confirmed by Alejandro Bodas-Salcedo by email.
 component = aerosol
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i519[lblev=1, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -553,9 +557,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[390]
 
 [rlutaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i517[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -564,9 +568,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[391]
 
 [rlutcsaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i519[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -575,9 +579,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[393]
 
 [rsdaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = correct_multilevel_metadata(m01s01i518[llbproc=128])
@@ -586,9 +590,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = MISSING_MODEL_UNITS
+# Issue number(s):[1882]
 
 [rsdcsaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = correct_multilevel_metadata(m01s01i520[llbproc=128])
@@ -597,9 +601,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = MISSING_MODEL_UNITS
+# Issue number(s):[1883]
 
 [rsutaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s01i517[lblev=86, lbproc=128]
@@ -608,9 +612,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[397]
 
 [rsutcsaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s01i519[lblev=86, lbproc=128]
@@ -619,9 +623,10 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[399]
 
 [sfpm10_tavg-al-hxy-u]
-comment = 
+comment = Dust MMRs are added on separately since the dust scheme is separate to the aerosol scheme used for PM calculation. The first four dust bins and a fraction (PM10_DUST_BIN5_FRACTION=0.398) of the 5th range up to 10um in diameter and are used here. Model outputs PM in ug/m3 and so we need to divide by the air density to get ug/kg. However, this lead to inaccuracies since we have use the daily mean air density rather than the instantaneous value.
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (m01s38i560[lbproc=128] / m01s15i271[lbproc=128])*KG_PER_MICROGRAM + m01s00i431[lbproc=128] + m01s00i432[lbproc=128] + m01s00i433[lbproc=128] + m01s00i434[lbproc=128] + m01s00i435[lbproc=128]*PM10_DUST_BIN5_FRACTION
@@ -630,9 +635,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[354]
 
 [sfpm10_tavg-h2m-hxy-u]
-comment = 
+comment = Dust MMRs are added on separately since the dust scheme is separate to the aerosol scheme used for PM calculation. The first four dust bins and a fraction (PM10_DUST_BIN5_FRACTION=0.398) of the 5th range up to 10um in diameter and are used here. Model outputs PM in ug/m3 and so we need to divide by the air density to get ug/kg. However, this lead to inaccuracies since we have use the daily mean air density rather than the instantaneous value.
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = (replace_altitude_with_height2m(m01s38i560[lblev=1, lbproc=128]) / replace_altitude_with_height2m(m01s15i271[lblev=1, lbproc=128]))*KG_PER_MICROGRAM + replace_altitude_with_height2m(m01s00i431[lblev=1, lbproc=128] + m01s00i432[lblev=1, lbproc=128] + m01s00i433[lblev=1, lbproc=128] + m01s00i434[lblev=1, lbproc=128] + m01s00i435[lblev=1, lbproc=128]*PM10_DUST_BIN5_FRACTION)
@@ -641,9 +647,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[236, 218]
 
 [sfpm25_tavg-h2m-hxy-u]
-comment = 
+comment = Dust MMRs are added on separately since the dust scheme is separate to the aerosol scheme used for PM calculation. The first three dust bins and a fraction (PM2PT5_DUST_BIN4_FRACTION=0.194) of the 4th range up to 2.5um in diameter and are used here. Model outputs PM in ug/m3 and so we need to divide by the air density to get ug/kg. However, this lead to inaccuracies since we have use the daily mean air density rather than the instantaneous value.
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = (replace_altitude_with_height2m(m01s38i561[lblev=1, lbproc=128]) / replace_altitude_with_height2m(m01s15i271[lblev=1, lbproc=128]))*KG_PER_MICROGRAM + replace_altitude_with_height2m(m01s00i431[lblev=1, lbproc=128] + m01s00i432[lblev=1, lbproc=128] + m01s00i433[lblev=1, lbproc=128] + m01s00i434[lblev=1, lbproc=128]*PM2PT5_DUST_BIN4_FRACTION)
@@ -652,9 +659,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[237, 219]
 
 [so2_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i072[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_SO2)
@@ -663,9 +670,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[403]
 
 [so2_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s34i072[lblev=1, lbproc=128]) * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_SO2)
@@ -674,9 +681,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[220]
 
 [so2_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_SO2) * m01s34i072[lbproc=0]
@@ -685,9 +692,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[702]
 
 [tatp_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s30i452[lbproc=128]
@@ -696,9 +703,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[405]
 
 [ua_tavg-10hPa-hxy-air]
-comment = 
 component = aerosol
 dimension = longitude latitude time p10
 expression = m01s30i201[blev=P10, lbproc=128] / m01s30i301[blev=P10, lbproc=128]
@@ -707,9 +714,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[222]
 
 [wa_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s00i150[lbproc=128]
@@ -718,9 +725,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[417]
 
 [wetdust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s04i231[lbproc=128] + m01s04i232[lbproc=128] + m01s04i233[lbproc=128] + m01s04i234[lbproc=128] + m01s04i235[lbproc=128] + m01s04i236[lbproc=128] + m01s05i281[lbproc=128] + m01s05i282[lbproc=128] + m01s05i283[lbproc=128] + m01s05i284[lbproc=128] + m01s05i285[lbproc=128] + m01s05i286[lbproc=128]
@@ -729,9 +736,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[419]
 
 [zg_tavg-10hPa-hxy-air]
-comment = 
 component = aerosol
 dimension = longitude latitude time p10
 expression = m01s30i297[blev=P10, lbproc=128] / m01s30i304[blev=P10, lbproc=128]
@@ -740,3 +747,4 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[226]

--- a/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_atmosChem_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_atmosChem_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the atmosChem realm
 
 [dms_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i071[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_DMS)
@@ -14,3 +13,4 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[276]

--- a/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_atmos_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_atmos_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the atmos realm
 
 [albisccp_tavg-u-hxy-cl]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = fix_packing_division(m01s02i331[lbproc=128], m01s02i334[lbproc=128])
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[512, 475]
 
 [areacella_ti-u-hxy-u]
-comment = 
 component = atmos land
 dimension = longitude latitude
 expression = areacella(m01s00i505)
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m2
+# Issue number(s):[1844]
 
 [bldep_tavg-u-hxy-u]
-comment = 
 component = atmos aerosol land
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[654, 248]
 
 [bldep_tmax-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=8192]
@@ -47,9 +46,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[204]
 
 [bldep_tmin-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=4096]
@@ -58,9 +57,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[205]
 
 [cfadDbze94_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 dbze time
 expression = m01s02i372[lbproc=128]
@@ -69,9 +68,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[859]
 
 [cfadLidarsr532_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 scatratio time
 expression = m01s02i370[lbproc=128]
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[860]
 
 [ci_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i269[lbproc=128]
@@ -91,9 +90,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[11]
 
 [ci_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i269[lbproc=0]
@@ -102,9 +101,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[578]
 
 [cl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i261[lbproc=128]
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[478, 12]
 
 [cl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i261[lbproc=0]
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[580]
 
 [clc_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i317[lbproc=128]
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[513]
 
 [clcalipso_tavg-220hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p220
 expression = m01s02i346[lbproc=128, blev=P220] / m01s02i323[lbproc=128, blev=P220]
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[515, 480]
 
 [clcalipso_tavg-560hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p560
 expression = m01s02i345[lbproc=128, blev=P560] / m01s02i322[lbproc=128, blev=P560]
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[521, 485]
 
 [clcalipso_tavg-840hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p840
 expression = m01s02i344[lbproc=128, blev=P840] / m01s02i321[lbproc=128, blev=P840]
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[520, 484]
 
 [clcalipso_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 time
 expression = m01s02i371[lbproc=128] / m01s02i325[lbproc=128]
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[514, 479]
 
 [clcalipsoice_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 time
 expression = m01s02i474[lbproc=128] / m01s02i325[lbproc=128]
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[861]
 
 [clcalipsoliq_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 time
 expression = m01s02i473[lbproc=128] / m01s02i325[lbproc=128]
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[862]
 
 [cldncl_tavg-u-hxy-cl]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i298[lbproc=128] / m01s01i299[lbproc=128]
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = cm-3
+# Issue number(s):[864]
 
 [cldnvi_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i280[lbproc=128] / m01s01i281[lbproc=128]
@@ -223,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-2
+# Issue number(s):[865, 709]
 
 [cli_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i309[lbproc=128]
@@ -234,9 +233,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[481, 13]
 
 [cli_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i309[lbproc=0]
@@ -245,9 +244,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[581]
 
 [clic_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i319[lbproc=128]
@@ -256,9 +255,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[516]
 
 [clic_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i319[lbproc=0]
@@ -267,9 +266,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[448]
 
 [climodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i453[lbproc=128] / m01s02i330[lbproc=128]
@@ -278,9 +277,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[866]
 
 [clis_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i309[lbproc=128] - m01s02i319[lbproc=128]
@@ -289,9 +288,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[517]
 
 [clis_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i309[lbproc=0] - m01s02i319[lbproc=0]
@@ -300,9 +299,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[449]
 
 [clisccp_tavg-p7c-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7c tau time
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=128], m01s02i330[lbproc=128])
@@ -311,9 +310,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[518, 482]
 
 [clivi_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i392[lbproc=128]
@@ -322,9 +321,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[682, 483, 14]
 
 [clivi_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i392[lbproc=0]
@@ -333,9 +332,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[582]
 
 [clivi_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i392[lbproc=0]
@@ -344,9 +343,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[450]
 
 [clivic_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i396[lbproc=128]
@@ -355,9 +354,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[710]
 
 [clivimodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i467[lbproc=128] / m01s02i330[lbproc=128]
@@ -366,9 +365,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[519]
 
 [clmisr_tavg-h16-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt16 tau time
 expression = fix_clmisr_height(m01s02i360[lbproc=128], m01s02i330[lbproc=128])
@@ -377,9 +376,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[867]
 
 [clmodis_tavg-p7c-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7c tau time
 expression = divide_by_mask(m01s02i450[blev=PLEV7C, lbproc=128], m01s02i330[lbproc=128])
@@ -388,9 +387,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[522]
 
 [cls_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i312[lbproc=128] + m01s02i313[lbproc=128] - m01s02i317[lbproc=128]
@@ -399,9 +398,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[527]
 
 [clt_tavg-u-hxy-lnd]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i204[lbproc=128]
@@ -410,9 +409,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[711]
 
 [clt_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i204[lbproc=128]
@@ -421,9 +420,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1795, 655, 80, 15]
 
 [clt_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i204[lbproc=0]
@@ -432,9 +431,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[583]
 
 [clt_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i204[lbproc=0]
@@ -443,9 +442,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[451]
 
 [cltcalipso_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i347[lbproc=128] / m01s02i324[lbproc=128]
@@ -454,9 +453,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[528, 486]
 
 [cltcalipso_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i347[lbproc=0] / m01s02i324[lbproc=0]
@@ -465,9 +464,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[690]
 
 [cltisccp_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i334[lbproc=128] / m01s02i330[lbproc=128]
@@ -476,9 +475,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[529, 487]
 
 [cltmodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i451[lbproc=128] / m01s02i330[lbproc=128]
@@ -487,9 +486,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[868]
 
 [clw_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i308[lbproc=128]
@@ -498,9 +497,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[488, 16]
 
 [clw_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i308[lbproc=0]
@@ -509,9 +508,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[584]
 
 [clwc_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i318[lbproc=128]
@@ -520,9 +519,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[531]
 
 [clwc_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i318[lbproc=0]
@@ -531,9 +530,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[452]
 
 [clwmodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i452[lbproc=128] / m01s02i330[lbproc=128]
@@ -542,9 +541,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[869]
 
 [clws_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i308[lbproc=128] - m01s02i318[lbproc=128]
@@ -553,9 +552,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[532]
 
 [clws_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i308[lbproc=0] - m01s02i318[lbproc=0]
@@ -564,9 +563,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[453]
 
 [clwvi_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128] + m01s02i392[lbproc=128]
@@ -575,9 +574,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[683, 489, 17]
 
 [clwvi_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i391[lbproc=0] + m01s02i392[lbproc=0]
@@ -586,9 +585,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[585]
 
 [clwvi_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i391[lbproc=0]+m01s02i392[lbproc=0]
@@ -597,9 +596,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[454]
 
 [clwvic_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i395[lbproc=128] + m01s02i396[lbproc=128]
@@ -608,9 +607,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[712]
 
 [clwvimodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i466[lbproc=128] / m01s02i330[lbproc=128]
@@ -619,9 +618,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[533]
 
 [co2mass_tavg-u-hm-u]
-comment = 
 component = atmos
 dimension = time
 expression = m01s30i465[lbproc=128]
@@ -630,9 +629,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg
+# Issue number(s):[20]
 
 [epfy_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = scale_epflux(m01s30i312[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -641,9 +640,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m3 s-2
+# Issue number(s):[1061, 810]
 
 [epfz_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = scale_epflux(m01s30i313[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -652,9 +651,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = m3 s-2
+# Issue number(s):[1062, 811]
 
 [evspsbl_tavg-u-hxy-lnd]
-comment = 
 component = atmos land
 dimension = longitude latitude time
 expression = m01s03i223[lbproc=128]
@@ -663,9 +662,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[720]
 
 [evspsbl_tavg-u-hxy-u]
-comment = 
 component = atmos land
 dimension = longitude latitude time
 expression = m01s03i223[lbproc=128]
@@ -674,9 +673,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[22]
 
 [evspsbl_tpt-u-hs-u]
-comment = 
 component = atmos land
 dimension = site time1
 expression = m01s03i223[lbproc=0]
@@ -685,9 +684,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[587]
 
 [hfls_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i234[lbproc=128]
@@ -696,9 +695,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1796, 656, 88, 27]
 
 [hfls_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s03i234[lbproc=0]
@@ -707,9 +706,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[592]
 
 [hfss_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i217[lbproc=128]
@@ -718,9 +717,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1797, 657, 90, 28]
 
 [hfss_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s03i217[lbproc=0]
@@ -729,9 +728,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[593]
 
 [hur_tavg-700hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p700
 expression = m01s30i296[blev=P700, lbproc=128] / m01s30i304[blev=P700, lbproc=128]
@@ -740,9 +739,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[491]
 
 [hur_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i113[lbproc=128]
@@ -751,9 +750,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[537, 490]
 
 [hur_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -762,9 +761,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[29]
 
 [hur_tavg-p19-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -773,9 +772,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1798]
 
 [hur_tpt-100hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p100
 expression = m01s30i296[blev=P100, lbproc=0] / m01s30i304[blev=P100, lbproc=0]
@@ -784,9 +783,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[170]
 
 [hur_tpt-500hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p500
 expression = m01s30i296[blev=P500, lbproc=0] / m01s30i304[blev=P500, lbproc=0]
@@ -795,9 +794,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[171]
 
 [hur_tpt-850hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p850
 expression = m01s30i296[blev=P850, lbproc=0] / m01s30i304[blev=P850, lbproc=0]
@@ -806,9 +805,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[172]
 
 [hur_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i113[lbproc=0]
@@ -817,9 +816,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[594]
 
 [hurs_tavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i245[lbproc=128]
@@ -828,9 +827,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1799, 658, 153, 30]
 
 [hurs_tmax-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i245[lbproc=8192]
@@ -839,9 +838,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1800]
 
 [hurs_tmin-h2m-hxy-crp]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i245[lbproc=4096]
@@ -850,9 +849,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[728]
 
 [hurs_tmin-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i245[lbproc=4096]
@@ -861,9 +860,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1801]
 
 [hurs_tpt-h2m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height2m
 expression = m01s03i245[lbproc=0]
@@ -872,9 +871,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[595]
 
 [hurs_tpt-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height2m
 expression = m01s03i245[lbproc=0]
@@ -883,9 +882,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[457]
 
 [hus_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s00i010[lbproc=128]
@@ -894,9 +893,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[538, 492]
 
 [hus_tavg-p19-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -905,9 +904,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1802, 31]
 
 [hus_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s00i010[lbproc=0]
@@ -916,9 +915,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[596]
 
 [hus_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
@@ -927,9 +926,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[692, 147]
 
 [hus_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i295[blev=PLEV6, lbproc=0] / m01s30i304[blev=PLEV6, lbproc=0]
@@ -938,9 +937,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[693]
 
 [hus_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i295[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
@@ -949,9 +948,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[173]
 
 [huss_tavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i237[lbproc=128]
@@ -960,9 +959,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1803, 154, 32]
 
 [huss_tpt-h2m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height2m
 expression = m01s03i237[lbproc=0]
@@ -971,9 +970,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[597]
 
 [huss_tpt-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height2m
 expression = m01s03i237[lbproc=0]
@@ -982,9 +981,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[659, 91]
 
 [intuadse_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = SPECIFIC_HEAT_OF_DRY_AIR * m01s30i425[lbproc=128] + m01s30i422[lbproc=128]
@@ -993,9 +992,9 @@ positive =
 reviewer = none
 status = embargoed
 units = J m-1 s-1
+# Issue number(s):[929, 730]
 
 [intuaw_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i462[lbproc=128]
@@ -1004,9 +1003,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-1 s-1
+# Issue number(s):[930, 731]
 
 [intuaw_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s30i462[lbproc=0]
@@ -1015,9 +1014,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-1 s-1
+# Issue number(s):[174]
 
 [intvadse_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = SPECIFIC_HEAT_OF_DRY_AIR * m01s30i426[lbproc=128] + m01s30i423[lbproc=128]
@@ -1026,9 +1025,9 @@ positive =
 reviewer = none
 status = embargoed
 units = J m-1 s-1
+# Issue number(s):[931, 732]
 
 [intvaw_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i463[lbproc=128]
@@ -1037,9 +1036,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-1 s-1
+# Issue number(s):[932, 733]
 
 [intvaw_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s30i463[lbproc=0]
@@ -1048,9 +1047,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-1 s-1
+# Issue number(s):[175]
 
 [loaddust_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = calc_loaddust(m01s17i257[lbproc=128], m01s50i255[lbproc=128])
@@ -1059,9 +1058,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[739]
 
 [mc_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = (m01s05i250[lbproc=128] - m01s05i251[lbproc=128]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
@@ -1070,9 +1069,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[493, 33]
 
 [mc_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = (m01s05i250[lbproc=0] - m01s05i251[lbproc=0]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
@@ -1081,9 +1080,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[598]
 
 [mcd_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = m01s05i251[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
@@ -1092,9 +1091,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[539]
 
 [mcu_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = m01s05i250[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
@@ -1103,9 +1102,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[540]
 
 [parasolRefl_tavg-u-hxy-sea]
-comment = 
 component = atmos
 dimension = longitude latitude sza5 time
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=128])
@@ -1114,9 +1113,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[969, 759]
 
 [pctisccp_tavg-u-hxy-cl]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i333[lbproc=128] / m01s02i334[lbproc=128]
@@ -1125,9 +1124,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[541, 494]
 
 [pfull_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s00i408[lbproc=128]
@@ -1136,9 +1135,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[495, 384]
 
 [pfull_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s00i408[lbproc=0]
@@ -1147,9 +1146,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[599]
 
 [pfull_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s00i408[lbproc=0]
@@ -1158,9 +1157,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[458]
 
 [phalf_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = m01s00i407[lbproc=128]
@@ -1169,9 +1168,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[496, 385]
 
 [phalf_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = m01s00i407[lbproc=0]
@@ -1180,9 +1179,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[600]
 
 [pr_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128]
@@ -1191,9 +1190,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1813, 660, 155, 97, 42]
 
 [pr_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i216[lbproc=0]
@@ -1202,9 +1201,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[601]
 
 [pr_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s05i216[lbproc=0]
@@ -1213,9 +1212,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[459, 176]
 
 [prc_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128] + m01s05i206[lbproc=128]
@@ -1224,9 +1223,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1814, 43]
 
 [prc_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i205[lbproc=0] + m01s05i206[lbproc=0]
@@ -1235,9 +1234,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[602]
 
 [prra_tavg-u-hxy-lnd]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i214[lbproc=128]
@@ -1246,9 +1245,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[763]
 
 [prra_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i214[lbproc=128]
@@ -1257,9 +1256,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[157, 44]
 
 [prsn_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i215[lbproc=128]
@@ -1268,9 +1267,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1815, 158, 98, 45]
 
 [prsn_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i215[lbproc=0]
@@ -1279,9 +1278,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[603]
 
 [prsnc_tavg-u-hxy-lnd]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i206[lbproc=128]
@@ -1290,9 +1289,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[765]
 
 [prw_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i461[lbproc=128]
@@ -1301,9 +1300,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[767, 684, 46]
 
 [prw_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s30i461[lbproc=0]
@@ -1312,9 +1311,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[604]
 
 [prw_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s30i461[lbproc=0]
@@ -1323,9 +1322,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[460, 177]
 
 [ps_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s00i409[lbproc=128]
@@ -1334,9 +1333,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[497, 232, 159, 47]
 
 [ps_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s00i409[lbproc=0]
@@ -1345,9 +1344,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[605]
 
 [ps_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
@@ -1356,9 +1355,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[661, 148, 99]
 
 [psl_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s16i222[lbproc=128]
@@ -1367,9 +1366,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[1816, 160, 48]
 
 [psl_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s16i222[lbproc=0]
@@ -1378,9 +1377,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[606]
 
 [psl_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s16i222[lbproc=0]
@@ -1389,9 +1388,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[662, 178]
 
 [ptp_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i451[lbproc=128]
@@ -1400,9 +1399,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[388]
 
 [reffcclwtop_tavg-u-hxy-ccl]
-comment = 
 component = atmos atmosChem aerosol
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128], m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
@@ -1411,9 +1410,9 @@ positive =
 reviewer = none
 status = embargoed
 units = um
+# Issue number(s):[987, 770]
 
 [reffclic_tavg-al-hxy-ccl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
@@ -1422,9 +1421,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[989]
 
 [reffclic_tpt-al-hs-ccl]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
@@ -1433,9 +1432,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1077]
 
 [reffclic_tpt-al-hxy-ccl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
@@ -1444,9 +1443,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[461]
 
 [reffclis_tavg-al-hxy-scl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
@@ -1455,9 +1454,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[990]
 
 [reffclis_tpt-al-hs-scl]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
@@ -1466,9 +1465,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1078]
 
 [reffclis_tpt-al-hxy-scl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
@@ -1477,9 +1476,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[462]
 
 [reffclwc_tavg-al-hxy-ccl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
@@ -1488,9 +1487,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[991]
 
 [reffclwc_tpt-al-hs-ccl]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
@@ -1499,9 +1498,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1079]
 
 [reffclwc_tpt-al-hxy-ccl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
@@ -1510,9 +1509,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[463]
 
 [reffclws_tavg-al-hxy-scl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
@@ -1521,9 +1520,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[992]
 
 [reffclws_tpt-al-hs-scl]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
@@ -1532,9 +1531,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1080]
 
 [reffclws_tpt-al-hxy-scl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
@@ -1543,9 +1542,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[464]
 
 [reffsclwtop_tavg-u-hxy-scl]
-comment = 
 component = atmos atmosChem aerosol
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128], m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128] + m01s02i396[lbproc=128]))
@@ -1554,9 +1553,9 @@ positive =
 reviewer = none
 status = embargoed
 units = um
+# Issue number(s):[993, 771]
 
 [rld4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i522[lbproc=128])
@@ -1565,9 +1564,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[543]
 
 [rld_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i218[lbproc=128])
@@ -1576,9 +1575,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[542]
 
 [rld_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i218[lbproc=0])
@@ -1587,9 +1586,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[607]
 
 [rldcs4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i524[lbproc=128])
@@ -1598,9 +1597,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[545]
 
 [rldcs_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i220[lbproc=128])
@@ -1609,9 +1608,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[544]
 
 [rldcs_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i220[lbproc=0])
@@ -1620,9 +1619,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[608]
 
 [rlds_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i207[lbproc=128]
@@ -1631,9 +1630,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1817, 663, 161, 100, 49]
 
 [rlds_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i207[lbproc=0]
@@ -1642,9 +1641,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[609]
 
 [rlds_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i207[lbproc=0]
@@ -1653,9 +1652,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[465]
 
 [rldscs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i208[lbproc=128]
@@ -1664,9 +1663,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[498, 50]
 
 [rldscs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i208[lbproc=0]
@@ -1675,9 +1674,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[610]
 
 [rldscs_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i208[lbproc=0]
@@ -1686,9 +1685,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[466]
 
 [rls_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i201[lbproc=128] - (m01s03i332[lbproc=128] - m01s02i205[lbproc=128])
@@ -1697,9 +1696,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1818, 1002]
 
 [rlu4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i521[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
@@ -1708,9 +1707,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[547]
 
 [rlu_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i217[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
@@ -1719,9 +1718,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[546]
 
 [rlu_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i217[lbproc=0])
@@ -1730,9 +1729,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[611]
 
 [rlucs4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i523[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
@@ -1741,9 +1740,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[549]
 
 [rlucs_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i219[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
@@ -1752,9 +1751,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[548]
 
 [rlucs_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i219[lbproc=0])
@@ -1763,9 +1762,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[612]
 
 [rlus_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i207[lbproc=128] - m01s02i201[lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1774,9 +1773,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1819, 664, 101, 51]
 
 [rlus_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i207[lbproc=0] - m01s02i201[lbproc=0]
@@ -1785,9 +1784,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[613]
 
 [rluscs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i219[lblev=1, lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1796,9 +1795,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1820, 52]
 
 [rlut4co2_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i521[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1807,9 +1806,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[550]
 
 [rlut_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i332[lbproc=128]
@@ -1818,9 +1817,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1821, 685, 53]
 
 [rlut_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s03i332[lbproc=128, lbtim_ia=24])
@@ -1829,9 +1828,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[677]
 
 [rlut_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i205[lbproc=0]
@@ -1840,9 +1839,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[614]
 
 [rlut_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s03i332[lbproc=0]
@@ -1851,9 +1850,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[467]
 
 [rlutcs4co2_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i523[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1862,9 +1861,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[551]
 
 [rlutcs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i206[lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1873,9 +1872,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[686, 499, 54]
 
 [rlutcs_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s02i206[lbproc=128, lbtim_ia=24] + m01s03i332[lbproc=128, lbtim_ia=24] - m01s02i205[lbproc=128, lbtim_ia=24])
@@ -1884,9 +1883,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[678]
 
 [rlutcs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i206[lbproc=0]
@@ -1895,9 +1894,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[615]
 
 [rlutcs_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i206[lbproc=0]+m01s03i332[lbproc=0]-m01s02i205[lbproc=0]
@@ -1906,9 +1905,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[468]
 
 [rsd4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i522[lbproc=128])
@@ -1917,9 +1916,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[553]
 
 [rsd_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i218[lbproc=128])
@@ -1928,9 +1927,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[552]
 
 [rsd_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i218[lbproc=0])
@@ -1939,9 +1938,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[616]
 
 [rsdcs4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i524[lbproc=128])
@@ -1950,9 +1949,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[555]
 
 [rsdcs_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i220[lbproc=128])
@@ -1961,9 +1960,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[554]
 
 [rsdcs_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i220[lbproc=0])
@@ -1972,9 +1971,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[617]
 
 [rsds_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i235[lbproc=128]
@@ -1983,9 +1982,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1822, 665, 162, 102, 55]
 
 [rsds_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i235[lbproc=0]
@@ -1994,9 +1993,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[618]
 
 [rsds_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s01i235[lbproc=0]
@@ -2005,9 +2004,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[469]
 
 [rsdscs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i210[lbproc=128]
@@ -2016,9 +2015,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[500, 56]
 
 [rsdscs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i210[lbproc=0]
@@ -2027,9 +2026,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[619]
 
 [rsdscs_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s01i210[lbproc=0]
@@ -2038,9 +2037,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[470]
 
 [rsdsdiff_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i216[lbproc=128]
@@ -2049,9 +2048,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[776, 666]
 
 [rsdt_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i207[lbproc=128]
@@ -2060,9 +2059,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[501, 57]
 
 [rsdt_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s01i207[lbproc=128, lbtim_ia=24])
@@ -2071,9 +2070,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[679]
 
 [rsdt_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i207[lbproc=0]
@@ -2082,9 +2081,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[620]
 
 [rss_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i201[lbproc=128]
@@ -2093,9 +2092,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1824, 1008]
 
 [rsu4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i521[lbproc=128])
@@ -2104,9 +2103,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[557]
 
 [rsu_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i217[lbproc=128])
@@ -2115,9 +2114,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[556]
 
 [rsu_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i217[lbproc=0])
@@ -2126,9 +2125,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[621]
 
 [rsucs4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i523[lbproc=128])
@@ -2137,9 +2136,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[559]
 
 [rsucs_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i219[lbproc=128])
@@ -2148,9 +2147,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[558]
 
 [rsucs_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i219[lbproc=0])
@@ -2159,9 +2158,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[622]
 
 [rsus_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i235[lbproc=128] - m01s01i201[lbproc=128]
@@ -2170,9 +2169,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1825, 667, 104, 58]
 
 [rsus_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i235[lbproc=0] - m01s01i201[lbproc=0]
@@ -2181,9 +2180,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[623]
 
 [rsuscs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i211[lbproc=128]
@@ -2192,9 +2191,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[502, 59]
 
 [rsuscs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i211[lbproc=0]
@@ -2203,9 +2202,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[624]
 
 [rsut4co2_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i521[lblev=86, lbproc=128]
@@ -2214,9 +2213,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[560]
 
 [rsut_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i208[lbproc=128]
@@ -2225,9 +2224,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[687, 503, 60]
 
 [rsut_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s01i208[lbproc=128, lbtim_ia=24])
@@ -2236,9 +2235,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[680]
 
 [rsut_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i208[lbproc=0]
@@ -2247,9 +2246,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[625]
 
 [rsut_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s01i208[lbproc=0]
@@ -2258,9 +2257,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[471]
 
 [rsutcs4co2_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i523[lblev=86, lbproc=128]
@@ -2269,9 +2268,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[561]
 
 [rsutcs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i209[lbproc=128]
@@ -2280,9 +2279,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[688, 504, 61]
 
 [rsutcs_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s01i209[lbproc=128, lbtim_ia=24])
@@ -2291,9 +2290,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[681]
 
 [rsutcs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i209[lbproc=0]
@@ -2302,9 +2301,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[626]
 
 [rsutcs_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s01i209[lbproc=0]
@@ -2313,9 +2312,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[472]
 
 [rtmt_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i207[lbproc=128] - m01s01i208[lbproc=128] - m01s03i332[lbproc=128]
@@ -2324,9 +2323,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[62]
 
 [rtmt_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i207[lbproc=0] - m01s01i208[lbproc=0] - m01s02i205[lbproc=0]
@@ -2335,9 +2334,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[627]
 
 [rv850_tavg-850hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p850
 expression = m01s30i455[blev=P850, lbproc=128]
@@ -2346,9 +2345,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[163]
 
 [rv850_tpt-850hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p850
 expression = m01s30i455[blev=P850, lbproc=0]
@@ -2357,9 +2356,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[179]
 
 [sci_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i270[lbproc=128]
@@ -2368,9 +2367,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[64]
 
 [sci_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i270[lbproc=0]
@@ -2379,9 +2378,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[629]
 
 [scldncl_tavg-u-hxy-scl]
-comment = 
 component = atmos atmosChem aerosol
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128], m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128] + m01s02i396[lbproc=128]))
@@ -2390,9 +2389,9 @@ positive =
 reviewer = none
 status = embargoed
 units = cm-3
+# Issue number(s):[1014, 779]
 
 [sfcWind_tavg-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i230[lbproc=128]
@@ -2401,9 +2400,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1827, 689, 668, 164, 65]
 
 [sfcWind_tmax-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i230[lbproc=8192]
@@ -2412,9 +2411,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1828]
 
 [sfcWind_tmaxavg-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time4 height10m
 expression = mon_mean_from_day(m01s03i230[lbproc=8192])
@@ -2423,9 +2422,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1015]
 
 [sfcWind_tpt-h10m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height10m
 expression = m01s03i230[lbproc=0]
@@ -2434,9 +2433,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[630]
 
 [sftlf_ti-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude
 expression = m01s00i505
@@ -2445,9 +2444,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1855]
 
 [snwc_tavg-u-hxy-lnd]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i236[lbproc=128], m01s03i317[lbproc=128], land_class='canopy')
@@ -2456,9 +2455,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[784]
 
 [ta_tavg-700hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p700
 expression = m01s30i294[blev=P700, lbproc=128] / m01s30i304[blev=P700, lbproc=128]
@@ -2467,9 +2466,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[506]
 
 [ta_tavg-850hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p850
 expression = m01s30i294[blev=P850, lbproc=128] / m01s30i304[blev=P850, lbproc=128]
@@ -2478,9 +2477,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[788]
 
 [ta_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i111[lbproc=128]
@@ -2489,9 +2488,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[563, 505]
 
 [ta_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -2500,9 +2499,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1831, 66]
 
 [ta_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s30i294[blev=PLEV39, lbproc=192] / m01s30i304[blev=PLEV39, lbproc=192]
@@ -2511,9 +2510,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[813, 443]
 
 [ta_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i111[lbproc=0]
@@ -2522,9 +2521,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[631]
 
 [ta_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s30i111[lbproc=0]
@@ -2533,9 +2532,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[473, 149]
 
 [ta_tpt-p3-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev3 time1
 expression = m01s30i294[blev=PLEV3, lbproc=0] / m01s30i304[blev=PLEV3, lbproc=0]
@@ -2544,9 +2543,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[180]
 
 [ta_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i294[blev=PLEV6, lbproc=0] / m01s30i304[blev=PLEV6, lbproc=0]
@@ -2555,9 +2554,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[703]
 
 [ta_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i294[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
@@ -2566,9 +2565,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[181]
 
 [tas_tavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i236[lbproc=128]
@@ -2577,9 +2576,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1832, 238, 165, 67]
 
 [tas_tmax-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i236[lbproc=8192]
@@ -2588,9 +2587,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1833]
 
 [tas_tmaxavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time4 height2m
 expression = mon_mean_from_day(m01s03i236[lbproc=8192])
@@ -2599,9 +2598,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[68]
 
 [tas_tmin-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i236[lbproc=4096]
@@ -2610,9 +2609,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1834]
 
 [tas_tminavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time4 height2m
 expression = mon_mean_from_day(m01s03i236[lbproc=4096])
@@ -2621,9 +2620,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[69]
 
 [tas_tpt-h2m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height2m
 expression = m01s03i236[lbproc=0]
@@ -2632,9 +2631,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[632]
 
 [tas_tpt-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height2m
 expression = m01s03i236[lbproc=0]
@@ -2643,9 +2642,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[108]
 
 [tauu_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
@@ -2654,9 +2653,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[791, 70]
 
 [tauu_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s03i460[lbproc=0]
@@ -2665,9 +2664,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[633]
 
 [tauupbl_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
@@ -2676,9 +2675,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[792]
 
 [tauv_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
@@ -2687,9 +2686,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[793, 71]
 
 [tauv_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s03i461[lbproc=0]
@@ -2698,9 +2697,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[634]
 
 [tauvpbl_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
@@ -2709,9 +2708,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[794]
 
 [tdps_tavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i250[lbproc=128]
@@ -2720,9 +2719,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1028, 795]
 
 [tnhus_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i182[lbproc=128] / ATMOS_TIMESTEP
@@ -2731,9 +2730,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[564]
 
 [tnhus_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i182[lbproc=0] / ATMOS_TIMESTEP
@@ -2742,9 +2741,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[635]
 
 [tnhusa_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s12i182[lbproc=128] + m01s12i382[lbproc=128]) / ATMOS_TIMESTEP
@@ -2753,9 +2752,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[565]
 
 [tnhusa_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s12i182[lbproc=0] + m01s12i382[lbproc=0]) / ATMOS_TIMESTEP
@@ -2764,9 +2763,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[636]
 
 [tnhusc_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s05i162[lbproc=128] / ATMOS_TIMESTEP
@@ -2775,9 +2774,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[566]
 
 [tnhusc_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s05i162[lbproc=0] / ATMOS_TIMESTEP
@@ -2786,9 +2785,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[637]
 
 [tnhusmp_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s04i982[lbproc=128] + m01s05i182[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128] + m01s35i025[lbproc=128] ) / ATMOS_TIMESTEP
@@ -2797,9 +2796,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[568]
 
 [tnhusmp_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0] + m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0] + m01s04i982[lbproc=0] + m01s05i182[lbproc=0] + m01s16i162[lbproc=0] + m01s16i182[lbproc=0] + m01s35i025[lbproc=0] ) / ATMOS_TIMESTEP
@@ -2808,9 +2807,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[639]
 
 [tnhuspbl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s03i190[lbproc=128] / ATMOS_TIMESTEP
@@ -2819,9 +2818,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1033]
 
 [tnhuspbl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s03i190[lbproc=0] / ATMOS_TIMESTEP
@@ -2830,9 +2829,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1081]
 
 [tnhusscp_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] - m01s03i190[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
@@ -2841,9 +2840,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1034]
 
 [tnhusscp_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0] + m01s03i182[lbproc=0] - m01s03i190[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0] + m01s05i182[lbproc=0] - m01s05i162[lbproc=0] + m01s16i162[lbproc=0] + m01s16i182[lbproc=0]) / ATMOS_TIMESTEP
@@ -2852,9 +2851,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1082]
 
 [tnhusscpbl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
@@ -2863,9 +2862,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[569]
 
 [tnhusscpbl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0] + m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0] + m01s05i182[lbproc=0] - m01s05i162[lbproc=0] + m01s16i162[lbproc=0] + m01s16i182[lbproc=0]) / ATMOS_TIMESTEP
@@ -2874,9 +2873,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[640]
 
 [tnt_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i181[lbproc=128] / ATMOS_TIMESTEP
@@ -2885,9 +2884,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[570]
 
 [tnt_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i181[lbproc=0] / ATMOS_TIMESTEP
@@ -2896,9 +2895,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[641]
 
 [tnta_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s10i181[lbproc=128] + m01s12i181[lbproc=128] + m01s12i381[lbproc=128]) / ATMOS_TIMESTEP
@@ -2907,9 +2906,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[571]
 
 [tnta_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s10i181[lbproc=0] + m01s12i181[lbproc=0] + m01s12i381[lbproc=0]) / ATMOS_TIMESTEP
@@ -2918,9 +2917,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[642]
 
 [tntc_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s05i161[lbproc=128] / ATMOS_TIMESTEP
@@ -2929,9 +2928,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[572]
 
 [tntc_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s05i161[lbproc=0] / ATMOS_TIMESTEP
@@ -2940,9 +2939,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[643]
 
 [tntmp_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s14i181[lbproc=128] + m01s01i181[lbproc=128] + m01s02i181[lbproc=128] + m01s03i181[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s05i181[lbproc=128] + m01s06i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s35i029[lbproc=128]) / ATMOS_TIMESTEP
@@ -2951,9 +2950,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[573]
 
 [tntmp_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s14i181[lbproc=0]+ m01s01i181[lbproc=0] + m01s02i181[lbproc=0] + m01s03i181[lbproc=0] + m01s04i141[lbproc=0] + m01s04i181[lbproc=0] + m01s05i181[lbproc=0] + m01s06i181[lbproc=0] + m01s16i161[lbproc=0] + m01s16i181[lbproc=0] + m01s35i029[lbproc=0]) / ATMOS_TIMESTEP
@@ -2962,9 +2961,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[644]
 
 [tntpbl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s03i189[lbproc=128] / ATMOS_TIMESTEP
@@ -2973,9 +2972,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1035]
 
 [tntpbl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s03i189[lbproc=0] / ATMOS_TIMESTEP
@@ -2984,9 +2983,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1084]
 
 [tntr_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s01i161[lbproc=128] + m01s02i161[lbproc=128]) / ATMOS_TIMESTEP
@@ -2995,9 +2994,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[574]
 
 [tntr_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s01i161[lbproc=0] + m01s02i161[lbproc=0]) / ATMOS_TIMESTEP
@@ -3006,9 +3005,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[645]
 
 [tntrl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i161[lbproc=128] / ATMOS_TIMESTEP
@@ -3017,9 +3016,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[406]
 
 [tntrl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i161[lbproc=0] / ATMOS_TIMESTEP
@@ -3028,9 +3027,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1085]
 
 [tntrlcs_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i233[lbproc=128]
@@ -3039,9 +3038,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1036]
 
 [tntrlcs_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i233[lbproc=0]
@@ -3050,9 +3049,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1086]
 
 [tntrs_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s01i161[lbproc=128] / ATMOS_TIMESTEP
@@ -3061,9 +3060,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[407]
 
 [tntrs_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s01i161[lbproc=0] / ATMOS_TIMESTEP
@@ -3072,9 +3071,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1087]
 
 [tntrscs_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s01i233[lbproc=128]
@@ -3083,9 +3082,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1037]
 
 [tntrscs_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s01i233[lbproc=0]
@@ -3094,9 +3093,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1088]
 
 [tntscp_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s03i181[lbproc=128] - m01s03i189[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s01i181[lbproc=128] - m01s01i161[lbproc=128] + m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
@@ -3105,9 +3104,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1038]
 
 [tntscp_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s03i181[lbproc=0] - m01s03i189[lbproc=0] + m01s04i141[lbproc=0] + m01s04i181[lbproc=0] + m01s16i161[lbproc=0] + m01s16i181[lbproc=0] + m01s01i181[lbproc=0] - m01s01i161[lbproc=0] + m01s02i181[lbproc=0] - m01s02i161[lbproc=0] + m01s05i181[lbproc=0] - m01s05i161[lbproc=0]) / ATMOS_TIMESTEP
@@ -3116,9 +3115,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1089]
 
 [tntscpbl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s03i181[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s01i181[lbproc=128] - m01s01i161[lbproc=128] + m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
@@ -3127,9 +3126,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[575]
 
 [tntscpbl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s03i181[lbproc=0] + m01s04i141[lbproc=0] + m01s04i181[lbproc=0] + m01s16i161[lbproc=0] + m01s16i181[lbproc=0] + m01s01i181[lbproc=0] - m01s01i161[lbproc=0] + m01s02i181[lbproc=0] - m01s02i161[lbproc=0] + m01s05i181[lbproc=0] - m01s05i161[lbproc=0]) / ATMOS_TIMESTEP
@@ -3138,9 +3137,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[646]
 
 [ts_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128]
@@ -3149,9 +3148,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[797, 670, 166, 72]
 
 [ts_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s00i024[lbproc=0]
@@ -3160,9 +3159,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[647]
 
 [ts_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s00i024[lbproc=0]
@@ -3171,9 +3170,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[474, 183]
 
 [ua_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s00i002[lbproc=128]
@@ -3182,9 +3181,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[507, 415]
 
 [ua_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128] / m01s30i301[blev=PLEV19, lbproc=128]
@@ -3193,9 +3192,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1836, 73]
 
 [ua_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s30i201[blev=PLEV39, lbproc=192] / m01s30i301[blev=PLEV39, lbproc=192]
@@ -3204,9 +3203,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[822, 444]
 
 [ua_tpt-200hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p200
 expression = m01s30i201[blev=P200, lbproc=0] / m01s30i301[blev=P200, lbproc=0]
@@ -3215,9 +3214,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[185]
 
 [ua_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s00i002[lbproc=0]
@@ -3226,9 +3225,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[648]
 
 [ua_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s00i002[lbproc=0]
@@ -3237,9 +3236,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[150]
 
 [ua_tpt-p3-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev3 time1
 expression = m01s30i201[blev=PLEV3, lbproc=0] / m01s30i301[blev=PLEV3, lbproc=0]
@@ -3248,9 +3247,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[184]
 
 [ua_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i201[blev=PLEV6, lbproc=0] / m01s30i301[blev=PLEV6, lbproc=0]
@@ -3259,9 +3258,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[704]
 
 [ua_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0] / m01s30i301[blev=PLEV7H, lbproc=0]
@@ -3270,9 +3269,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[186]
 
 [uas_tavg-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i209[lbproc=128]
@@ -3281,9 +3280,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1837, 167, 74]
 
 [uas_tpt-h10m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height10m
 expression = m01s03i209[lbproc=0]
@@ -3292,9 +3291,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[649]
 
 [uas_tpt-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height10m
 expression = m01s03i209[lbproc=0]
@@ -3303,9 +3302,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[672, 188, 122]
 
 [utendepfd_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = zonal_apply_heaviside(m01s30i314[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -3314,9 +3313,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1072, 823]
 
 [utendnogw_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s06i115[blev=PLEV19, lbproc=128]
@@ -3325,9 +3324,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1045, 802]
 
 [utendnogw_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
@@ -3336,9 +3335,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1073, 824]
 
 [utendogw_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s06i247[blev=PLEV19, lbproc=128]
@@ -3347,9 +3346,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1046, 803]
 
 [utendogw_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s06i247[blev=PLEV39, lbproc=192]
@@ -3358,9 +3357,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1074, 825]
 
 [va_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s00i003[lbproc=128]
@@ -3369,9 +3368,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[508, 416]
 
 [va_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128] / m01s30i301[blev=PLEV19, lbproc=128]
@@ -3380,9 +3379,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1838, 75]
 
 [va_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s30i202[blev=PLEV39, lbproc=192] / m01s30i301[blev=PLEV39, lbproc=192]
@@ -3391,9 +3390,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[445]
 
 [va_tpt-200hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p200
 expression = m01s30i202[blev=P200, lbproc=0] / m01s30i301[blev=P200, lbproc=0]
@@ -3402,9 +3401,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[190]
 
 [va_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s00i003[lbproc=0]
@@ -3413,9 +3412,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[650]
 
 [va_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s00i003[lbproc=0]
@@ -3424,9 +3423,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[151]
 
 [va_tpt-p3-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev3 time1
 expression = m01s30i202[blev=PLEV3, lbproc=0] / m01s30i301[blev=PLEV3, lbproc=0]
@@ -3435,9 +3434,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[189]
 
 [va_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i202[blev=PLEV6, lbproc=0] / m01s30i301[blev=PLEV6, lbproc=0]
@@ -3446,9 +3445,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[705]
 
 [va_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0] / m01s30i301[blev=PLEV7H, lbproc=0]
@@ -3457,9 +3456,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[191]
 
 [vas_tavg-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i210[lbproc=128]
@@ -3468,9 +3467,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1839, 168, 76]
 
 [vas_tpt-h10m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height10m
 expression = m01s03i210[lbproc=0]
@@ -3479,9 +3478,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[651]
 
 [vas_tpt-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height10m
 expression = m01s03i210[lbproc=0]
@@ -3490,9 +3489,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[674, 193, 123]
 
 [vtem_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = mask_vtem(m01s30i310[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -3501,9 +3500,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1858, 1075]
 
 [wap_tavg-500hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p500
 expression = m01s30i298[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
@@ -3512,9 +3511,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[510]
 
 [wap_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i008[lbproc=128]
@@ -3523,9 +3522,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[509]
 
 [wap_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i298[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -3534,9 +3533,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[77]
 
 [wap_tavg-p19-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i298[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -3545,9 +3544,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[1840]
 
 [wap_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i008[lbproc=0]
@@ -3556,9 +3555,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[652]
 
 [wap_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i298[blev=PLEV6, lbproc=0] / m01s30i304[blev=PLEV6, lbproc=0]
@@ -3567,9 +3566,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[706]
 
 [wsg_tmax-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i463[lbproc=8192]
@@ -3578,9 +3577,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1060, 676]
 
 [wtem_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = mask_polar_column_zonal_means( m01s30i311[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -3589,9 +3588,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1076, 828]
 
 [zg_tavg-1000hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p1000
 expression = m01s30i297[blev=P1000, lbproc=128] / m01s30i304[blev=P1000, lbproc=128]
@@ -3600,9 +3599,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[227, 169]
 
 [zg_tavg-500hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p500
 expression = m01s30i297[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
@@ -3611,9 +3610,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[228]
 
 [zg_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s16i201[lbproc=128]
@@ -3622,9 +3621,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[511, 429]
 
 [zg_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -3633,9 +3632,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1843, 78]
 
 [zg_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s30i297[blev=PLEV39, lbproc=192] / m01s30i304[blev=PLEV39, lbproc=192]
@@ -3644,9 +3643,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[829, 447]
 
 [zg_tpt-500hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p500
 expression = m01s30i297[blev=P500, lbproc=0] / m01s30i304[blev=P500, lbproc=0]
@@ -3655,9 +3654,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[195]
 
 [zg_tpt-700hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p700
 expression = m01s30i297[blev=P700, lbproc=0] / m01s30i304[blev=P700, lbproc=0]
@@ -3666,9 +3665,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[196]
 
 [zg_tpt-925hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p925
 expression = m01s30i297[blev=P925, lbproc=0] / m01s30i304[blev=P925, lbproc=0]
@@ -3677,9 +3676,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[198]
 
 [zg_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s16i201[lbproc=0]
@@ -3688,9 +3687,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[653]
 
 [zg_tpt-p3-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev3 time1
 expression = m01s30i297[blev=PLEV3, lbproc=0] / m01s30i304[blev=PLEV3, lbproc=0]
@@ -3699,9 +3698,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[194]
 
 [zg_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i297[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
@@ -3710,9 +3709,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[197]
 
 [ztp_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i453[lbproc=128] + m01s00i033[lbproc=128]
@@ -3721,3 +3720,4 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[430]

--- a/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_landIce_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_landIce_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the landIce realm
 
 [acabf_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i578[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1233, 1200, 1167]
 
 [hfdsn_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = m01s08i202[lbproc=128]
@@ -25,9 +24,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1235, 726]
 
 [hfls_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i330[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -36,9 +35,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1236]
 
 [hfss_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i290[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -47,9 +46,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1237]
 
 [litemptop_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i576[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -58,9 +57,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1239, 1212, 1179]
 
 [mrfso_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128] * m01s08i230[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
@@ -69,9 +68,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1290]
 
 [mrro_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i583[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1241]
 
 [rlds_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i384[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -91,9 +90,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1246]
 
 [rlus_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i383[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -102,9 +101,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1247]
 
 [sbl_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i331[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1251]
 
 [sbl_tavg-u-hxy-lnd]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i331[lbproc=128], m01s03i317[lbproc=128], land_class='all')
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1250]
 
 [sbl_tpt-u-hs-u]
-comment = 
 component = landIce
 dimension = site time1
 expression = m01s03i298[lbproc=0]
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[628]
 
 [snc_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = snc_calc(m01s08i236[lbproc=128], m01s03i317[lbproc=128], m01s03i395[lbproc=128])
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1862, 1829]
 
 [snd_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i376[lbproc=128], m01s03i317[lbproc=128], land_class='all')
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1256, 780]
 
 [snicem_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i579[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1258]
 
 [snm_tavg-u-hxy-is]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i579[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1260]
 
 [snm_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i237[lbproc=128], m01s03i317[lbproc=128], land_class='all')
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1259, 781]
 
 [snrefr_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i580[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1257]
 
 [snw_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i236[lbproc=128], m01s03i317[lbproc=128], land_class='all')
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1830, 1261]
 
 [tas_tavg-h2m-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time height2m
 expression = land_class_mean(m01s03i328[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -223,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1263]
 
 [ts_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i316[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -234,3 +233,4 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1265]

--- a/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_land_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_land_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the land realm
 
 [evspsblpot_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i334[lbproc=128]
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[878, 721]
 
 [evspsblsoi_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i296[lbproc=128] + m01s03i298[lbproc=128] - m01s03i539[lbproc=128]
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1279]
 
 [evspsblsoi_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s03i296[lbproc=128] + m01s03i298[lbproc=128] - m01s03i539[lbproc=128]) * m01s00i505
@@ -36,9 +35,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[722, 81]
 
 [evspsblveg_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
@@ -47,9 +46,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1280]
 
 [evspsblveg_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128] * m01s00i505
@@ -58,9 +57,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[723, 82]
 
 [hfdsl_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = -1.0 * m01s03i202[lbproc=128]
@@ -69,9 +68,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[87]
 
 [mrro_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128] + m01s08i235[lbproc=128]
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1808, 1291, 93]
 
 [mrrob_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i235[lbproc=128]
@@ -91,9 +90,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[750]
 
 [mrros_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128]
@@ -102,9 +101,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1292, 751, 94]
 
 [mrsfl_tavg-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i230[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[938, 752]
 
 [mrsll_tavg-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i229[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[939, 753]
 
 [mrso_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128])
@@ -135,9 +134,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1809, 1293]
 
 [mrsofc_ti-u-hxy-lnd]
-comment = 
+comment = The factor 3.0 m is the soil depth.
 component = land
 dimension = longitude latitude
 expression = mask_zeros(m01s00i041 * FRESHWATER_DENSITY * 3.0)
@@ -146,9 +146,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1851]
 
 [mrsol_tavg-d100cm-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time sdepth100cm
 expression = m01s08i223[blev=0.05, lbproc=128] + m01s08i223[blev=0.225, lbproc=128] + m01s08i223[blev=0.675, lbproc=128]
@@ -157,9 +157,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[95]
 
 [mrsol_tavg-d10cm-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time sdepth10cm
 expression = m01s08i223[blev=0.05, lbproc=128]
@@ -168,9 +168,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1810, 1294]
 
 [mrsol_tavg-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
@@ -179,9 +179,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[940, 755]
 
 [mrsol_tpt-d10cm-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time1 sdepth10cm
 expression = m01s08i223[blev=0.05, lbproc=0]
@@ -190,9 +190,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[96]
 
 [orog_ti-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude
 expression = m01s00i033
@@ -201,9 +201,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1852]
 
 [rootd_ti-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude
 expression = calc_rootd(m01s00i009, m01s00i216, ice_class='ice')
@@ -212,9 +212,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1853]
 
 [sftgif_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128], land_class='ice')
@@ -223,9 +223,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1253, 1217, 1184]
 
 [sftgif_ti-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude
 expression = land_class_area(m01s00i216, m01s00i505, land_class='ice')
@@ -234,9 +234,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1854]
 
 [sftlaf_ti-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude typelkins
 expression = land_class_area(m01s00i216, m01s00i505, land_class='water')
@@ -245,9 +245,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1856]
 
 [slthick_ti-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth
 expression = calc_slthick(m01s00i009, m01s00i216, ice_class='ice')
@@ -256,9 +256,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[832]
 
 [srfrad_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s02i201[lbproc=128] - m01s01i201[lbproc=128]
@@ -267,9 +267,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[106]
 
 [sweLut_tavg-u-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time
 expression = land_use_tile_mean( m01s08i236[lbproc=128] / FRESHWATER_DENSITY, m01s03i317[lbproc=128])
@@ -278,9 +278,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1019]
 
 [tran_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i539[lbproc=128]
@@ -289,9 +289,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1305]
 
 [tran_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i539[lbproc=128] * m01s00i505
@@ -300,9 +300,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[112]
 
 [tsl_tavg-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
@@ -311,9 +311,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1307, 798]
 
 [wetlandCH4_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i242[lbproc=128] * MOLECULAR_MASS_OF_CH4 / ATOMIC_MASS_OF_C
@@ -322,9 +322,9 @@ positive =
 reviewer = none
 status = embargoed
 units = ug m-2 s-1
+# Issue number(s):[1055]
 
 [wetlandFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typewetla
 expression = m01s08i248[lbproc=128] * m01s03i395[lbproc=128]
@@ -333,9 +333,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1058]
 
 [wtd_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i249[lbproc=128]
@@ -344,3 +344,4 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[808]

--- a/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_ocean_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_ocean_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the ocean realm
 
 [areacello_ti-u-hxy-u]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = areacello
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m2
+# Issue number(s):[1361]
 
 [basin_ti-u-hxy-u]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = basin
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1362]
 
 [bigthetao_tavg-ol-hm-sea]
-comment = 
 component = ocean
 dimension = olevel time
 expression = area_mean(bigthetao, volcello(thkcello, areacello))
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1381]
 
 [bigthetao_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = bigthetao
@@ -47,9 +46,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1380]
 
 [deptho_ti-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = deptho
@@ -58,9 +57,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1363]
 
 [dxto_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e1t
@@ -69,9 +69,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1364]
 
 [dxuo_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e1u
@@ -80,9 +81,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1365]
 
 [dxvo_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e1v
@@ -91,9 +93,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1366]
 
 [dyto_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e2t
@@ -102,9 +105,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1367]
 
 [dyuo_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e2u
@@ -113,9 +117,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1368]
 
 [dyvo_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e2v
@@ -124,9 +129,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1369]
 
 [evspsbl_tavg-u-hxy-ifs]
-comment = 
+comment = This requires the bug fix for `rain_ao_cea` introduced at [NEMO_4.0.4_GOSI9_package_16448_N216_GC5c@16958](https://code.metoffice.gov.uk/trac/nemo/browser/NEMO/branches/UKMO/NEMO_4.0.4_GOSI9_package_16448_N216_GC5c?rev=16958)
 component = ocean
 dimension = longitude latitude time
 expression = correct_evaporation(evs, empmr - (evs - (berg_total_melt + friver + snow_ao_cea + rain_ao_cea - fsitherm) ), areacello)
@@ -135,9 +141,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1417]
 
 [ficeberg_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = -1*fwfisf3d
@@ -146,9 +152,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1430]
 
 [flandice_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = flandice
@@ -157,9 +163,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[916]
 
 [friver_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = friver
@@ -168,9 +174,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1434]
 
 [hfbasin_tavg-u-hyb-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasin[basin=1], hfbasin[basin=2], hfbasin[basin=5], mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -179,9 +186,10 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1442]
 
 [hfbasinpadv_tavg-u-hyb-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpadv[basin=1], hfbasinpadv[basin=2], hfbasinpadv[basin=5], mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -190,9 +198,10 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1443]
 
 [hfbasinpmadv_tavg-u-hyb-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpadv[basin=1], hfbasinpadv[basin=2], hfbasinpadv[basin=5], mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -201,9 +210,10 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1444]
 
 [hfbasinpmdiff_tavg-u-hyb-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpmdiff[basin=1], hfbasinpmdiff[basin=2], hfbasinpmdiff[basin=5], mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -212,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1445]
 
 [hfds_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfds
@@ -223,9 +233,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1447]
 
 [hfevapds_tavg-u-hxy-ifs]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfevapds
@@ -234,9 +244,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1448]
 
 [hfgeou_ti-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = hfgeou
@@ -245,9 +255,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1370]
 
 [hfibthermds_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = qlatisf3d
@@ -256,9 +266,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1450]
 
 [hfrainds_tavg-u-hxy-ifs]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfrainds
@@ -267,9 +277,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1452]
 
 [hfrunoffds_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(hflx_rnf_cea, -1*qhcisf3d)
@@ -278,9 +288,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1453]
 
 [hfsnthermds_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfsnthermds
@@ -289,9 +299,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1456]
 
 [hfx_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfxint
@@ -300,9 +310,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W
+# Issue number(s):[1458, 1318]
 
 [hfy_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfyint
@@ -311,9 +321,10 @@ positive =
 reviewer = none
 status = embargoed
 units = W
+# Issue number(s):[1460, 1319]
 
 [htovgyre_tavg-u-hyb-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(htovgyre[basin=1], htovgyre[basin=2], htovgyre[basin=5], mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V_34S, mask_indpac=indian_pacific_ocean_1D_V_34S)
@@ -322,9 +333,10 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1461]
 
 [htovovrt_tavg-u-hyb-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(htovovrt[basin=1], htovovrt[basin=2], htovovrt[basin=5], mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V_34S, mask_indpac=indian_pacific_ocean_1D_V_34S)
@@ -333,9 +345,9 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1462]
 
 [masscello_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thkcello * SEAWATER_DENSITY
@@ -344,9 +356,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1497]
 
 [masso_tavg-u-hm-sea]
-comment = 
 component = ocean
 dimension = time
 expression = masso
@@ -355,9 +367,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg
+# Issue number(s):[1498]
 
 [mlotst_tavg-u-hxy-sea]
-comment = 
+comment = Note that changes to the NEMO namelist are needed- see comments
 component = ocean
 dimension = longitude latitude time deltasigt
 expression = mlotst
@@ -366,9 +379,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1500, 748]
 
 [mlotst_tmax-u-hxy-sea]
-comment = 
+comment = Note that changes to the NEMO namelist are needed- see comments
 component = ocean
 dimension = longitude latitude time deltasigt
 expression = mlotstmax
@@ -377,9 +391,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1501]
 
 [mlotst_tmin-u-hxy-sea]
-comment = 
+comment = Note that changes to the NEMO namelist are needed- see comments
 component = ocean
 dimension = longitude latitude time deltasigt
 expression = mlotstmin
@@ -388,9 +403,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1502]
 
 [mlotstsq_tavg-u-hxy-sea]
-comment = 
+comment = Note that changes to the NEMO namelist are needed- see comments
 component = ocean
 dimension = longitude latitude time deltasigt
 expression = mlotstsq
@@ -399,9 +415,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m2
+# Issue number(s):[1503]
 
 [msftbarot_tavg-u-hxy-sea]
-comment = 
+comment = `areacello` is a time-invariant variable sourced from CDDS ancillary files
 component = ocean
 dimension = longitude latitude time
 expression = ocean_quasi_barotropic_streamfunc(u_masstr_vint, areacello, cube_mask=mask_2D_T)
@@ -410,9 +427,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1507]
 
 [msfty_tavg-ol-ht-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = gridlatitude olevel basin time
 expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsf[basin=1], zomsf[basin=2], zomsf[basin=5], mask_global=global_ocean_2D_V, mask_atl=atlantic_arctic_ocean_2D_V_34S, mask_indpac=indian_pacific_ocean_2D_V_34S)
@@ -421,9 +439,9 @@ positive =
 reviewer = none
 status = embargoed
 units = sverdrup kg m-3
+# Issue number(s):[1515]
 
 [obvfsq_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = obvfsq
@@ -432,9 +450,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-2
+# Issue number(s):[1524]
 
 [pbo_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = pbo
@@ -443,9 +461,9 @@ positive =
 reviewer = none
 status = embargoed
 units = dbar
+# Issue number(s):[1526]
 
 [sfdsi_tavg-u-hxy-sea]
-comment = 
 component = ocean seaIce
 dimension = longitude latitude time
 expression = sfxice
@@ -454,9 +472,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1552]
 
 [sftof_ti-u-hxy-u]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = sftof
@@ -465,9 +483,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1372]
 
 [sfx_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = sfxint
@@ -476,9 +494,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g s-1
+# Issue number(s):[1555]
 
 [sfy_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = sfyint
@@ -487,9 +505,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g s-1
+# Issue number(s):[1557]
 
 [siflfwbot_tavg-u-hxy-sea]
-comment = 
 component = ocean seaIce
 dimension = longitude latitude time
 expression = fsitherm
@@ -498,9 +516,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1438]
 
 [sltbasin_tavg-u-hyb-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The `1026 *` factor in the XML is no longer needed, as the underlying bug (NEMO diagnostic not multiplied by reference density) has been fixed in GOSI9. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(sltbasin[basin=1], sltbasin[basin=2], sltbasin[basin=5], mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -509,9 +528,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1560]
 
 [sltovgyre_tavg-u-hyb-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The `1026 *` factor in the XML is no longer needed, as the underlying bug (NEMO diagnostic not multiplied by reference density) has been fixed in GOSI9. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(sltovgyre[basin=1], sltovgyre[basin=2], sltovgyre[basin=5], mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V_34S, mask_indpac=indian_pacific_ocean_1D_V_34S)
@@ -520,9 +540,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1561]
 
 [sltovovrt_tavg-u-hyb-sea]
-comment = 
+comment = Basins are already combined over a `basin` axis in GOSI9, but this has an integer value (`Global=1, Atlantic=2, Pacific=3, Indian=4, Indo-Pacific=5`) and not all basins are required. The `1026 *` factor in the XML is no longer needed, as the underlying bug (NEMO diagnostic not multiplied by reference density) has been fixed in GOSI9. The reference latitude is now the closest native grid line passing through 90N, 0E (North Pole).
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(sltovovrt[basin=1], sltovovrt[basin=2], sltovovrt[basin=5], mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V_34S, mask_indpac=indian_pacific_ocean_1D_V_34S)
@@ -531,9 +552,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1562]
 
 [so_tavg-ol-hm-sea]
-comment = 
 component = ocean
 dimension = olevel time
 expression = area_mean(so, volcello(thkcello, areacello))
@@ -542,9 +563,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1565]
 
 [so_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = so
@@ -553,9 +574,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1563, 1337]
 
 [sob_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = sob
@@ -564,9 +585,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1564]
 
 [sos_tavg-u-hm-sea]
-comment = 
 component = ocean
 dimension = time
 expression = area_mean(sos, volcello(thkcello[olevel=0], areacello))
@@ -575,9 +596,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1567]
 
 [sos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = sos
@@ -586,9 +607,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1566, 1338]
 
 [sossq_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = sossq
@@ -597,9 +618,10 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-6
+# Issue number(s):[1568]
 
 [t20d_tavg-u-hxy-sea]
-comment = 
+comment = Calculated from conservative temperature, rather than potential temperature
 component = ocean
 dimension = longitude latitude time
 expression = t20d
@@ -608,9 +630,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1021, 786]
 
 [tauuo_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = mask_copy(tauuo, mask_3D_U[depth<1])
@@ -619,9 +641,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1575]
 
 [tauvo_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = mask_copy(tauvo, mask_3D_V[depth<1])
@@ -630,9 +652,10 @@ positive = down
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1576]
 
 [thetao_tavg-d2000m-hxy-sea]
-comment = 
+comment = This processor will need adjusting to implement the new keyword arguments
 component = ocean
 dimension = longitude latitude time olayer2000m
 expression = level_mean(thetao, thkcello, bottom=2000)
@@ -641,9 +664,10 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1030]
 
 [thetao_tavg-d300m-hxy-sea]
-comment = 
+comment = This processor will need adjusting to implement the new keyword arguments
 component = ocean
 dimension = longitude latitude time olayer300m
 expression = level_mean(thetao, thkcello, bottom=300)
@@ -652,9 +676,10 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1031]
 
 [thetao_tavg-d700m-hxy-sea]
-comment = 
+comment = This processor will need adjusting to implement the new keyword arguments
 component = ocean
 dimension = longitude latitude time olayer700m
 expression = level_mean(thetao, thkcello, bottom=700)
@@ -663,9 +688,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1032]
 
 [thetao_tavg-ol-hm-sea]
-comment = 
 component = ocean
 dimension = olevel time
 expression = area_mean(thetao, volcello(thkcello, areacello))
@@ -674,9 +699,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1578]
 
 [thetao_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thetao
@@ -685,9 +710,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1577]
 
 [thetao_tavg-op20bar-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time op20bar
 expression = thetao[olevel=30]
@@ -696,9 +721,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1339]
 
 [thetaot_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao, thkcello)
@@ -707,9 +732,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1029]
 
 [thkcello_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thkcello
@@ -718,9 +743,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1579]
 
 [thkcelluo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thkcelluo
@@ -729,9 +754,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1580]
 
 [thkcellvo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thkcellvo
@@ -740,9 +765,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1581]
 
 [tos_tavg-u-hm-sea]
-comment = 
 component = ocean
 dimension = time
 expression = area_mean(tos, volcello(thkcello[olevel=0], areacello))
@@ -751,9 +776,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1864]
 
 [tos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = tos
@@ -762,9 +787,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1583, 1340]
 
 [tossq_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = tossq
@@ -773,9 +798,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC2
+# Issue number(s):[1584, 1341]
 
 [umo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = umo
@@ -784,9 +809,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1585]
 
 [uo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = uo
@@ -795,9 +820,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1586]
 
 [uos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = uos
@@ -806,9 +831,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1342]
 
 [vmo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = vmo
@@ -817,9 +842,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1587]
 
 [vo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = vo
@@ -828,9 +853,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1588]
 
 [volcello_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = volcello(thkcello, areacello)
@@ -839,9 +864,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m3
+# Issue number(s):[1652, 1589]
 
 [volo_tavg-u-hm-sea]
-comment = 
 component = ocean
 dimension = time
 expression = volo
@@ -850,9 +875,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m3
+# Issue number(s):[1590]
 
 [vos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = vos
@@ -861,9 +886,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1343]
 
 [wfo_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = wfo
@@ -872,9 +897,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1601]
 
 [wmo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = wmo
@@ -883,9 +908,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1602]
 
 [wo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = wo
@@ -894,9 +919,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1603, 1344]
 
 [zos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = zos
@@ -905,9 +930,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1618, 1348]
 
 [zossq_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = zossq
@@ -916,9 +941,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m2
+# Issue number(s):[1619]
 
 [zostoga_tavg-u-hm-sea]
-comment = 
 component = ocean
 dimension = time
 expression = calc_zostoga(thetao, thkcello, areacello, zfullo_0, so_0, rho_0_mean, deptho_0_mean)
@@ -927,3 +952,4 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1620, 1349]

--- a/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_ocnBgchem_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_ocnBgchem_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the ocnBgchem realm
 
 [fgdms_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = calc_fgdms(m01s00i505, m01s50i214[lbproc=128] / MOLECULAR_MASS_OF_DMS )
@@ -14,3 +13,4 @@ positive = up
 reviewer = none
 status = embargoed
 units = kmol m-2 s-1
+# Issue number(s):[1429]

--- a/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_seaIce_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukcm2/data/UKCM2_seaIce_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the seaIce realm
 
 [evspsbl_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmassevapsubl
@@ -14,9 +13,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1711]
 
 [prsn_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sndmasssnf
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1769]
 
 [rlds_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s02i501[lbproc=128] / m01s00i031[lbproc=128]
@@ -36,9 +35,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1731, 1664]
 
 [rlus_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s03i531[lbproc=128] / m01s00i031[lbproc=128]
@@ -47,9 +46,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1732, 1665]
 
 [rsds_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s01i501[lbproc=128] / m01s00i031[lbproc=128]
@@ -58,9 +57,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1737, 1669]
 
 [rsus_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s01i503[lbproc=128] / m01s00i031[lbproc=128]
@@ -69,9 +68,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1738, 1670]
 
 [sbl_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sndmasssubl
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1770]
 
 [sfdsi_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sfxice
@@ -91,9 +90,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1733]
 
 [siage_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siage * SECONDS_IN_DAY
@@ -102,9 +101,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s
+# Issue number(s):[1698, 1653]
 
 [sicompstren_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sicompstren
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-1
+# Issue number(s):[1704]
 
 [siconc_tavg-u-hxy-u]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siconc/100.
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1705, 1656]
 
 [siconca_tavg-u-hxy-u]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s00i031[lbproc=128]
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1706, 1657]
 
 [sidconcdyn_tavg-u-hxy-sea]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidconcdyn
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1707]
 
 [sidconcth_tavg-u-hxy-sea]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidconcth
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1708]
 
 [sidivvel_tpt-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time1
 expression = sidivvel
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1709]
 
 [sidmassdyn_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmassdyn
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1710]
 
 [sidmassgrowthbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmassgrowthbot
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1712]
 
 [sidmassgrowthsi_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmasssi
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1713]
 
 [sidmassgrowthwat_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmassgrowthwat
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1714]
 
 [sidmassmeltbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmassmeltbot
@@ -223,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1715]
 
 [sidmassmeltlat_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmassmeltlat
@@ -234,9 +233,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1716]
 
 [sidmassmelttop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmassmelttop
@@ -245,9 +244,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1717]
 
 [sidmassth_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmassth
@@ -256,9 +255,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1718]
 
 [sidmasstranx_tavg-u-hxy-u]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmasstranx
@@ -267,9 +266,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1719]
 
 [sidmasstrany_tavg-u-hxy-u]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmasstrany
@@ -278,9 +277,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1720]
 
 [sidragtop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s03i538[lbproc=128] / m01s00i031[lbproc=128]
@@ -289,9 +288,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1722]
 
 [sieqthick_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sivol
@@ -300,9 +299,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1792]
 
 [sifb_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sifb
@@ -311,9 +310,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1725, 1660]
 
 [siflcondbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = hfxcndbot/(siconc/100.)
@@ -322,9 +321,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1726, 1661]
 
 [siflcondtop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = hfxcndtop/(siconc/100.)
@@ -333,9 +332,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1727, 1662]
 
 [siflfwbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = vfxice
@@ -344,9 +343,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1728]
 
 [siflfwdrain_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = vfxsum
@@ -355,9 +354,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1729]
 
 [sifllattop_tavg-u-hxy-si]
-comment = 
+comment = This data has been produced on the ocean grid rather than the atmosphere grid as originally requested.
 component = seaIce
 dimension = longitude latitude time
 expression = -1. * hfxsub / (siconc/100.)
@@ -366,9 +366,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1730, 1663]
 
 [siflsensbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = hfxsensib/(siconc/100.)
@@ -377,9 +377,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1734, 1666]
 
 [siflsenstop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = -1. * m01s03i533[lbproc=128] / m01s00i031[lbproc=128]
@@ -388,9 +388,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1735, 1667]
 
 [siflswdbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = qtr_ice_bot / (siconc/100.)
@@ -399,9 +399,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1736, 1668]
 
 [siforcecoriolx_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(siforcecoriolx, u_coord_reference)
@@ -410,9 +410,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1739]
 
 [siforcecorioly_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(siforcecorioly, v_coord_reference)
@@ -421,9 +421,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1740]
 
 [siforceintstrx_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(sforceintstrx, u_coord_reference)
@@ -432,9 +432,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1741]
 
 [siforceintstry_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(siforceintstry, v_coord_reference)
@@ -443,9 +443,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1742]
 
 [siforcetiltx_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(siforcetiltx, u_coord_reference)
@@ -454,9 +454,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1743]
 
 [siforcetilty_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(siforcetilty, v_coord_reference)
@@ -465,9 +465,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1744]
 
 [sihc_tavg-u-hxy-sea]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sihc
@@ -476,9 +476,9 @@ positive =
 reviewer = none
 status = embargoed
 units = J m-2
+# Issue number(s):[1746, 1671]
 
 [siitdconc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude iceband time
 expression = siitdconc/100.
@@ -487,9 +487,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1747, 1672]
 
 [siitdsnconc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude iceband time
 expression = siitdsnconc/100.
@@ -498,9 +498,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1748, 1673]
 
 [siitdsnthick_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude iceband time
 expression = siitdsnthick
@@ -509,9 +509,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1749, 1674]
 
 [siitdthick_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude iceband time
 expression = siitdthick
@@ -520,9 +520,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1750, 1675]
 
 [simass_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = simass
@@ -531,9 +531,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1751]
 
 [simpconc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time typemp
 expression = siapnd / (siconc/100.)
@@ -542,9 +542,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1753, 1676]
 
 [simpeffconc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time typemp
 expression = siepnd / (siconc/100.)
@@ -553,9 +553,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1754, 1677]
 
 [simprefrozen_tavg-u-hxy-simp]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = simprefrozen * FRESHWATER_DENSITY/ICE_DENSITY
@@ -564,9 +564,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1755, 1678]
 
 [simpthick_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = simpthick
@@ -575,9 +575,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1679]
 
 [simpthick_tavg-u-hxy-simp]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = simpthick
@@ -586,9 +586,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1756]
 
 [sisali_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sisali
@@ -597,9 +597,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1761, 1682]
 
 [sisaltmass_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sisaltmass
@@ -608,9 +608,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1762, 1683]
 
 [sishearvel_tpt-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time1
 expression = sishearvel
@@ -619,9 +619,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1763]
 
 [sisndmassdyn_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sndmassdyn
@@ -630,9 +630,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1766]
 
 [sisndmasssi_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sndmasssi
@@ -641,9 +641,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1768]
 
 [sisnhc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sisnhc
@@ -652,9 +652,9 @@ positive =
 reviewer = none
 status = embargoed
 units = J m-2
+# Issue number(s):[1772, 1684]
 
 [sispeed_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sispeed
@@ -663,9 +663,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1778, 1688]
 
 [sistressave_tpt-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time1
 expression = sistressave
@@ -674,9 +674,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-1
+# Issue number(s):[1779]
 
 [sistressmax_tpt-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time1
 expression = sistressmax
@@ -685,9 +685,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-1
+# Issue number(s):[1780]
 
 [sistrxdtop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(100.*utai_ai/siconc, u_coord_reference)
@@ -696,9 +696,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1781]
 
 [sistrxubot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(100.*utau_oi/siconc, u_coord_reference)
@@ -707,9 +707,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1782]
 
 [sistrydtop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(100.*vtau_ai/siconc, v_coord_reference)
@@ -718,9 +718,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1783]
 
 [sistryubot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(100.*vtau_oi/siconc, v_coord_reference)
@@ -729,9 +729,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1784]
 
 [sitempbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sitempbot
@@ -740,9 +740,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1785, 1689]
 
 [sitempsnic_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sitempsnic
@@ -751,9 +751,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1786, 1690]
 
 [sithick_tavg-u-hxy-si]
-comment = 
 component = seaIce ocean
 dimension = longitude latitude time
 expression = sithick
@@ -762,9 +762,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1788, 1692]
 
 [sitimefrac_tavg-u-hxy-sea]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sitimefrac
@@ -773,9 +773,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1789, 1693]
 
 [siu_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(siu, u_coord_reference)
@@ -784,9 +784,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1790, 1694]
 
 [siv_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = apply_ocean_coordinates(siv, v_coord_reference)
@@ -795,9 +795,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1791, 1695]
 
 [snc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sisnconc / 100.
@@ -806,9 +806,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1765]
 
 [snd_tavg-u-hxy-sn]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sisnthick
@@ -817,9 +817,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1777, 1687]
 
 [snm_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sndmassmelt
@@ -828,9 +828,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1767]
 
 [snw_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sisnmass
@@ -839,9 +839,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1773]
 
 [ts_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s03i535[lbproc=128] / m01s00i031[lbproc=128]
@@ -850,3 +850,4 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1787, 1691]

--- a/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_aerosol_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_aerosol_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the aerosol realm
 
 [abs550aer_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda550nm
 expression = m01s02i240[lbplev=3, lbproc=128] + m01s02i241[lbplev=3, lbproc=128] + m01s02i242[lbplev=3, lbproc=128] + m01s02i243[lbplev=3, lbproc=128] + m01s02i585[lbplev=3, lbproc=128]
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[239]
 
 [abs550dust_tavg-u-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time lambda550nm
 expression = m01s02i585[lbplev=3, lbproc=128]
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[241]
 
 [airmass_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = div_by_area(m01s50i063[lbproc=128])
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[246]
 
 [bry_tavg-p39-hy-air]
-comment = 
 component = aerosol
 dimension = latitude plev39 time
 expression = MOLECULAR_MASS_OF_AIR * ((m01s51i045[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BROMINE) + (m01s51i047[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRCL) + (m01s51i048[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRONO2) + (m01s51i052[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HBR) + (m01s51i053[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HOBR) + (m01s51i994[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRO)) / m01s51i999[blev=PLEV39, lbproc=192]
@@ -47,9 +46,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[431]
 
 [c2h6_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C2H6) * m01s34i014[lbproc=128]
@@ -58,9 +57,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[251]
 
 [c3h6_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i093[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C3H6)
@@ -69,9 +68,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[252]
 
 [c3h8_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_C3H8) * m01s34i018[lbproc=128]
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[253]
 
 [ccldncl_tavg-u-hxy-ccl]
-comment = 
 component = aerosol atmos atmosChem
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128], m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
@@ -91,9 +90,9 @@ positive =
 reviewer = none
 status = embargoed
 units = cm-3
+# Issue number(s):[858, 707]
 
 [cdnc_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s01i241[lbproc=128] / m01s01i223[lbproc=128]
@@ -102,9 +101,9 @@ positive =
 reviewer = none
 status = embargoed
 units = cm-3
+# Issue number(s):[258]
 
 [ch3coch3_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH3COCH3) * m01s34i022[lbproc=128]
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[260]
 
 [cheaqpso4_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, (m01s38i201[lbproc=128] + m01s38i202[lbproc=128] + m01s38i203[lbproc=128] + m01s38i285[lbproc=128] + m01s38i286[lbproc=128] + m01s38i288[lbproc=128] + m01s38i289[lbproc=128]), areadiv='True')
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[264]
 
 [chegpso4_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s50i150[lbproc=128], areadiv='True')
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[266]
 
 [chepsoa_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet( ATOMIC_MASS_OF_C * CONV_C_ORGM, m01s38i301[lbproc=128] + m01s38i302[lbproc=128] + m01s38i303[lbproc=128] + m01s38i304[lbproc=128] + m01s38i305[lbproc=128], sumlev='True', areadiv='True')
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[270]
 
 [cly_tavg-p39-hy-air]
-comment = 
 component = aerosol
 dimension = latitude plev39 time
 expression = MOLECULAR_MASS_OF_AIR * ((m01s51i041[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CHLORINE) + (m01s51i042[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CLOX) + (2 * m01s51i043[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CL2O2) + (m01s51i044[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_OCLO) + (m01s51i047[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRCL) + (m01s51i051[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HOCL) + (m01s51i054[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CLONO2) + (m01s51i992[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HCL)) / m01s51i999[blev=PLEV39, lbproc=192]
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[433]
 
 [co_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO) * m01s34i010[lbproc=128]
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[272]
 
 [co_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO) * remove_altitude_coords(m01s34i010[lblev=1, lbproc=128])
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[199]
 
 [cod_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s02i332[lbproc=128] / m01s02i334[lbproc=128]
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[274, 200]
 
 [conccn_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s38i504[lbproc=128]+m01s38i505[lbproc=128]+m01s38i506[lbproc=128]+m01s38i507[lbproc=128]+m01s38i508[lbproc=128]
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-3
+# Issue number(s):[275]
 
 [conccn_tpt-u-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1
 expression = m01s38i504[lbproc=0]+m01s38i505[lbproc=0]+m01s38i506[lbproc=0]+m01s38i507[lbproc=0]+m01s38i508[lbproc=0]
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-3
+# Issue number(s):[691]
 
 [depdust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s03i440[lbproc=128]
@@ -223,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[875]
 
 [drybc_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C, m01s38i220[lbproc=128] + m01s38i221[lbproc=128] + m01s38i222[lbproc=128] + m01s38i223[lbproc=128], sumlev='True', areadiv='True')
@@ -234,9 +233,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[278]
 
 [drydust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s03i441[lbproc=128] + m01s03i442[lbproc=128] + m01s03i443[lbproc=128] + m01s03i444[lbproc=128] + m01s03i445[lbproc=128] + m01s03i446[lbproc=128] + m01s03i451[lbproc=128] + m01s03i452[lbproc=128] + m01s03i453[lbproc=128] + m01s03i454[lbproc=128] + m01s03i455[lbproc=128] + m01s03i456[lbproc=128]
@@ -245,9 +244,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[279]
 
 [dryo3_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_O3, m01s50i131[lbproc=128], sumlev='True', areadiv='True')
@@ -256,9 +255,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[286]
 
 [dryoa_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C * CONV_C_ORGM, m01s38i224[lbproc=128] + m01s38i225[lbproc=128] + m01s38i226[lbproc=128] + m01s38i227[lbproc=128] + m01s38i228[lbproc=128], sumlev='True', areadiv='True')
@@ -267,9 +266,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[287]
 
 [dryso2_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO2, m01s50i154[lbproc=128], sumlev='True', areadiv='True')
@@ -278,9 +277,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[288]
 
 [dryso4_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s38i214[lbproc=128] + m01s38i215[lbproc=128] + m01s38i216[lbproc=128] + m01s38i217[lbproc=128], sumlev='True', areadiv='True')
@@ -289,9 +288,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[289]
 
 [dryss_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL, m01s38i218[lbproc=128] + m01s38i219[lbproc=128], sumlev='True', areadiv='True')
@@ -300,9 +299,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[290]
 
 [ec550aer_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time lambda550nm
 expression = m01s02i530[lbplev=3, lbproc=128] + m01s02i540[lbplev=3, lbproc=128]
@@ -311,9 +310,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-1
+# Issue number(s):[877]
 
 [ec550aer_tpt-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time1 lambda550nm
 expression = m01s02i530[lbplev=3, lbproc=0] + m01s02i540[lbplev=3, lbproc=0]
@@ -322,9 +321,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-1
+# Issue number(s):[146]
 
 [emibc_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C, m01s38i207[lbproc=128], sumlev='True', areadiv='True')
@@ -333,9 +332,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[306]
 
 [emibvoc_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = (m01s03i495[lbproc=128] + m01s03i496[lbproc=128]) * m01s00i505
@@ -344,9 +343,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[307]
 
 [emico_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s50i158[lbproc=128]
@@ -355,9 +354,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[316]
 
 [emidms_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s50i214[lbproc=128]
@@ -366,9 +365,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[317]
 
 [emidust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s03i401[lbproc=128] + m01s03i402[lbproc=128] + m01s03i403[lbproc=128] + m01s03i404[lbproc=128] + m01s03i405[lbproc=128] + m01s03i406[lbproc=128]
@@ -377,9 +376,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[318]
 
 [emiisop_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = (MOLECULAR_MASS_OF_ISOPRENE / (5.0 * ATOMIC_MASS_OF_C)) * (m01s03i495[lbproc=128] * m01s00i505)
@@ -388,9 +387,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[320]
 
 [eminh3_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s50i213[lbproc=128]
@@ -399,9 +398,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[323]
 
 [eminox_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(1.0, m01s50i172[lbproc=128], cube2d=m01s50i156[lbproc=128], sumlev='True')
@@ -410,9 +409,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[324]
 
 [emioa_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet( ATOMIC_MASS_OF_C * CONV_C_ORGM, m01s38i208[lbproc=128] + m01s38i209[lbproc=128] + m01s38i301[lbproc=128] + m01s38i302[lbproc=128] + m01s38i303[lbproc=128] + m01s38i304[lbproc=128] + m01s38i305[lbproc=128], sumlev='True', areadiv='True')
@@ -421,9 +420,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[325]
 
 [emiso2_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(1.0, m01s50i217[lbproc=128], cube2d=(m01s50i215[lbproc=128] + m01s50i216[lbproc=128]), sumlev='True')
@@ -432,9 +431,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[326]
 
 [emiso4_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s38i201[lbproc=128] + m01s38i202[lbproc=128] + m01s38i203[lbproc=128], sumlev='True', areadiv='True')
@@ -443,9 +442,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[327]
 
 [emiss_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL, m01s38i204[lbproc=128] + m01s38i205[lbproc=128], sumlev='True', areadiv='True')
@@ -454,9 +453,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[328]
 
 [emivoc_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = ((m01s50i159[lbproc=128] / MOLECULAR_MASS_OF_HCHO) + (m01s50i160[lbproc=128] * (2.0 / MOLECULAR_MASS_OF_C2H6)) + (m01s50i161[lbproc=128] * (3.0 / MOLECULAR_MASS_OF_C3H8)) + (m01s50i162[lbproc=128] * (3.0 / MOLECULAR_MASS_OF_ME2CO)) + (m01s50i163[lbproc=128] * (2.0 / MOLECULAR_MASS_OF_MECHO)) + (m01s50i212[lbproc=128] / MOLECULAR_MASS_OF_MEOH) + (m01s50i300[lbproc=128] * (5.0 / MOLECULAR_MASS_OF_ISOPRENE)) + (m01s50i301[lbproc=128] * (10.0 / MOLECULAR_MASS_OF_MONOTERPENE))) * ATOMIC_MASS_OF_C
@@ -465,9 +464,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[329]
 
 [h2o_tavg-al-hxy-u]
-comment = 
+comment = This includes water vapour, and the prognostic liquid and ice cloud condensate (qcl + qcf) and rain (qrain) from the large-scale cloud scheme. However, it does not include condensate or precipitation asssociated with the convection scheme.
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s16i207[lbproc=128]+m01s00i272[lbproc=128]
@@ -476,9 +476,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[332]
 
 [hcho_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCHO) * m01s34i011[lbproc=128]
@@ -487,9 +487,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[335]
 
 [hcl_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL) * m01s34i992[lbproc=128]
@@ -498,9 +498,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[336]
 
 [hcl_tavg-p39-hy-air]
-comment = 
 component = aerosol
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HCL) * m01s51i992[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
@@ -509,9 +509,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[435]
 
 [hno3_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3) * m01s34i007[lbproc=128]
@@ -520,9 +520,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[339]
 
 [hno3_tavg-p39-hy-air]
-comment = 
 component = aerosol
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HNO3) * m01s51i007[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
@@ -531,9 +531,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[436]
 
 [ho2_tavg-p39-hy-air]
-comment = 
 component = aerosol
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_HO2) * m01s51i082[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
@@ -542,9 +542,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[437]
 
 [isop_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_ISOPRENE) * m01s34i027[lbproc=128]
@@ -553,9 +553,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[340]
 
 [jno2_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s50i229[lbproc=128]
@@ -564,9 +564,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[341]
 
 [lossch4_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s50i247[lbproc=128] / m01s50i255[lbproc=128]
@@ -575,9 +575,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol m-3 s-1
+# Issue number(s):[342]
 
 [lossco_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s50i071[lbproc=128] / m01s50i255[lbproc=128]
@@ -586,9 +586,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol m-3 s-1
+# Issue number(s):[343]
 
 [lwp_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128]
@@ -597,9 +597,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[345]
 
 [mmraerh2o_tavg-al-hxy-u]
-comment = 
+comment = SECONDS_IN_HOUR / ATMOS_TIMESTEP factor is no longer needed - this was due to a bug in the diagnostic that was fixed by https://code.metoffice.gov.uk/trac/um/ticket/4909
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s38i545[lbproc=128]
@@ -608,9 +609,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[347]
 
 [mmraerh2o_tavg-h2m-hxy-u]
-comment = 
+comment = SECONDS_IN_HOUR / ATMOS_TIMESTEP factor is no longer needed - this was due to a bug in the diagnostic that was fixed by https://code.metoffice.gov.uk/trac/um/ticket/4909
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s38i545[lblev=1, lbproc=128])
@@ -619,9 +621,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[206]
 
 [mmraerh2o_tpt-h2m-hs-u]
-comment = 
+comment = SECONDS_IN_HOUR / ATMOS_TIMESTEP factor is no longer needed - this was due to a bug in the diagnostic that was fixed by https://code.metoffice.gov.uk/trac/um/ticket/4909
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s38i545[lbproc=0]
@@ -630,9 +633,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[694]
 
 [mmrbc_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s34i105[lbproc=128] + m01s34i109[lbproc=128] + m01s34i115[lbproc=128] + m01s34i120[lbproc=128]
@@ -641,9 +644,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[348]
 
 [mmrbc_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s34i105[lblev=1, lbproc=128] + m01s34i109[lblev=1, lbproc=128] + m01s34i115[lblev=1, lbproc=128] + m01s34i120[lblev=1, lbproc=128])
@@ -652,9 +655,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[207]
 
 [mmrbc_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s34i105[lbproc=0] + m01s34i109[lbproc=0] + m01s34i115[lbproc=0] + m01s34i120[lbproc=0]
@@ -663,9 +666,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[695]
 
 [mmrdust_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s00i431[lbproc=128] + m01s00i432[lbproc=128] + m01s00i433[lbproc=128] + m01s00i434[lbproc=128] + m01s00i435[lbproc=128] + m01s00i436[lbproc=128]
@@ -674,9 +677,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[349]
 
 [mmrdust_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s00i431[lblev=1, lbproc=128] + m01s00i432[lblev=1, lbproc=128] + m01s00i433[lblev=1, lbproc=128] + m01s00i434[lblev=1, lbproc=128] + m01s00i435[lblev=1, lbproc=128] + m01s00i436[lblev=1, lbproc=128])
@@ -685,9 +688,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[208]
 
 [mmrdust_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s00i431[lbproc=0] + m01s00i432[lbproc=0] + m01s00i433[lbproc=0] + m01s00i434[lbproc=0] + m01s00i435[lbproc=0] + m01s00i436[lbproc=0]
@@ -696,9 +699,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[696]
 
 [mmroa_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s34i106[lbproc=128] + m01s34i110[lbproc=128] + m01s34i116[lbproc=128] + m01s34i121[lbproc=128] + m01s34i126[lbproc=128]
@@ -707,9 +710,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[352]
 
 [mmroa_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s34i106[lblev=1, lbproc=128] + m01s34i110[lblev=1, lbproc=128] + m01s34i116[lblev=1, lbproc=128] + m01s34i121[lblev=1, lbproc=128] + m01s34i126[lblev=1, lbproc=128])
@@ -718,9 +721,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[211]
 
 [mmroa_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s34i106[lbproc=0] + m01s34i110[lbproc=0] + m01s34i116[lbproc=0] + m01s34i121[lbproc=0]
@@ -729,9 +732,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[699]
 
 [mmrpm2p5_tavg-al-hxy-u]
-comment = 
+comment = Dust MMRs are added on separately since the dust scheme is separate to the aerosol scheme used for PM calculation. The first three dust bins and a fraction (PM2PT5_DUST_BIN4_FRACTION=0.194) of the 4th range up to 2.5um in diameter and are used here. Model outputs PM in ug/m3 and so we need to divide by the air density to get ug/kg. However, this lead to inaccuracies since we have use the daily mean air density rather than the instantaneous value.
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (m01s38i561[lbproc=128] / m01s15i271[lbproc=128])*KG_PER_MICROGRAM + m01s00i431[lbproc=128] + m01s00i432[lbproc=128] + m01s00i433[lbproc=128] + m01s00i434[lbproc=128]*PM2PT5_DUST_BIN4_FRACTION
@@ -740,9 +744,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[355]
 
 [mmrso4_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4) * (m01s34i102[lbproc=128] + m01s34i104[lbproc=128] + m01s34i108[lbproc=128] + m01s34i114[lbproc=128])
@@ -751,9 +755,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[356]
 
 [mmrso4_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4) * replace_altitude_with_height2m(m01s34i102[lblev=1, lbproc=128] + m01s34i104[lblev=1, lbproc=128] + m01s34i108[lblev=1, lbproc=128] + m01s34i114[lblev=1, lbproc=128])
@@ -762,9 +766,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[212]
 
 [mmrso4_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4) * (m01s34i102[lbproc=0] + m01s34i104[lbproc=0] + m01s34i108[lbproc=0] + m01s34i114[lbproc=0])
@@ -773,9 +777,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[700]
 
 [mmrss_tavg-al-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude alevel time
 expression = m01s34i111[lbproc=128] + m01s34i117[lbproc=128]
@@ -784,9 +788,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[358]
 
 [mmrss_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s34i111[lblev=1, lbproc=128] + m01s34i117[lblev=1, lbproc=128])
@@ -795,9 +799,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[214]
 
 [mmrss_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = m01s34i111[lbproc=0] + m01s34i117[lbproc=0]
@@ -806,9 +810,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[701]
 
 [no2_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2) * m01s34i996[lbproc=128]
@@ -817,9 +821,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[362]
 
 [no2_tavg-h2m-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time height2m
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO2) * m01s34i996[lblev=1, lbproc=128]
@@ -828,9 +832,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[233]
 
 [no_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_NO) * m01s34i002[lbproc=128]
@@ -839,9 +843,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[361]
 
 [noy_tavg-p39-hy-air]
-comment = 
 component = aerosol
 dimension = latitude plev39 time
 expression = MOLECULAR_MASS_OF_AIR * ((m01s51i002[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO) + (m01s51i003[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO3) + (2 * m01s51i005[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_N2O5) + (m01s51i006[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HO2NO2) + (m01s51i007[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HNO3) + (m01s51i013[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_HONO) + (m01s51i025[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_MEONO2) + (m01s51i048[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_BRONO2) + (m01s51i054[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_CLONO2) + (m01s51i058[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NITROGEN) + (m01s51i996[blev=PLEV39, lbproc=192] / MOLECULAR_MASS_OF_NO2)) / m01s51i999[blev=PLEV39, lbproc=192]
@@ -850,9 +854,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[440]
 
 [o3_tavg-h2m-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time height2m
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s34i001[lblev=1, lbproc=128]
@@ -861,9 +865,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[234]
 
 [o3_tmax-h2m-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time height2m
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s34i001[lblev=1, lbproc=8192]
@@ -872,9 +876,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[216]
 
 [o3loss_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (m01s50i011[lbproc=128] + m01s50i013[lbproc=128] + m01s50i014[lbproc=128] + m01s50i015[lbproc=128]) / m01s50i255[lbproc=128]
@@ -883,9 +887,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol m-3 s-1
+# Issue number(s):[365]
 
 [o3prod_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (m01s50i001[lbproc=128] + m01s50i003[lbproc=128] + m01s50i103[lbproc=128]) / m01s50i255[lbproc=128]
@@ -894,9 +898,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol m-3 s-1
+# Issue number(s):[366]
 
 [od550aer_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda550nm
 expression = m01s02i285[lbplev=3, lbproc=128] + m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128] + m01s02i302[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
@@ -905,9 +909,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[369, 215]
 
 [od550dust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda550nm
 expression = m01s02i285[lbplev=3, lbproc=128]
@@ -916,9 +920,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[374]
 
 [od550lt1aer_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda550nm
 expression = m01s02i300[lbplev=3, lbproc=128] + m01s02i301[lbplev=3, lbproc=128] + m01s02i303[lbplev=3, lbproc=128]
@@ -927,9 +931,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[375]
 
 [od865aer_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time lambda865nm
 expression = m01s02i285[lbplev=5, lbproc=128] + m01s02i300[lbplev=5, lbproc=128] + m01s02i301[lbplev=5, lbproc=128] + m01s02i302[lbplev=5, lbproc=128] + m01s02i303[lbplev=5, lbproc=128]
@@ -938,9 +942,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[381]
 
 [oh_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH) * m01s34i081[lbproc=128]
@@ -949,9 +953,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[382]
 
 [oh_tavg-p39-hy-air]
-comment = 
 component = aerosol
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_OH) * m01s51i081[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
@@ -960,9 +964,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[442]
 
 [pan_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_PAN) * m01s34i017[lbproc=128]
@@ -971,9 +975,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[383]
 
 [photo1d_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s50i228[lbproc=128]
@@ -982,9 +986,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[386]
 
 [reffclwtop_tavg-u-hxy-cl]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s01i245[lbproc=128] / m01s01i246[lbproc=128]
@@ -993,9 +997,9 @@ positive =
 reviewer = none
 status = embargoed
 units = um
+# Issue number(s):[389]
 
 [rldaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = correct_multilevel_metadata(m01s02i518[llbproc=128])
@@ -1004,9 +1008,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = MISSING_MODEL_UNITS
+# Issue number(s):[1880]
 
 [rldcsaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = correct_multilevel_metadata(m01s02i520[llbproc=128])
@@ -1015,9 +1019,10 @@ positive = up
 reviewer = none
 status = embargoed
 units = MISSING_MODEL_UNITS
+# Issue number(s):[1881]
 
 [rluscsaf_tavg-u-hxy-u]
-comment = 
+comment = Ticket https://code.metoffice.gov.uk/trac/UKESM/ticket/172 explains why the TOA correction for the changes in surface temperature due to the boundary layer scheme between radiation time steps can be used for the surface LW upwards flux here. This was confirmed by Alejandro Bodas-Salcedo by email.
 component = aerosol
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i519[lblev=1, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1026,9 +1031,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[390]
 
 [rlutaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i517[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1037,9 +1042,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[391]
 
 [rlutcsaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i519[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1048,9 +1053,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[393]
 
 [rsdaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = correct_multilevel_metadata(m01s01i518[llbproc=128])
@@ -1059,9 +1064,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = MISSING_MODEL_UNITS
+# Issue number(s):[1882]
 
 [rsdcsaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = correct_multilevel_metadata(m01s01i520[llbproc=128])
@@ -1070,9 +1075,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = MISSING_MODEL_UNITS
+# Issue number(s):[1883]
 
 [rsutaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s01i517[lblev=86, lbproc=128]
@@ -1081,9 +1086,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[397]
 
 [rsutcsaf_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s01i519[lblev=86, lbproc=128]
@@ -1092,9 +1097,10 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[399]
 
 [sfpm10_tavg-al-hxy-u]
-comment = 
+comment = Dust MMRs are added on separately since the dust scheme is separate to the aerosol scheme used for PM calculation. The first four dust bins and a fraction (PM10_DUST_BIN5_FRACTION=0.398) of the 5th range up to 10um in diameter and are used here. Model outputs PM in ug/m3 and so we need to divide by the air density to get ug/kg. However, this lead to inaccuracies since we have use the daily mean air density rather than the instantaneous value.
 component = aerosol
 dimension = longitude latitude alevel time
 expression = (m01s38i560[lbproc=128] / m01s15i271[lbproc=128])*KG_PER_MICROGRAM + m01s00i431[lbproc=128] + m01s00i432[lbproc=128] + m01s00i433[lbproc=128] + m01s00i434[lbproc=128] + m01s00i435[lbproc=128]*PM10_DUST_BIN5_FRACTION
@@ -1103,9 +1109,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[354]
 
 [sfpm10_tavg-h2m-hxy-u]
-comment = 
+comment = Dust MMRs are added on separately since the dust scheme is separate to the aerosol scheme used for PM calculation. The first four dust bins and a fraction (PM10_DUST_BIN5_FRACTION=0.398) of the 5th range up to 10um in diameter and are used here. Model outputs PM in ug/m3 and so we need to divide by the air density to get ug/kg. However, this lead to inaccuracies since we have use the daily mean air density rather than the instantaneous value.
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = (replace_altitude_with_height2m(m01s38i560[lblev=1, lbproc=128]) / replace_altitude_with_height2m(m01s15i271[lblev=1, lbproc=128]))*KG_PER_MICROGRAM + replace_altitude_with_height2m(m01s00i431[lblev=1, lbproc=128] + m01s00i432[lblev=1, lbproc=128] + m01s00i433[lblev=1, lbproc=128] + m01s00i434[lblev=1, lbproc=128] + m01s00i435[lblev=1, lbproc=128]*PM10_DUST_BIN5_FRACTION)
@@ -1114,9 +1121,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[236, 218]
 
 [sfpm25_tavg-h2m-hxy-u]
-comment = 
+comment = Dust MMRs are added on separately since the dust scheme is separate to the aerosol scheme used for PM calculation. The first three dust bins and a fraction (PM2PT5_DUST_BIN4_FRACTION=0.194) of the 4th range up to 2.5um in diameter and are used here. Model outputs PM in ug/m3 and so we need to divide by the air density to get ug/kg. However, this lead to inaccuracies since we have use the daily mean air density rather than the instantaneous value.
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = (replace_altitude_with_height2m(m01s38i561[lblev=1, lbproc=128]) / replace_altitude_with_height2m(m01s15i271[lblev=1, lbproc=128]))*KG_PER_MICROGRAM + replace_altitude_with_height2m(m01s00i431[lblev=1, lbproc=128] + m01s00i432[lblev=1, lbproc=128] + m01s00i433[lblev=1, lbproc=128] + m01s00i434[lblev=1, lbproc=128]*PM2PT5_DUST_BIN4_FRACTION)
@@ -1125,9 +1133,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[237, 219]
 
 [so2_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i072[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_SO2)
@@ -1136,9 +1144,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[403]
 
 [so2_tavg-h2m-hxy-u]
-comment = 
 component = aerosol atmosChem
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s34i072[lblev=1, lbproc=128]) * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_SO2)
@@ -1147,9 +1155,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[220]
 
 [so2_tpt-h2m-hs-u]
-comment = 
 component = aerosol atmosChem
 dimension = site time1 height2m
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_SO2) * m01s34i072[lbproc=0]
@@ -1158,9 +1166,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[702]
 
 [tatp_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s30i452[lbproc=128]
@@ -1169,9 +1177,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[405]
 
 [toz_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = DOBSON_UNIT_TO_METRES * m01s50i219[lblev=1, lbproc=128]
@@ -1180,9 +1188,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[408, 221]
 
 [tropoz_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = DOBSON_UNIT_TO_METRES * trop_o3col(m01s34i001[lbproc=128] * m01s50i063[lbproc=128] * m01s50i062[lbproc=128])
@@ -1191,9 +1199,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[413]
 
 [ua_tavg-10hPa-hxy-air]
-comment = 
 component = aerosol
 dimension = longitude latitude time p10
 expression = m01s30i201[blev=P10, lbproc=128] / m01s30i301[blev=P10, lbproc=128]
@@ -1202,9 +1210,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[222]
 
 [wa_tavg-al-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude alevel time
 expression = m01s00i150[lbproc=128]
@@ -1213,9 +1221,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[417]
 
 [wetbc_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C, m01s38i243[lbproc=128] + m01s38i244[lbproc=128] + m01s38i245[lbproc=128] + m01s38i246[lbproc=128] + m01s38i267[lbproc=128] + m01s38i268[lbproc=128] + m01s38i269[lbproc=128] + m01s38i270[lbproc=128], cube2d=(m01s38i906[lbproc=128] + m01s38i912[lbproc=128] + m01s38i921[lbproc=128]), sumlev='True', areadiv='True')
@@ -1224,9 +1232,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[418]
 
 [wetdust_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = m01s04i231[lbproc=128] + m01s04i232[lbproc=128] + m01s04i233[lbproc=128] + m01s04i234[lbproc=128] + m01s04i235[lbproc=128] + m01s04i236[lbproc=128] + m01s05i281[lbproc=128] + m01s05i282[lbproc=128] + m01s05i283[lbproc=128] + m01s05i284[lbproc=128] + m01s05i285[lbproc=128] + m01s05i286[lbproc=128]
@@ -1235,9 +1243,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[419]
 
 [wetoa_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(ATOMIC_MASS_OF_C * CONV_C_ORGM, m01s38i248[lbproc=128] + m01s38i249[lbproc=128] + m01s38i250[lbproc=128] + m01s38i251[lbproc=128] + m01s38i271[lbproc=128] + m01s38i272[lbproc=128] + m01s38i273[lbproc=128] + m01s38i274[lbproc=128] + m01s38i275[lbproc=128], cube2d=(m01s38i907[lbproc=128] + m01s38i913[lbproc=128] + m01s38i922[lbproc=128]), sumlev='True', areadiv='True')
@@ -1246,9 +1254,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[425]
 
 [wetso2_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO2, m01s50i155[lbproc=128], sumlev='True', areadiv='True')
@@ -1257,9 +1265,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[426]
 
 [wetso4_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_SO4, m01s38i238[lbproc=128] + m01s38i239[lbproc=128] + m01s38i240[lbproc=128] + m01s38i261[lbproc=128] + m01s38i262[lbproc=128] + m01s38i263[lbproc=128] + m01s38i264[lbproc=128], cube2d=(m01s38i905[lbproc=128] + m01s38i911[lbproc=128] + m01s38i920[lbproc=128]), sumlev='True', areadiv='True')
@@ -1268,9 +1276,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[427]
 
 [wetss_tavg-u-hxy-u]
-comment = 
 component = aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_NACL, m01s38i241[lbproc=128] + m01s38i242[lbproc=128] + m01s38i265[lbproc=128] + m01s38i266[lbproc=128], cube2d=(m01s38i914[lbproc=128] + m01s38i923[lbproc=128]), sumlev='True', areadiv='True')
@@ -1279,9 +1287,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[428]
 
 [zg_tavg-10hPa-hxy-air]
-comment = 
 component = aerosol
 dimension = longitude latitude time p10
 expression = m01s30i297[blev=P10, lbproc=128] / m01s30i304[blev=P10, lbproc=128]
@@ -1290,3 +1298,4 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[226]

--- a/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_atmosChem_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_atmosChem_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the atmosChem realm
 
 [cfc11_tavg-u-hm-air]
-comment = 
 component = atmosChem
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i055[lbproc=128], MOLECULAR_MASS_OF_CFC11)
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[5]
 
 [cfc12_tavg-u-hm-air]
-comment = 
 component = atmosChem
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i056[lbproc=128], MOLECULAR_MASS_OF_CFC12)
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[6]
 
 [ch3oh_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_METHANOL) * m01s34i090[lbproc=128]
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[261]
 
 [ch4_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4) * m01s34i009[lbproc=128]
@@ -47,9 +46,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[262]
 
 [ch4_tavg-p19-hxy-air]
-comment = 
 component = atmosChem
 dimension = longitude latitude plev19 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4) * m01s51i009[blev=PLEV19, lbproc=128] / m01s51i999[blev=PLEV19, lbproc=128]
@@ -58,9 +57,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[7]
 
 [ch4_tavg-p39-hy-air]
-comment = 
 component = atmosChem aerosol
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CH4) * m01s51i009[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
@@ -69,9 +68,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[432]
 
 [ch4_tavg-u-hm-air]
-comment = 
 component = atmosChem
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i009[lbproc=128], MOLECULAR_MASS_OF_CH4)
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[9]
 
 [ch4losssoil_tavg-u-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_CH4, m01s50i438[lbproc=128], sumlev='True', areadiv='True')
@@ -91,9 +90,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[263]
 
 [chegph2oo1d_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = (2.0 * m01s50i122[lbproc=128] ) / m01s50i255[lbproc=128]
@@ -102,9 +101,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol m-3 s-1
+# Issue number(s):[265]
 
 [dms_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i071[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_DMS)
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[276]
 
 [do3chm_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = (m01s50i001[lbproc=128] + m01s50i003[lbproc=128] + m01s50i103[lbproc=128]) - (m01s50i011[lbproc=128] + m01s50i012[lbproc=128] + m01s50i013[lbproc=128] + m01s50i014[lbproc=128] + m01s50i015[lbproc=128])/ m01s50i255[lbproc=128]
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol m-3 s-1
+# Issue number(s):[277]
 
 [dryhno3_tavg-u-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_HNO3, m01s50i174[lbproc=128], sumlev='True', areadiv='True')
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[281]
 
 [drynoy_tavg-u-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet( MOLECULAR_MASS_OF_NITROGEN, m01s50i242[lbproc=128], sumlev='True', areadiv='True')
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[285, 203]
 
 [emiavnox_tavg-u-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet(1.0, m01s50i217[lbproc=128]*MOLECULAR_MASS_OF_NITROGEN/MOLECULAR_MASS_OF_NO, sumlev='True')
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[296]
 
 [emic2h6_tavg-u-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s50i160[lbproc=128]
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[310]
 
 [emic3h8_tavg-u-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s50i161[lbproc=128]
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[312]
 
 [emich3oh_tavg-u-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s50i212[lbproc=128]
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[314]
 
 [emich4_tavg-u-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s50i427[lbproc=128]
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[315]
 
 [flashrate_tavg-u-hxy-u]
-comment = 
 component = atmosChem
 dimension = longitude latitude time
 expression = div_by_area(m01s50i082[lbproc=128])
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-2 min-1
+# Issue number(s):[917, 724]
 
 [h2_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_H2) * m01s34i070[lbproc=128]
@@ -223,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[330]
 
 [meanage_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = m01s34i150[lbproc=128] * 1.0/(seconds_in_day*days_in_year)
@@ -234,9 +233,9 @@ positive =
 reviewer = none
 status = embargoed
 units = yr
+# Issue number(s):[346]
 
 [meanage_tavg-p39-hy-air]
-comment = 
 component = atmosChem aerosol
 dimension = latitude plev39 time
 expression = (m01s51i150[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -245,9 +244,9 @@ positive =
 reviewer = none
 status = embargoed
 units = yr
+# Issue number(s):[438]
 
 [n2o_tavg-al-hxy-u]
-comment = 
 component = atmosChem
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O) * m01s34i049[lbproc=128]
@@ -256,9 +255,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[359]
 
 [n2o_tavg-p19-hxy-air]
-comment = 
 component = atmosChem
 dimension = longitude latitude plev19 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O) * m01s51i049[blev=PLEV19, lbproc=128] / m01s51i999[blev=PLEV19, lbproc=128]
@@ -267,9 +266,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[34]
 
 [n2o_tavg-p39-hy-air]
-comment = 
 component = atmosChem
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_N2O) * m01s51i049[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
@@ -278,9 +277,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[439]
 
 [n2o_tavg-u-hm-air]
-comment = 
 component = atmosChem
 dimension = time
 expression = mmr2molefrac(m01s50i063[lbproc=128], m01s34i049[lbproc=128], MOLECULAR_MASS_OF_N2O)
@@ -289,9 +288,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[36]
 
 [o3_tavg-al-hxy-u]
-comment = 
 component = atmosChem
 dimension = longitude latitude alevel time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s34i001[lbproc=128]
@@ -300,9 +299,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[363]
 
 [o3_tavg-p19-hxy-air]
-comment = 
 component = atmosChem
 dimension = longitude latitude plev19 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s51i001[blev=PLEV19, lbproc=128] / m01s51i999[blev=PLEV19, lbproc=128]
@@ -311,9 +310,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[38]
 
 [o3_tavg-p39-hy-air]
-comment = 
 component = atmosChem
 dimension = latitude plev39 time
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s51i001[blev=PLEV39, lbproc=192] / m01s51i999[blev=PLEV39, lbproc=192]
@@ -322,9 +321,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[441]
 
 [o3_tpt-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time1
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s34i001[lbproc=128]
@@ -333,9 +332,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[364]
 
 [o3ref_tclm-al-hxy-u]
-comment = 
 component = atmosChem
 dimension = longitude latitude alevel time2
 expression = (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_O3) * m01s00i060[lbproc=128]
@@ -344,9 +343,10 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[231]
 
 [rlutch4ref_tavg-u-hxy-u]
-comment = 
+comment = This is a 3D field in the model, but only need output at top of atmosphere
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s02i521[lblev=86, lbproc=128]
@@ -355,9 +355,10 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[392]
 
 [rlutcsch4ref_tavg-u-hxy-u]
-comment = 
+comment = This is a 3D field in the model, but only need at top of atmosphere
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s02i523[lblev=86, lbproc=128]
@@ -366,9 +367,10 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[394]
 
 [rlutcso3ref_tavg-u-hxy-u]
-comment = 
+comment = This is a 3D field in the model, but only need output at top of atmosphere; Will need processing to correct for possible contamination when methane double radiation call is also active
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s02i419[lblev=86, lbproc=128]
@@ -377,9 +379,10 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[395]
 
 [rluto3ref_tavg-u-hxy-u]
-comment = 
+comment = This is a 3D field in the model, but only need output at top of atmosphere; Will need processing to correct for possible contamination when methane double radiation call is also active
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s02i417[lblev=86, lbproc=128]
@@ -388,9 +391,10 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[396]
 
 [rsutch4ref_tavg-u-hxy-u]
-comment = 
+comment = This field is 3D, but only require output at top of atmosphere
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s01i521[lblev=86, lbproc=128]
@@ -399,9 +403,10 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[398]
 
 [rsutcsch4ref_tavg-u-hxy-u]
-comment = 
+comment = This field is 3D, but only require output at top of atmosphere
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s01i523[lblev=86, lbproc=128]
@@ -410,9 +415,10 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[400]
 
 [rsutcso3ref_tavg-u-hxy-u]
-comment = 
+comment = This field is 3D, but only require output at top of atmosphere; Will need processing to correct for possible contamination when methane double radiation call is also active
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s01i419[lblev=86, lbproc=128]
@@ -421,9 +427,10 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[401]
 
 [rsuto3ref_tavg-u-hxy-u]
-comment = 
+comment = This field is 3D, but only require output at top of atmosphere; Will need processing to correct for possible contamination when methane double radiation call is also active
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = m01s01i417[lblev=86, lbproc=128]
@@ -432,9 +439,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[402]
 
 [tropch4lossoh_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = m01s50i041[lbproc=128] / m01s50i255[lbproc=128]
@@ -443,9 +450,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol m-3 s-1
+# Issue number(s):[410]
 
 [tropdo3chm_tavg-al-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = m01s50i052[lbproc=128] / m01s50i255[lbproc=128]
@@ -454,9 +461,10 @@ positive =
 reviewer = none
 status = embargoed
 units = mol m-3 s-1
+# Issue number(s):[411]
 
 [wethno3_tavg-al-hxy-u]
-comment = 
+comment = Equally, this could be referred to as "MOLECULAR_MASS_OF_HNO3"; Value from ukca model = 63.01
 component = atmosChem aerosol
 dimension = longitude latitude alevel time
 expression = achem_emdrywet(MOLECULAR_MASS_OF_HONO2, m01s50i190[lbproc=128], areadiv='True')
@@ -465,9 +473,9 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[420]
 
 [wetnoy_tavg-u-hxy-u]
-comment = 
 component = atmosChem aerosol
 dimension = longitude latitude time
 expression = achem_emdrywet( MOLECULAR_MASS_OF_NITROGEN, m01s50i241[lbproc=128], sumlev='True', areadiv='True')
@@ -476,3 +484,4 @@ positive =
 reviewer = none
 status = embargoed
 units = g m-2 s-1
+# Issue number(s):[424, 225]

--- a/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_atmos_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_atmos_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the atmos realm
 
 [albisccp_tavg-u-hxy-cl]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = fix_packing_division(m01s02i331[lbproc=128], m01s02i334[lbproc=128])
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[512, 475]
 
 [areacella_ti-u-hxy-u]
-comment = 
 component = atmos land
 dimension = longitude latitude
 expression = areacella(m01s00i505)
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m2
+# Issue number(s):[1844]
 
 [bldep_tavg-u-hxy-u]
-comment = 
 component = atmos aerosol land
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=128]
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[654, 248]
 
 [bldep_tmax-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=8192]
@@ -47,9 +46,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[204]
 
 [bldep_tmin-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i304[lbproc=4096]
@@ -58,9 +57,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[205]
 
 [cfadDbze94_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 dbze time
 expression = m01s02i372[lbproc=128]
@@ -69,9 +68,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[859]
 
 [cfadLidarsr532_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 scatratio time
 expression = m01s02i370[lbproc=128]
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[860]
 
 [ci_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i269[lbproc=128]
@@ -91,9 +90,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[11]
 
 [ci_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i269[lbproc=0]
@@ -102,9 +101,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[578]
 
 [cl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i261[lbproc=128]
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[478, 12]
 
 [cl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i261[lbproc=0]
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[580]
 
 [clc_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i317[lbproc=128]
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[513]
 
 [clcalipso_tavg-220hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p220
 expression = m01s02i346[lbproc=128, blev=P220] / m01s02i323[lbproc=128, blev=P220]
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[515, 480]
 
 [clcalipso_tavg-560hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p560
 expression = m01s02i345[lbproc=128, blev=P560] / m01s02i322[lbproc=128, blev=P560]
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[521, 485]
 
 [clcalipso_tavg-840hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p840
 expression = m01s02i344[lbproc=128, blev=P840] / m01s02i321[lbproc=128, blev=P840]
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[520, 484]
 
 [clcalipso_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 time
 expression = m01s02i371[lbproc=128] / m01s02i325[lbproc=128]
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[514, 479]
 
 [clcalipsoice_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 time
 expression = m01s02i474[lbproc=128] / m01s02i325[lbproc=128]
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[861]
 
 [clcalipsoliq_tavg-h40-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt40 time
 expression = m01s02i473[lbproc=128] / m01s02i325[lbproc=128]
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[862]
 
 [cldncl_tavg-u-hxy-cl]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i298[lbproc=128] / m01s01i299[lbproc=128]
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = cm-3
+# Issue number(s):[864]
 
 [cldnvi_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i280[lbproc=128] / m01s01i281[lbproc=128]
@@ -223,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m-2
+# Issue number(s):[865, 709]
 
 [cli_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i309[lbproc=128]
@@ -234,9 +233,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[481, 13]
 
 [cli_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i309[lbproc=0]
@@ -245,9 +244,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[581]
 
 [clic_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i319[lbproc=128]
@@ -256,9 +255,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[516]
 
 [clic_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i319[lbproc=0]
@@ -267,9 +266,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[448]
 
 [climodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i453[lbproc=128] / m01s02i330[lbproc=128]
@@ -278,9 +277,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[866]
 
 [clis_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i309[lbproc=128] - m01s02i319[lbproc=128]
@@ -289,9 +288,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[517]
 
 [clis_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i309[lbproc=0] - m01s02i319[lbproc=0]
@@ -300,9 +299,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[449]
 
 [clisccp_tavg-p7c-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7c tau time
 expression = divide_by_mask(m01s02i337[blev=PLEV7C, lbproc=128], m01s02i330[lbproc=128])
@@ -311,9 +310,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[518, 482]
 
 [clivi_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i392[lbproc=128]
@@ -322,9 +321,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[682, 483, 14]
 
 [clivi_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i392[lbproc=0]
@@ -333,9 +332,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[582]
 
 [clivi_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i392[lbproc=0]
@@ -344,9 +343,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[450]
 
 [clivic_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i396[lbproc=128]
@@ -355,9 +354,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[710]
 
 [clivimodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i467[lbproc=128] / m01s02i330[lbproc=128]
@@ -366,9 +365,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[519]
 
 [clmisr_tavg-h16-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude alt16 tau time
 expression = fix_clmisr_height(m01s02i360[lbproc=128], m01s02i330[lbproc=128])
@@ -377,9 +376,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[867]
 
 [clmodis_tavg-p7c-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7c tau time
 expression = divide_by_mask(m01s02i450[blev=PLEV7C, lbproc=128], m01s02i330[lbproc=128])
@@ -388,9 +387,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[522]
 
 [cls_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i312[lbproc=128] + m01s02i313[lbproc=128] - m01s02i317[lbproc=128]
@@ -399,9 +398,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[527]
 
 [clt_tavg-u-hxy-lnd]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i204[lbproc=128]
@@ -410,9 +409,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[711]
 
 [clt_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i204[lbproc=128]
@@ -421,9 +420,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1795, 655, 80, 15]
 
 [clt_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i204[lbproc=0]
@@ -432,9 +431,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[583]
 
 [clt_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i204[lbproc=0]
@@ -443,9 +442,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[451]
 
 [cltcalipso_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i347[lbproc=128] / m01s02i324[lbproc=128]
@@ -454,9 +453,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[528, 486]
 
 [cltcalipso_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i347[lbproc=0] / m01s02i324[lbproc=0]
@@ -465,9 +464,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[690]
 
 [cltisccp_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i334[lbproc=128] / m01s02i330[lbproc=128]
@@ -476,9 +475,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[529, 487]
 
 [cltmodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i451[lbproc=128] / m01s02i330[lbproc=128]
@@ -487,9 +486,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[868]
 
 [clw_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i308[lbproc=128]
@@ -498,9 +497,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[488, 16]
 
 [clw_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i308[lbproc=0]
@@ -509,9 +508,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[584]
 
 [clwc_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i318[lbproc=128]
@@ -520,9 +519,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[531]
 
 [clwc_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i318[lbproc=0]
@@ -531,9 +530,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[452]
 
 [clwmodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i452[lbproc=128] / m01s02i330[lbproc=128]
@@ -542,9 +541,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[869]
 
 [clws_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i308[lbproc=128] - m01s02i318[lbproc=128]
@@ -553,9 +552,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[532]
 
 [clws_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i308[lbproc=0] - m01s02i318[lbproc=0]
@@ -564,9 +563,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[453]
 
 [clwvi_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i391[lbproc=128] + m01s02i392[lbproc=128]
@@ -575,9 +574,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[683, 489, 17]
 
 [clwvi_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i391[lbproc=0] + m01s02i392[lbproc=0]
@@ -586,9 +585,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[585]
 
 [clwvi_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i391[lbproc=0]+m01s02i392[lbproc=0]
@@ -597,9 +596,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[454]
 
 [clwvic_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i395[lbproc=128] + m01s02i396[lbproc=128]
@@ -608,9 +607,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[712]
 
 [clwvimodis_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i466[lbproc=128] / m01s02i330[lbproc=128]
@@ -619,9 +618,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[533]
 
 [co23D_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s00i252[lbproc=128]
@@ -630,9 +629,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg kg-1
+# Issue number(s):[871]
 
 [co2_tavg-al-hxy-u]
-comment = 
 component = atmos aerosol
 dimension = longitude latitude alevel time
 expression = m01s00i252[lbproc=128] * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO2)
@@ -641,9 +640,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[273]
 
 [co2_tavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = replace_altitude_with_height2m(m01s00i252[lblev=1, lbproc=128]) * (MOLECULAR_MASS_OF_AIR / MOLECULAR_MASS_OF_CO2)
@@ -652,9 +651,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mol mol-1
+# Issue number(s):[872]
 
 [co2mass_tavg-u-hm-u]
-comment = 
 component = atmos
 dimension = time
 expression = m01s30i465[lbproc=128]
@@ -663,9 +662,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg
+# Issue number(s):[20]
 
 [epfy_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = scale_epflux(m01s30i312[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -674,9 +673,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m3 s-2
+# Issue number(s):[1061, 810]
 
 [epfz_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = scale_epflux(m01s30i313[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -685,9 +684,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = m3 s-2
+# Issue number(s):[1062, 811]
 
 [evspsbl_tavg-u-hxy-lnd]
-comment = 
 component = atmos land
 dimension = longitude latitude time
 expression = m01s03i223[lbproc=128]
@@ -696,9 +695,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[720]
 
 [evspsbl_tavg-u-hxy-u]
-comment = 
 component = atmos land
 dimension = longitude latitude time
 expression = m01s03i223[lbproc=128]
@@ -707,9 +706,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[22]
 
 [evspsbl_tpt-u-hs-u]
-comment = 
 component = atmos land
 dimension = site time1
 expression = m01s03i223[lbproc=0]
@@ -718,9 +717,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[587]
 
 [fco2antt_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s00i251[lbproc=128] * (ATOMIC_MASS_OF_C / MOLECULAR_MASS_OF_CO2) + m01s03i395[lbproc=128] * (mdi_to_zero(m01s19i042[lbtim_ia=240,lbproc=128]) + mdi_to_zero(m01s19i044[lbtim_ia=240,lbproc=128])) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -729,9 +728,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[23]
 
 [fco2fos_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s00i251[lbproc=128] * (ATOMIC_MASS_OF_C / MOLECULAR_MASS_OF_CO2)
@@ -740,9 +739,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[24]
 
 [fco2nat_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = ((mdi_to_zero(m01s03i327[lbproc=128]) - m01s00i251[lbproc=128]) * (ATOMIC_MASS_OF_C / MOLECULAR_MASS_OF_CO2)) - (m01s03i395[lbproc=128, lbtim_ia=6] * (mdi_to_zero(m01s19i042[lbtim_ia=240,lbproc=128]) + mdi_to_zero(m01s19i044[lbtim_ia=240,lbproc=128]))) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -751,9 +750,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[25]
 
 [hfls_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i234[lbproc=128]
@@ -762,9 +761,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1796, 656, 88, 27]
 
 [hfls_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s03i234[lbproc=0]
@@ -773,9 +772,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[592]
 
 [hfss_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i217[lbproc=128]
@@ -784,9 +783,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1797, 657, 90, 28]
 
 [hfss_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s03i217[lbproc=0]
@@ -795,9 +794,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[593]
 
 [hur_tavg-700hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p700
 expression = m01s30i296[blev=P700, lbproc=128] / m01s30i304[blev=P700, lbproc=128]
@@ -806,9 +805,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[491]
 
 [hur_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i113[lbproc=128]
@@ -817,9 +816,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[537, 490]
 
 [hur_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -828,9 +827,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[29]
 
 [hur_tavg-p19-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i296[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -839,9 +838,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1798]
 
 [hur_tpt-100hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p100
 expression = m01s30i296[blev=P100, lbproc=0] / m01s30i304[blev=P100, lbproc=0]
@@ -850,9 +849,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[170]
 
 [hur_tpt-500hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p500
 expression = m01s30i296[blev=P500, lbproc=0] / m01s30i304[blev=P500, lbproc=0]
@@ -861,9 +860,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[171]
 
 [hur_tpt-850hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p850
 expression = m01s30i296[blev=P850, lbproc=0] / m01s30i304[blev=P850, lbproc=0]
@@ -872,9 +871,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[172]
 
 [hur_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i113[lbproc=0]
@@ -883,9 +882,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[594]
 
 [hurs_tavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i245[lbproc=128]
@@ -894,9 +893,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1799, 658, 153, 30]
 
 [hurs_tmax-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i245[lbproc=8192]
@@ -905,9 +904,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1800]
 
 [hurs_tmin-h2m-hxy-crp]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i245[lbproc=4096]
@@ -916,9 +915,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[728]
 
 [hurs_tmin-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i245[lbproc=4096]
@@ -927,9 +926,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1801]
 
 [hurs_tpt-h2m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height2m
 expression = m01s03i245[lbproc=0]
@@ -938,9 +937,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[595]
 
 [hurs_tpt-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height2m
 expression = m01s03i245[lbproc=0]
@@ -949,9 +948,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[457]
 
 [hus_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s00i010[lbproc=128]
@@ -960,9 +959,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[538, 492]
 
 [hus_tavg-p19-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i295[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -971,9 +970,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1802, 31]
 
 [hus_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s00i010[lbproc=0]
@@ -982,9 +981,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[596]
 
 [hus_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s00i010[lbproc=0]
@@ -993,9 +992,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[692, 147]
 
 [hus_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i295[blev=PLEV6, lbproc=0] / m01s30i304[blev=PLEV6, lbproc=0]
@@ -1004,9 +1003,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[693]
 
 [hus_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i295[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
@@ -1015,9 +1014,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[173]
 
 [huss_tavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i237[lbproc=128]
@@ -1026,9 +1025,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1803, 154, 32]
 
 [huss_tpt-h2m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height2m
 expression = m01s03i237[lbproc=0]
@@ -1037,9 +1036,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[597]
 
 [huss_tpt-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height2m
 expression = m01s03i237[lbproc=0]
@@ -1048,9 +1047,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[659, 91]
 
 [intuadse_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = SPECIFIC_HEAT_OF_DRY_AIR * m01s30i425[lbproc=128] + m01s30i422[lbproc=128]
@@ -1059,9 +1058,9 @@ positive =
 reviewer = none
 status = embargoed
 units = J m-1 s-1
+# Issue number(s):[929, 730]
 
 [intuaw_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i462[lbproc=128]
@@ -1070,9 +1069,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-1 s-1
+# Issue number(s):[930, 731]
 
 [intuaw_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s30i462[lbproc=0]
@@ -1081,9 +1080,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-1 s-1
+# Issue number(s):[174]
 
 [intvadse_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = SPECIFIC_HEAT_OF_DRY_AIR * m01s30i426[lbproc=128] + m01s30i423[lbproc=128]
@@ -1092,9 +1091,9 @@ positive =
 reviewer = none
 status = embargoed
 units = J m-1 s-1
+# Issue number(s):[931, 732]
 
 [intvaw_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i463[lbproc=128]
@@ -1103,9 +1102,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-1 s-1
+# Issue number(s):[932, 733]
 
 [intvaw_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s30i463[lbproc=0]
@@ -1114,9 +1113,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-1 s-1
+# Issue number(s):[175]
 
 [loadbc_tavg-u-hxy-u]
-comment = 
+comment = SECONDS_IN_HOUR / ATMOS_TIMESTEP factor is no longer needed - this was due to a bug in the diagnostic that was fixed by https://code.metoffice.gov.uk/trac/um/ticket/4909
 component = atmos
 dimension = longitude latitude time
 expression = m01s38i525[lbproc=128]
@@ -1125,9 +1125,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[738]
 
 [loaddust_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = calc_loaddust(m01s17i257[lbproc=128], m01s50i255[lbproc=128])
@@ -1136,9 +1136,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[739]
 
 [loadoa_tavg-u-hxy-u]
-comment = 
+comment = SECONDS_IN_HOUR / ATMOS_TIMESTEP factor is no longer needed - this was due to a bug in the diagnostic that was fixed by https://code.metoffice.gov.uk/trac/um/ticket/4909
 component = atmos
 dimension = longitude latitude time
 expression = m01s38i531[lbproc=128]
@@ -1147,20 +1148,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
-
-[loadso4_tavg-u-hxy-u]
-comment = 
-component = atmos
-dimension = longitude latitude time
-expression = (MOLECULAR_MASS_OF_SO4 / MOLECULAR_MASS_OF_H2SO4) * m01s38i520[lbproc=128]
-mip_table_id = atmos
-positive = 
-reviewer = none
-status = embargoed
-units = kg m-2
+# Issue number(s):[742]
 
 [loadss_tavg-u-hxy-u]
-comment = 
+comment = SECONDS_IN_HOUR / ATMOS_TIMESTEP factor is no longer needed - this was due to a bug in the diagnostic that was fixed by https://code.metoffice.gov.uk/trac/um/ticket/4909
 component = atmos
 dimension = longitude latitude time
 expression = m01s38i539[lbproc=128]
@@ -1169,9 +1160,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[746]
 
 [mc_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = (m01s05i250[lbproc=128] - m01s05i251[lbproc=128]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
@@ -1180,9 +1171,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[493, 33]
 
 [mc_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = (m01s05i250[lbproc=0] - m01s05i251[lbproc=0]) / ACCELERATION_DUE_TO_EARTH_GRAVITY
@@ -1191,9 +1182,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[598]
 
 [mcd_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = m01s05i251[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
@@ -1202,9 +1193,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[539]
 
 [mcu_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = m01s05i250[lbproc=128] / ACCELERATION_DUE_TO_EARTH_GRAVITY
@@ -1213,9 +1204,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[540]
 
 [parasolRefl_tavg-u-hxy-sea]
-comment = 
 component = atmos
 dimension = longitude latitude sza5 time
 expression = fix_parasol_sza_axis(m01s02i348[lbproc=128])
@@ -1224,9 +1215,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[969, 759]
 
 [pctisccp_tavg-u-hxy-cl]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i333[lbproc=128] / m01s02i334[lbproc=128]
@@ -1235,9 +1226,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[541, 494]
 
 [pfull_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s00i408[lbproc=128]
@@ -1246,9 +1237,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[495, 384]
 
 [pfull_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s00i408[lbproc=0]
@@ -1257,9 +1248,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[599]
 
 [pfull_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s00i408[lbproc=0]
@@ -1268,9 +1259,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[458]
 
 [phalf_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = m01s00i407[lbproc=128]
@@ -1279,9 +1270,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[496, 385]
 
 [phalf_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = m01s00i407[lbproc=0]
@@ -1290,9 +1281,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[600]
 
 [pr_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i216[lbproc=128]
@@ -1301,9 +1292,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1813, 660, 155, 97, 42]
 
 [pr_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i216[lbproc=0]
@@ -1312,9 +1303,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[601]
 
 [pr_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s05i216[lbproc=0]
@@ -1323,9 +1314,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[459, 176]
 
 [prc_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i205[lbproc=128] + m01s05i206[lbproc=128]
@@ -1334,9 +1325,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1814, 43]
 
 [prc_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i205[lbproc=0] + m01s05i206[lbproc=0]
@@ -1345,9 +1336,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[602]
 
 [prra_tavg-u-hxy-lnd]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i214[lbproc=128]
@@ -1356,9 +1347,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[763]
 
 [prra_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i214[lbproc=128]
@@ -1367,9 +1358,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[157, 44]
 
 [prsn_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i215[lbproc=128]
@@ -1378,9 +1369,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1815, 158, 98, 45]
 
 [prsn_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i215[lbproc=0]
@@ -1389,9 +1380,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[603]
 
 [prsnc_tavg-u-hxy-lnd]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i206[lbproc=128]
@@ -1400,9 +1391,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[765]
 
 [prw_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i461[lbproc=128]
@@ -1411,9 +1402,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[767, 684, 46]
 
 [prw_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s30i461[lbproc=0]
@@ -1422,9 +1413,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[604]
 
 [prw_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s30i461[lbproc=0]
@@ -1433,9 +1424,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[460, 177]
 
 [ps_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s00i409[lbproc=128]
@@ -1444,9 +1435,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[497, 232, 159, 47]
 
 [ps_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s00i409[lbproc=0]
@@ -1455,9 +1446,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[605]
 
 [ps_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s00i409[lbproc=0]
@@ -1466,9 +1457,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[661, 148, 99]
 
 [psl_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s16i222[lbproc=128]
@@ -1477,9 +1468,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[1816, 160, 48]
 
 [psl_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s16i222[lbproc=0]
@@ -1488,9 +1479,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[606]
 
 [psl_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s16i222[lbproc=0]
@@ -1499,9 +1490,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[662, 178]
 
 [ptp_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i451[lbproc=128]
@@ -1510,9 +1501,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[388]
 
 [reffcclwtop_tavg-u-hxy-ccl]
-comment = 
 component = atmos atmosChem aerosol
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128], m01s02i395[lbproc=128] + m01s02i396[lbproc=128])
@@ -1521,9 +1512,9 @@ positive =
 reviewer = none
 status = embargoed
 units = um
+# Issue number(s):[987, 770]
 
 [reffclic_tavg-al-hxy-ccl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
@@ -1532,9 +1523,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[989]
 
 [reffclic_tpt-al-hs-ccl]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
@@ -1543,9 +1534,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1077]
 
 [reffclic_tpt-al-hxy-ccl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
@@ -1554,9 +1545,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[461]
 
 [reffclis_tavg-al-hxy-scl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = 0.5 * m01s02i398[lbproc=128] / m01s02i313[lbproc=128]
@@ -1565,9 +1556,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[990]
 
 [reffclis_tpt-al-hs-scl]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
@@ -1576,9 +1567,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1078]
 
 [reffclis_tpt-al-hxy-scl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = 0.5 * m01s02i398[lbproc=0] / m01s02i313[lbproc=0]
@@ -1587,9 +1578,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[462]
 
 [reffclwc_tavg-al-hxy-ccl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
@@ -1598,9 +1589,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[991]
 
 [reffclwc_tpt-al-hs-ccl]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
@@ -1609,9 +1600,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1079]
 
 [reffclwc_tpt-al-hxy-ccl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
@@ -1620,9 +1611,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[463]
 
 [reffclws_tavg-al-hxy-scl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i397[lbproc=128] / m01s02i312[lbproc=128]
@@ -1631,9 +1622,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[992]
 
 [reffclws_tpt-al-hs-scl]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
@@ -1642,9 +1633,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1080]
 
 [reffclws_tpt-al-hxy-scl]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s02i397[lbproc=0] / m01s02i312[lbproc=0]
@@ -1653,9 +1644,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[464]
 
 [reffsclwtop_tavg-u-hxy-scl]
-comment = 
 component = atmos atmosChem aerosol
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i245[lbproc=128] / m01s01i246[lbproc=128], m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128] + m01s02i396[lbproc=128]))
@@ -1664,9 +1655,9 @@ positive =
 reviewer = none
 status = embargoed
 units = um
+# Issue number(s):[993, 771]
 
 [rld4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i522[lbproc=128])
@@ -1675,9 +1666,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[543]
 
 [rld_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i218[lbproc=128])
@@ -1686,9 +1677,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[542]
 
 [rld_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i218[lbproc=0])
@@ -1697,9 +1688,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[607]
 
 [rldcs4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i524[lbproc=128])
@@ -1708,9 +1699,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[545]
 
 [rldcs_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s02i220[lbproc=128])
@@ -1719,9 +1710,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[544]
 
 [rldcs_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i220[lbproc=0])
@@ -1730,9 +1721,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[608]
 
 [rlds_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i207[lbproc=128]
@@ -1741,9 +1732,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1817, 663, 161, 100, 49]
 
 [rlds_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i207[lbproc=0]
@@ -1752,9 +1743,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[609]
 
 [rlds_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i207[lbproc=0]
@@ -1763,9 +1754,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[465]
 
 [rldscs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i208[lbproc=128]
@@ -1774,9 +1765,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[498, 50]
 
 [rldscs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i208[lbproc=0]
@@ -1785,9 +1776,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[610]
 
 [rldscs_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i208[lbproc=0]
@@ -1796,9 +1787,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[466]
 
 [rls_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i201[lbproc=128] - (m01s03i332[lbproc=128] - m01s02i205[lbproc=128])
@@ -1807,9 +1798,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1818, 1002]
 
 [rlu4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i521[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
@@ -1818,9 +1809,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[547]
 
 [rlu_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i217[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
@@ -1829,9 +1820,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[546]
 
 [rlu_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i217[lbproc=0])
@@ -1840,9 +1831,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[611]
 
 [rlucs4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i523[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
@@ -1851,9 +1842,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[549]
 
 [rlucs_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = hotspot(m01s02i219[lbproc=128], m01s03i332[lbproc=128], m01s02i205[lbproc=128])
@@ -1862,9 +1853,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[548]
 
 [rlucs_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s02i219[lbproc=0])
@@ -1873,9 +1864,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[612]
 
 [rlus_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i207[lbproc=128] - m01s02i201[lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1884,9 +1875,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1819, 664, 101, 51]
 
 [rlus_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i207[lbproc=0] - m01s02i201[lbproc=0]
@@ -1895,9 +1886,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[613]
 
 [rluscs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i219[lblev=1, lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128] 
@@ -1906,9 +1897,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1820, 52]
 
 [rlut4co2_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i521[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1917,9 +1908,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[550]
 
 [rlut_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i332[lbproc=128]
@@ -1928,9 +1919,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1821, 685, 53]
 
 [rlut_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s03i332[lbproc=128, lbtim_ia=24])
@@ -1939,9 +1930,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[677]
 
 [rlut_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i205[lbproc=0]
@@ -1950,9 +1941,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[614]
 
 [rlut_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s03i332[lbproc=0]
@@ -1961,9 +1952,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[467]
 
 [rlutcs4co2_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = remove_altitude_coords(m01s02i523[lblev=86, lbproc=128]) + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1972,9 +1963,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[551]
 
 [rlutcs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s02i206[lbproc=128] + m01s03i332[lbproc=128] - m01s02i205[lbproc=128]
@@ -1983,9 +1974,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[686, 499, 54]
 
 [rlutcs_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s02i206[lbproc=128, lbtim_ia=24] + m01s03i332[lbproc=128, lbtim_ia=24] - m01s02i205[lbproc=128, lbtim_ia=24])
@@ -1994,9 +1985,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[678]
 
 [rlutcs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s02i206[lbproc=0]
@@ -2005,9 +1996,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[615]
 
 [rlutcs_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s02i206[lbproc=0]+m01s03i332[lbproc=0]-m01s02i205[lbproc=0]
@@ -2016,9 +2007,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[468]
 
 [rsd4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i522[lbproc=128])
@@ -2027,9 +2018,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[553]
 
 [rsd_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i218[lbproc=128])
@@ -2038,9 +2029,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[552]
 
 [rsd_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i218[lbproc=0])
@@ -2049,9 +2040,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[616]
 
 [rsdcs4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i524[lbproc=128])
@@ -2060,9 +2051,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[555]
 
 [rsdcs_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i220[lbproc=128])
@@ -2071,9 +2062,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[554]
 
 [rsdcs_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i220[lbproc=0])
@@ -2082,9 +2073,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[617]
 
 [rsds_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i235[lbproc=128]
@@ -2093,9 +2084,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1822, 665, 162, 102, 55]
 
 [rsds_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i235[lbproc=0]
@@ -2104,9 +2095,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[618]
 
 [rsds_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s01i235[lbproc=0]
@@ -2115,9 +2106,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[469]
 
 [rsdscs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i210[lbproc=128]
@@ -2126,9 +2117,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[500, 56]
 
 [rsdscs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i210[lbproc=0]
@@ -2137,9 +2128,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[619]
 
 [rsdscs_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s01i210[lbproc=0]
@@ -2148,9 +2139,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[470]
 
 [rsdsdiff_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i216[lbproc=128]
@@ -2159,9 +2150,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[776, 666]
 
 [rsdt_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i207[lbproc=128]
@@ -2170,9 +2161,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[501, 57]
 
 [rsdt_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s01i207[lbproc=128, lbtim_ia=24])
@@ -2181,9 +2172,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[679]
 
 [rsdt_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i207[lbproc=0]
@@ -2192,9 +2183,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[620]
 
 [rss_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i201[lbproc=128]
@@ -2203,9 +2194,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1824, 1008]
 
 [rsu4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i521[lbproc=128])
@@ -2214,9 +2205,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[557]
 
 [rsu_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i217[lbproc=128])
@@ -2225,9 +2216,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[556]
 
 [rsu_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i217[lbproc=0])
@@ -2236,9 +2227,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[621]
 
 [rsucs4co2_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i523[lbproc=128])
@@ -2247,9 +2238,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[559]
 
 [rsucs_tavg-alh-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevhalf time
 expression = correct_multilevel_metadata(m01s01i219[lbproc=128])
@@ -2258,9 +2249,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[558]
 
 [rsucs_tpt-alh-hs-u]
-comment = 
 component = atmos
 dimension = alevhalf site time1
 expression = correct_multilevel_metadata(m01s01i219[lbproc=0])
@@ -2269,9 +2260,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[622]
 
 [rsus_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i235[lbproc=128] - m01s01i201[lbproc=128]
@@ -2280,9 +2271,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1825, 667, 104, 58]
 
 [rsus_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i235[lbproc=0] - m01s01i201[lbproc=0]
@@ -2291,9 +2282,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[623]
 
 [rsuscs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i211[lbproc=128]
@@ -2302,9 +2293,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[502, 59]
 
 [rsuscs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i211[lbproc=0]
@@ -2313,9 +2304,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[624]
 
 [rsut4co2_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i521[lblev=86, lbproc=128]
@@ -2324,9 +2315,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[560]
 
 [rsut_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i208[lbproc=128]
@@ -2335,9 +2326,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[687, 503, 60]
 
 [rsut_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s01i208[lbproc=128, lbtim_ia=24])
@@ -2346,9 +2337,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[680]
 
 [rsut_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i208[lbproc=0]
@@ -2357,9 +2348,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[625]
 
 [rsut_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s01i208[lbproc=0]
@@ -2368,9 +2359,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[471]
 
 [rsutcs4co2_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i523[lblev=86, lbproc=128]
@@ -2379,9 +2370,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[561]
 
 [rsutcs_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i209[lbproc=128]
@@ -2390,9 +2381,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[688, 504, 61]
 
 [rsutcs_tclmdc-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time3
 expression = mean_diurnal_cycle(m01s01i209[lbproc=128, lbtim_ia=24])
@@ -2401,9 +2392,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[681]
 
 [rsutcs_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i209[lbproc=0]
@@ -2412,9 +2403,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[626]
 
 [rsutcs_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s01i209[lbproc=0]
@@ -2423,9 +2414,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[472]
 
 [rtmt_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s01i207[lbproc=128] - m01s01i208[lbproc=128] - m01s03i332[lbproc=128]
@@ -2434,9 +2425,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[62]
 
 [rtmt_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s01i207[lbproc=0] - m01s01i208[lbproc=0] - m01s02i205[lbproc=0]
@@ -2445,9 +2436,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[627]
 
 [rv850_tavg-850hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p850
 expression = m01s30i455[blev=P850, lbproc=128]
@@ -2456,9 +2447,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[163]
 
 [rv850_tpt-850hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p850
 expression = m01s30i455[blev=P850, lbproc=0]
@@ -2467,9 +2458,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[179]
 
 [sci_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s05i270[lbproc=128]
@@ -2478,9 +2469,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[64]
 
 [sci_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s05i270[lbproc=0]
@@ -2489,9 +2480,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[629]
 
 [scldncl_tavg-u-hxy-scl]
-comment = 
 component = atmos atmosChem aerosol
 dimension = longitude latitude time
 expression = mask_using_cube(m01s01i298[lbproc=128] / m01s01i299[lbproc=128], m01s02i391[lbproc=128] + m01s02i392[lbproc=128] - (m01s02i395[lbproc=128] + m01s02i396[lbproc=128]))
@@ -2500,9 +2491,9 @@ positive =
 reviewer = none
 status = embargoed
 units = cm-3
+# Issue number(s):[1014, 779]
 
 [sfcWind_tavg-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i230[lbproc=128]
@@ -2511,9 +2502,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1827, 689, 668, 164, 65]
 
 [sfcWind_tmax-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i230[lbproc=8192]
@@ -2522,9 +2513,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1828]
 
 [sfcWind_tmaxavg-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time4 height10m
 expression = mon_mean_from_day(m01s03i230[lbproc=8192])
@@ -2533,9 +2524,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1015]
 
 [sfcWind_tpt-h10m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height10m
 expression = m01s03i230[lbproc=0]
@@ -2544,9 +2535,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[630]
 
 [sftlf_ti-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude
 expression = m01s00i505
@@ -2555,9 +2546,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1855]
 
 [snwc_tavg-u-hxy-lnd]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i236[lbproc=128], m01s03i317[lbproc=128], land_class='canopy')
@@ -2566,9 +2557,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[784]
 
 [ta_tavg-700hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p700
 expression = m01s30i294[blev=P700, lbproc=128] / m01s30i304[blev=P700, lbproc=128]
@@ -2577,9 +2568,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[506]
 
 [ta_tavg-850hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p850
 expression = m01s30i294[blev=P850, lbproc=128] / m01s30i304[blev=P850, lbproc=128]
@@ -2588,9 +2579,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[788]
 
 [ta_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i111[lbproc=128]
@@ -2599,9 +2590,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[563, 505]
 
 [ta_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i294[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -2610,9 +2601,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1831, 66]
 
 [ta_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s30i294[blev=PLEV39, lbproc=192] / m01s30i304[blev=PLEV39, lbproc=192]
@@ -2621,9 +2612,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[813, 443]
 
 [ta_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i111[lbproc=0]
@@ -2632,9 +2623,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[631]
 
 [ta_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s30i111[lbproc=0]
@@ -2643,9 +2634,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[473, 149]
 
 [ta_tpt-p3-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev3 time1
 expression = m01s30i294[blev=PLEV3, lbproc=0] / m01s30i304[blev=PLEV3, lbproc=0]
@@ -2654,9 +2645,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[180]
 
 [ta_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i294[blev=PLEV6, lbproc=0] / m01s30i304[blev=PLEV6, lbproc=0]
@@ -2665,9 +2656,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[703]
 
 [ta_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i294[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
@@ -2676,9 +2667,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[181]
 
 [tas_tavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i236[lbproc=128]
@@ -2687,9 +2678,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1832, 238, 165, 67]
 
 [tas_tmax-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i236[lbproc=8192]
@@ -2698,9 +2689,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1833]
 
 [tas_tmaxavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time4 height2m
 expression = mon_mean_from_day(m01s03i236[lbproc=8192])
@@ -2709,9 +2700,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[68]
 
 [tas_tmin-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i236[lbproc=4096]
@@ -2720,9 +2711,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1834]
 
 [tas_tminavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time4 height2m
 expression = mon_mean_from_day(m01s03i236[lbproc=4096])
@@ -2731,9 +2722,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[69]
 
 [tas_tpt-h2m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height2m
 expression = m01s03i236[lbproc=0]
@@ -2742,9 +2733,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[632]
 
 [tas_tpt-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height2m
 expression = m01s03i236[lbproc=0]
@@ -2753,9 +2744,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[108]
 
 [tauu_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
@@ -2764,9 +2755,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[791, 70]
 
 [tauu_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s03i460[lbproc=0]
@@ -2775,9 +2766,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[633]
 
 [tauupbl_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i460[lbproc=128]
@@ -2786,9 +2777,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[792]
 
 [tauv_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
@@ -2797,9 +2788,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[793, 71]
 
 [tauv_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s03i461[lbproc=0]
@@ -2808,9 +2799,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[634]
 
 [tauvpbl_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s03i461[lbproc=128]
@@ -2819,9 +2810,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa
+# Issue number(s):[794]
 
 [tdps_tavg-h2m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height2m
 expression = m01s03i250[lbproc=128]
@@ -2830,9 +2821,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1028, 795]
 
 [tnhus_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i182[lbproc=128] / ATMOS_TIMESTEP
@@ -2841,9 +2832,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[564]
 
 [tnhus_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i182[lbproc=0] / ATMOS_TIMESTEP
@@ -2852,9 +2843,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[635]
 
 [tnhusa_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s12i182[lbproc=128] + m01s12i382[lbproc=128]) / ATMOS_TIMESTEP
@@ -2863,9 +2854,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[565]
 
 [tnhusa_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s12i182[lbproc=0] + m01s12i382[lbproc=0]) / ATMOS_TIMESTEP
@@ -2874,9 +2865,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[636]
 
 [tnhusc_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s05i162[lbproc=128] / ATMOS_TIMESTEP
@@ -2885,9 +2876,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[566]
 
 [tnhusc_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s05i162[lbproc=0] / ATMOS_TIMESTEP
@@ -2896,9 +2887,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[637]
 
 [tnhusmp_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128] + m01s35i025[lbproc=128] ) / ATMOS_TIMESTEP + (m01s50i238[lbproc=128] - m01s50i239[lbproc=128])*MOLECULAR_MASS_OF_H2O/m01s50i063[lbproc=128] 
@@ -2907,9 +2898,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[568]
 
 [tnhusmp_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0] + m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0] + m01s04i982[lbproc=0] + m01s05i182[lbproc=0] + m01s16i162[lbproc=0] + m01s16i182[lbproc=0] + m01s35i025[lbproc=0] ) / ATMOS_TIMESTEP + replicate_chem_timeseries_to_match_model_timesteps( (m01s50i238[lbproc=0] - m01s50i239[lbproc=0])*MOLECULAR_MASS_OF_H2O/m01s50i063[lbproc=0] )
@@ -2918,9 +2909,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[639]
 
 [tnhuspbl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s03i190[lbproc=128] / ATMOS_TIMESTEP
@@ -2929,9 +2920,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1033]
 
 [tnhuspbl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s03i190[lbproc=0] / ATMOS_TIMESTEP
@@ -2940,9 +2931,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1081]
 
 [tnhusscp_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] - m01s03i190[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
@@ -2951,9 +2942,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1034]
 
 [tnhusscp_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0] + m01s03i182[lbproc=0] - m01s03i190[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0] + m01s05i182[lbproc=0] - m01s05i162[lbproc=0] + m01s16i162[lbproc=0] + m01s16i182[lbproc=0]) / ATMOS_TIMESTEP
@@ -2962,9 +2953,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1082]
 
 [tnhusscpbl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s01i182[lbproc=128] + m01s02i182[lbproc=128] + m01s03i182[lbproc=128] + m01s04i142[lbproc=128] + m01s04i182[lbproc=128] + m01s05i182[lbproc=128] - m01s05i162[lbproc=128] + m01s16i162[lbproc=128] + m01s16i182[lbproc=128]) / ATMOS_TIMESTEP
@@ -2973,9 +2964,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[569]
 
 [tnhusscpbl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s01i182[lbproc=0] + m01s02i182[lbproc=0] + m01s03i182[lbproc=0] + m01s04i142[lbproc=0] + m01s04i182[lbproc=0] + m01s05i182[lbproc=0] - m01s05i162[lbproc=0] + m01s16i162[lbproc=0] + m01s16i182[lbproc=0]) / ATMOS_TIMESTEP
@@ -2984,9 +2975,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[640]
 
 [tnt_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i181[lbproc=128] / ATMOS_TIMESTEP
@@ -2995,9 +2986,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[570]
 
 [tnt_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i181[lbproc=0] / ATMOS_TIMESTEP
@@ -3006,9 +2997,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[641]
 
 [tnta_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s10i181[lbproc=128] + m01s12i181[lbproc=128] + m01s12i381[lbproc=128]) / ATMOS_TIMESTEP
@@ -3017,9 +3008,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[571]
 
 [tnta_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s10i181[lbproc=0] + m01s12i181[lbproc=0] + m01s12i381[lbproc=0]) / ATMOS_TIMESTEP
@@ -3028,9 +3019,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[642]
 
 [tntc_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s05i161[lbproc=128] / ATMOS_TIMESTEP
@@ -3039,9 +3030,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[572]
 
 [tntc_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s05i161[lbproc=0] / ATMOS_TIMESTEP
@@ -3050,9 +3041,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[643]
 
 [tntmp_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s14i181[lbproc=128] + m01s01i181[lbproc=128] + m01s02i181[lbproc=128] + m01s03i181[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s05i181[lbproc=128] + m01s06i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s35i029[lbproc=128]) / ATMOS_TIMESTEP
@@ -3061,9 +3052,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[573]
 
 [tntmp_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s14i181[lbproc=0]+ m01s01i181[lbproc=0] + m01s02i181[lbproc=0] + m01s03i181[lbproc=0] + m01s04i141[lbproc=0] + m01s04i181[lbproc=0] + m01s05i181[lbproc=0] + m01s06i181[lbproc=0] + m01s16i161[lbproc=0] + m01s16i181[lbproc=0] + m01s35i029[lbproc=0]) / ATMOS_TIMESTEP
@@ -3072,9 +3063,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[644]
 
 [tntpbl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s03i189[lbproc=128] / ATMOS_TIMESTEP
@@ -3083,9 +3074,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1035]
 
 [tntpbl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s03i189[lbproc=0] / ATMOS_TIMESTEP
@@ -3094,9 +3085,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1084]
 
 [tntr_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s01i161[lbproc=128] + m01s02i161[lbproc=128]) / ATMOS_TIMESTEP
@@ -3105,9 +3096,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[574]
 
 [tntr_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s01i161[lbproc=0] + m01s02i161[lbproc=0]) / ATMOS_TIMESTEP
@@ -3116,9 +3107,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[645]
 
 [tntrl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i161[lbproc=128] / ATMOS_TIMESTEP
@@ -3127,9 +3118,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[406]
 
 [tntrl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i161[lbproc=0] / ATMOS_TIMESTEP
@@ -3138,9 +3129,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1085]
 
 [tntrlcs_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s02i233[lbproc=128]
@@ -3149,9 +3140,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1036]
 
 [tntrlcs_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s02i233[lbproc=0]
@@ -3160,9 +3151,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1086]
 
 [tntrs_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s01i161[lbproc=128] / ATMOS_TIMESTEP
@@ -3171,9 +3162,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[407]
 
 [tntrs_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s01i161[lbproc=0] / ATMOS_TIMESTEP
@@ -3182,9 +3173,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1087]
 
 [tntrscs_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s01i233[lbproc=128]
@@ -3193,9 +3184,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1037]
 
 [tntrscs_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s01i233[lbproc=0]
@@ -3204,9 +3195,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1088]
 
 [tntscp_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s03i181[lbproc=128] - m01s03i189[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s01i181[lbproc=128] - m01s01i161[lbproc=128] + m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
@@ -3215,9 +3206,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1038]
 
 [tntscp_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s03i181[lbproc=0] - m01s03i189[lbproc=0] + m01s04i141[lbproc=0] + m01s04i181[lbproc=0] + m01s16i161[lbproc=0] + m01s16i181[lbproc=0] + m01s01i181[lbproc=0] - m01s01i161[lbproc=0] + m01s02i181[lbproc=0] - m01s02i161[lbproc=0] + m01s05i181[lbproc=0] - m01s05i161[lbproc=0]) / ATMOS_TIMESTEP
@@ -3226,9 +3217,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[1089]
 
 [tntscpbl_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = (m01s03i181[lbproc=128] + m01s04i141[lbproc=128] + m01s04i181[lbproc=128] + m01s16i161[lbproc=128] + m01s16i181[lbproc=128] + m01s01i181[lbproc=128] - m01s01i161[lbproc=128] + m01s02i181[lbproc=128] - m01s02i161[lbproc=128] + m01s05i181[lbproc=128] - m01s05i161[lbproc=128]) / ATMOS_TIMESTEP
@@ -3237,9 +3228,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[575]
 
 [tntscpbl_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = (m01s03i181[lbproc=0] + m01s04i141[lbproc=0] + m01s04i181[lbproc=0] + m01s16i161[lbproc=0] + m01s16i181[lbproc=0] + m01s01i181[lbproc=0] - m01s01i161[lbproc=0] + m01s02i181[lbproc=0] - m01s02i161[lbproc=0] + m01s05i181[lbproc=0] - m01s05i161[lbproc=0]) / ATMOS_TIMESTEP
@@ -3248,9 +3239,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K s-1
+# Issue number(s):[646]
 
 [ts_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s00i024[lbproc=128]
@@ -3259,9 +3250,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[797, 670, 166, 72]
 
 [ts_tpt-u-hs-u]
-comment = 
 component = atmos
 dimension = site time1
 expression = m01s00i024[lbproc=0]
@@ -3270,9 +3261,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[647]
 
 [ts_tpt-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1
 expression = m01s00i024[lbproc=0]
@@ -3281,9 +3272,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[474, 183]
 
 [ua_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s00i002[lbproc=128]
@@ -3292,9 +3283,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[507, 415]
 
 [ua_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i201[blev=PLEV19, lbproc=128] / m01s30i301[blev=PLEV19, lbproc=128]
@@ -3303,9 +3294,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1836, 73]
 
 [ua_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s30i201[blev=PLEV39, lbproc=192] / m01s30i301[blev=PLEV39, lbproc=192]
@@ -3314,9 +3305,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[822, 444]
 
 [ua_tpt-200hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p200
 expression = m01s30i201[blev=P200, lbproc=0] / m01s30i301[blev=P200, lbproc=0]
@@ -3325,9 +3316,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[185]
 
 [ua_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s00i002[lbproc=0]
@@ -3336,9 +3327,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[648]
 
 [ua_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s00i002[lbproc=0]
@@ -3347,9 +3338,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[150]
 
 [ua_tpt-p3-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev3 time1
 expression = m01s30i201[blev=PLEV3, lbproc=0] / m01s30i301[blev=PLEV3, lbproc=0]
@@ -3358,9 +3349,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[184]
 
 [ua_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i201[blev=PLEV6, lbproc=0] / m01s30i301[blev=PLEV6, lbproc=0]
@@ -3369,9 +3360,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[704]
 
 [ua_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i201[blev=PLEV7H, lbproc=0] / m01s30i301[blev=PLEV7H, lbproc=0]
@@ -3380,9 +3371,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[186]
 
 [uas_tavg-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i209[lbproc=128]
@@ -3391,9 +3382,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1837, 167, 74]
 
 [uas_tpt-h10m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height10m
 expression = m01s03i209[lbproc=0]
@@ -3402,9 +3393,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[649]
 
 [uas_tpt-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height10m
 expression = m01s03i209[lbproc=0]
@@ -3413,9 +3404,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[672, 188, 122]
 
 [utendepfd_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = zonal_apply_heaviside(m01s30i314[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -3424,9 +3415,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1072, 823]
 
 [utendnogw_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s06i115[blev=PLEV19, lbproc=128]
@@ -3435,9 +3426,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1045, 802]
 
 [utendnogw_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s06i115[blev=PLEV39, lbproc=192]
@@ -3446,9 +3437,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1073, 824]
 
 [utendogw_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s06i247[blev=PLEV19, lbproc=128]
@@ -3457,9 +3448,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1046, 803]
 
 [utendogw_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s06i247[blev=PLEV39, lbproc=192]
@@ -3468,9 +3459,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-2
+# Issue number(s):[1074, 825]
 
 [va_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s00i003[lbproc=128]
@@ -3479,9 +3470,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[508, 416]
 
 [va_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i202[blev=PLEV19, lbproc=128] / m01s30i301[blev=PLEV19, lbproc=128]
@@ -3490,9 +3481,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1838, 75]
 
 [va_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s30i202[blev=PLEV39, lbproc=192] / m01s30i301[blev=PLEV39, lbproc=192]
@@ -3501,9 +3492,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[445]
 
 [va_tpt-200hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p200
 expression = m01s30i202[blev=P200, lbproc=0] / m01s30i301[blev=P200, lbproc=0]
@@ -3512,9 +3503,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[190]
 
 [va_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s00i003[lbproc=0]
@@ -3523,9 +3514,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[650]
 
 [va_tpt-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time1
 expression = m01s00i003[lbproc=0]
@@ -3534,9 +3525,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[151]
 
 [va_tpt-p3-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev3 time1
 expression = m01s30i202[blev=PLEV3, lbproc=0] / m01s30i301[blev=PLEV3, lbproc=0]
@@ -3545,9 +3536,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[189]
 
 [va_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i202[blev=PLEV6, lbproc=0] / m01s30i301[blev=PLEV6, lbproc=0]
@@ -3556,9 +3547,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[705]
 
 [va_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i202[blev=PLEV7H, lbproc=0] / m01s30i301[blev=PLEV7H, lbproc=0]
@@ -3567,9 +3558,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[191]
 
 [vas_tavg-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i210[lbproc=128]
@@ -3578,9 +3569,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1839, 168, 76]
 
 [vas_tpt-h10m-hs-u]
-comment = 
 component = atmos
 dimension = site time1 height10m
 expression = m01s03i210[lbproc=0]
@@ -3589,9 +3580,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[651]
 
 [vas_tpt-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 height10m
 expression = m01s03i210[lbproc=0]
@@ -3600,9 +3591,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[674, 193, 123]
 
 [vtem_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = mask_vtem(m01s30i310[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -3611,9 +3602,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1858, 1075]
 
 [wap_tavg-500hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p500
 expression = m01s30i298[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
@@ -3622,9 +3613,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[510]
 
 [wap_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s30i008[lbproc=128]
@@ -3633,9 +3624,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[509]
 
 [wap_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i298[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -3644,9 +3635,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[77]
 
 [wap_tavg-p19-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i298[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -3655,9 +3646,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[1840]
 
 [wap_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s30i008[lbproc=0]
@@ -3666,9 +3657,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[652]
 
 [wap_tpt-p6-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev6 time1
 expression = m01s30i298[blev=PLEV6, lbproc=0] / m01s30i304[blev=PLEV6, lbproc=0]
@@ -3677,9 +3668,9 @@ positive =
 reviewer = none
 status = embargoed
 units = Pa s-1
+# Issue number(s):[706]
 
 [wsg_tmax-h10m-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time height10m
 expression = m01s03i463[lbproc=8192]
@@ -3688,9 +3679,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1060, 676]
 
 [wtem_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = mask_polar_column_zonal_means( m01s30i311[blev=PLEV39, lbproc=192], m01s30i301[blev=PLEV39, lbproc=192])
@@ -3699,9 +3690,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1076, 828]
 
 [zg_tavg-1000hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p1000
 expression = m01s30i297[blev=P1000, lbproc=128] / m01s30i304[blev=P1000, lbproc=128]
@@ -3710,9 +3701,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[227, 169]
 
 [zg_tavg-500hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time p500
 expression = m01s30i297[blev=P500, lbproc=128] / m01s30i304[blev=P500, lbproc=128]
@@ -3721,9 +3712,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[228]
 
 [zg_tavg-al-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude alevel time
 expression = m01s16i201[lbproc=128]
@@ -3732,9 +3723,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[511, 429]
 
 [zg_tavg-p19-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev19 time
 expression = m01s30i297[blev=PLEV19, lbproc=128] / m01s30i304[blev=PLEV19, lbproc=128]
@@ -3743,9 +3734,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1843, 78]
 
 [zg_tavg-p39-hy-air]
-comment = 
 component = atmos
 dimension = latitude plev39 time
 expression = m01s30i297[blev=PLEV39, lbproc=192] / m01s30i304[blev=PLEV39, lbproc=192]
@@ -3754,9 +3745,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[829, 447]
 
 [zg_tpt-500hPa-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p500
 expression = m01s30i297[blev=P500, lbproc=0] / m01s30i304[blev=P500, lbproc=0]
@@ -3765,9 +3756,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[195]
 
 [zg_tpt-700hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p700
 expression = m01s30i297[blev=P700, lbproc=0] / m01s30i304[blev=P700, lbproc=0]
@@ -3776,9 +3767,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[196]
 
 [zg_tpt-925hPa-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time1 p925
 expression = m01s30i297[blev=P925, lbproc=0] / m01s30i304[blev=P925, lbproc=0]
@@ -3787,9 +3778,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[198]
 
 [zg_tpt-al-hs-u]
-comment = 
 component = atmos
 dimension = alevel site time1
 expression = m01s16i201[lbproc=0]
@@ -3798,9 +3789,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[653]
 
 [zg_tpt-p3-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev3 time1
 expression = m01s30i297[blev=PLEV3, lbproc=0] / m01s30i304[blev=PLEV3, lbproc=0]
@@ -3809,9 +3800,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[194]
 
 [zg_tpt-p7h-hxy-air]
-comment = 
 component = atmos
 dimension = longitude latitude plev7h time1
 expression = m01s30i297[blev=PLEV7H, lbproc=0] / m01s30i304[blev=PLEV7H, lbproc=0]
@@ -3820,9 +3811,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[197]
 
 [ztp_tavg-u-hxy-u]
-comment = 
 component = atmos
 dimension = longitude latitude time
 expression = m01s30i453[lbproc=128] + m01s00i033[lbproc=128]
@@ -3831,3 +3822,4 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[430]

--- a/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_landIce_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_landIce_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the landIce realm
 
 [acabf_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i578[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1233, 1200, 1167]
 
 [hfdsn_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = m01s08i202[lbproc=128]
@@ -25,9 +24,10 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1235, 726]
 
 [hfgeoubed_ti-u-hxy-gis]
-comment = 
+comment = produced by UniCiCles
 component = landIce
 dimension = longitude latitude
 expression = hfgeoubed
@@ -36,9 +36,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W m^−2
+# Issue number(s):[1110, 1106]
 
 [hfls_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i330[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -47,9 +47,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1236]
 
 [hfss_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i290[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -58,9 +58,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1237]
 
 [icem_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i579[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -69,9 +69,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 
+# Issue number(s):[1238]
 
 [litemptop_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i576[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -80,9 +80,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1239, 1212, 1179]
 
 [mrfso_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128] * m01s08i230[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128]))
@@ -91,9 +91,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1290]
 
 [mrro_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i583[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -102,9 +102,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1241]
 
 [orog_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s00i033[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -113,9 +113,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1242, 1215, 1182]
 
 [prra_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s05i214[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -124,9 +124,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1244]
 
 [prsn_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s05i215[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -135,9 +135,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1245]
 
 [rlds_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i384[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -146,9 +146,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1246]
 
 [rlus_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i383[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -157,9 +157,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1247]
 
 [rsds_tavg-u-hxy-is]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s01i235[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -168,9 +168,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1248]
 
 [rsus_tavg-u-hxy-is]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s01i235[lbproc=128] - m01s01i201[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -179,9 +179,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1249]
 
 [sbl_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i331[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -190,9 +190,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1251]
 
 [sbl_tavg-u-hxy-lnd]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i331[lbproc=128], m01s03i317[lbproc=128], land_class='all')
@@ -201,9 +201,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1250]
 
 [sbl_tpt-u-hs-u]
-comment = 
 component = landIce
 dimension = site time1
 expression = m01s03i298[lbproc=0]
@@ -212,9 +212,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[628]
 
 [snc_tavg-u-hxy-is]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = snc_calc(m01s08i236[lbproc=128], m01s03i317[lbproc=128], m01s03i395[lbproc=128], land_class='iceElev')
@@ -223,9 +223,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1255]
 
 [snc_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = snc_calc(m01s08i236[lbproc=128], m01s03i317[lbproc=128], m01s03i395[lbproc=128])
@@ -234,9 +234,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1862, 1829]
 
 [snd_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i376[lbproc=128], m01s03i317[lbproc=128], land_class='all')
@@ -245,9 +245,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1256, 780]
 
 [snicem_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i579[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -256,9 +256,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1258]
 
 [snm_tavg-u-hxy-is]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i579[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -267,9 +267,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1260]
 
 [snm_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i237[lbproc=128], m01s03i317[lbproc=128], land_class='all')
@@ -278,9 +278,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1259, 781]
 
 [snrefr_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i580[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -289,9 +289,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1257]
 
 [snw_tavg-u-hxy-lnd]
-comment = 
 component = landIce land
 dimension = longitude latitude time
 expression = land_class_mean(m01s08i236[lbproc=128], m01s03i317[lbproc=128], land_class='all')
@@ -300,9 +300,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1830, 1261]
 
 [tas_tavg-h2m-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time height2m
 expression = land_class_mean(m01s03i328[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -311,9 +311,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1263]
 
 [ts_tavg-u-hxy-is]
-comment = 
 component = landIce
 dimension = longitude latitude time
 expression = land_class_mean(m01s03i316[lbproc=128], m01s03i317[lbproc=128], land_class='iceElev')
@@ -322,3 +322,4 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1265]

--- a/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_land_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_land_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the land realm
 
 [areacellg_ti-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude
 expression = areacell
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m^2
+# Issue number(s):[1109, 1105]
 
 [baresoilFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typebare
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='bareSoil')
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1268, 1090]
 
 [c3PftFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typec3pft
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='c3')
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1270]
 
 [c4PftFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typec4pft
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='c4')
@@ -47,9 +46,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1271]
 
 [cLand_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i002[lbtim_ia=240,lbproc=128] + m01s19i016[lbtim_ia=240,lbproc=128] + m01s19i032[lbtim_ia=240,lbproc=128] + m01s19i033[lbtim_ia=240,lbproc=128] + m01s19i034[lbtim_ia=240,lbproc=128]
@@ -58,9 +57,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[844]
 
 [cLeaf_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i026[lbtim_ia=240,lbproc=128]
@@ -69,9 +68,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1273]
 
 [cProduct_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i032[lbtim_ia=240,lbproc=128] + m01s19i033[lbtim_ia=240,lbproc=128] + m01s19i034[lbtim_ia=240,lbproc=128]
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1275]
 
 [cRoot_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i030[lbtim_ia=240,lbproc=128]
@@ -91,9 +90,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1276]
 
 [cSoil_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i016[lbtim_ia=240,lbproc=128]
@@ -102,9 +101,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[849]
 
 [cStem_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i028[lbtim_ia=240,lbproc=128]
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[853]
 
 [cVeg_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i002[lbtim_ia=240,lbproc=128]
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1277]
 
 [cVeg_tavg-u-hxy-ng]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[854]
 
 [cVeg_tavg-u-hxy-shb]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[855]
 
 [cVeg_tavg-u-hxy-tree]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i001[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[856]
 
 [cropFracC3_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typec3crop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128], land_class='c3Crop')
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[873]
 
 [cropFracC4_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typec4crop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128], land_class='c4Crop')
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[874]
 
 [cropFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typecrop
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128], land_class='crop')
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1278, 1095]
 
 [evspsblpot_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i334[lbproc=128]
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[878, 721]
 
 [evspsblsoi_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i296[lbproc=128] + m01s03i298[lbproc=128] - m01s03i539[lbproc=128]
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1279]
 
 [evspsblsoi_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s03i296[lbproc=128] + m01s03i298[lbproc=128] - m01s03i539[lbproc=128]) * m01s00i505
@@ -223,9 +222,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[722, 81]
 
 [evspsblveg_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128]
@@ -234,9 +233,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1280]
 
 [evspsblveg_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i297[lbproc=128] * m01s00i505
@@ -245,9 +244,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[723, 82]
 
 [fAnthDisturb_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s19i044[lbtim_ia=240,lbproc=128])/ (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -256,9 +255,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[880]
 
 [fBNF_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i113[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -267,9 +266,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[881]
 
 [fDeforestToProduct_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s19i036[lbtim_ia=240,lbproc=128] + m01s19i037[lbtim_ia=240,lbproc=128] + m01s19i038[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -278,9 +277,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[884]
 
 [fHarvestToAtmos_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i044[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -289,9 +288,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[887]
 
 [fLuc_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s19i039[lbtim_ia=240,lbproc=128] + m01s19i040[lbtim_ia=240,lbproc=128] + m01s19i041[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -300,9 +299,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[890]
 
 [fNAnthDisturb_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s19i120[lbtim_ia=240,lbproc=128] + m01s19i122[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -311,9 +310,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[893]
 
 [fNProduct_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i122[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -322,9 +321,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[897]
 
 [fNVegSoil_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i124[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -333,9 +332,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[899]
 
 [fNfert_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i126[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -344,9 +343,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[901]
 
 [fNgasNonFire_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i117[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -355,9 +354,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[904]
 
 [fNgas_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i117[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -366,9 +365,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[902]
 
 [fNleach_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i114[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -377,9 +376,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[905]
 
 [fNloss_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i118[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -388,9 +387,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[906]
 
 [fNnetmin_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s19i181[lbtim_ia=240,lbproc=128] - m01s19i171[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -399,9 +398,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[907]
 
 [fNup_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s19i160[lbtim_ia=240,lbproc=128] - m01s19i113[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -410,9 +409,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[908]
 
 [fProductDecomp_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i042[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -421,9 +420,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[909]
 
 [fVegSoil_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i005[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -432,9 +431,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1285]
 
 [fracLut_tpt-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude landuse time1
 expression = land_use_tile_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128])
@@ -443,9 +442,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1097, 918]
 
 [gppLut_tavg-u-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time
 expression = land_use_tile_mean( m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128])
@@ -454,9 +453,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[920]
 
 [gpp_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i183[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -465,9 +464,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1286]
 
 [gpp_tavg-u-hxy-ng]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean( m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
@@ -476,9 +475,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[919]
 
 [gpp_tavg-u-hxy-shb]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean( m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
@@ -487,9 +486,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[921]
 
 [gpp_tavg-u-hxy-tree]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean( m01s19i182[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
@@ -498,9 +497,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[922]
 
 [grassFracC3_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typec3natg
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='c3Grass')
@@ -509,9 +508,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[925]
 
 [grassFracC4_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typec4natg
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='c4Grass')
@@ -520,9 +519,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[926]
 
 [grassFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typenatgr
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128], land_class='grass')
@@ -531,9 +530,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1287, 1099]
 
 [hfdsl_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = -1.0 * m01s03i202[lbproc=128]
@@ -542,9 +541,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[87]
 
 [hflsLut_tavg-u-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time
 expression = land_use_tile_mean(m01s03i330[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
@@ -553,9 +552,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[927]
 
 [hfssLut_tavg-u-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time
 expression = land_use_tile_mean(m01s03i290[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
@@ -564,9 +563,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[928]
 
 [laiLut_tavg-u-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time
 expression = land_use_tile_mean(m01s19i014[lbtim_ia=240,lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
@@ -575,9 +574,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[936]
 
 [lai_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i014[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='veg')
@@ -586,9 +585,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1288]
 
 [landCoverFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude vegtype time
 expression = m01s19i013[lbtim_ia=240,lbproc=128] * m01s03i395[lbproc=128] * 100.0
@@ -597,9 +596,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1289]
 
 [mrro_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128] + m01s08i235[lbproc=128]
@@ -608,9 +607,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1808, 1291, 93]
 
 [mrrob_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i235[lbproc=128]
@@ -619,9 +618,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[750]
 
 [mrros_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i234[lbproc=128]
@@ -630,9 +629,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1292, 751, 94]
 
 [mrsfl_tavg-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i230[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
@@ -641,9 +640,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[938, 752]
 
 [mrsll_tavg-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128] * m01s08i229[lbproc=128] / (m01s08i230[lbproc=128] + m01s08i229[lbproc=128])
@@ -652,9 +651,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[939, 753]
 
 [mrso_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = level_sum(m01s08i223[lbproc=128])
@@ -663,9 +662,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1809, 1293]
 
 [mrsofc_ti-u-hxy-lnd]
-comment = 
+comment = The factor 3.0 m is the soil depth.
 component = land
 dimension = longitude latitude
 expression = mask_zeros(m01s00i041 * FRESHWATER_DENSITY * 3.0)
@@ -674,9 +674,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1851]
 
 [mrsol_tavg-d100cm-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time sdepth100cm
 expression = m01s08i223[blev=0.05, lbproc=128] + m01s08i223[blev=0.225, lbproc=128] + m01s08i223[blev=0.675, lbproc=128]
@@ -685,9 +685,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[95]
 
 [mrsol_tavg-d10cm-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time sdepth10cm
 expression = m01s08i223[blev=0.05, lbproc=128]
@@ -696,9 +696,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1810, 1294]
 
 [mrsol_tavg-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i223[lbproc=128]
@@ -707,9 +707,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[940, 755]
 
 [mrsol_tpt-d10cm-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time1 sdepth10cm
 expression = m01s08i223[blev=0.05, lbproc=0]
@@ -718,9 +718,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[96]
 
 [nLand_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i147[lbtim_ia=240,lbproc=128]
@@ -729,9 +729,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[943]
 
 [nLeaf_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i132[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
@@ -740,9 +740,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[944]
 
 [nMineral_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i146[lbtim_ia=240,lbproc=128]
@@ -751,9 +751,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[948]
 
 [nRoot_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i133[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
@@ -762,9 +762,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[953]
 
 [nSoil_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i145[lbtim_ia=240,lbproc=128]
@@ -773,9 +773,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[954]
 
 [nStem_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i131[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='veg') * land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='veg') / m01s03i395[lbproc=128] / 100.
@@ -784,9 +784,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[955]
 
 [nVeg_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i137[lbtim_ia=240,lbproc=128]
@@ -795,9 +795,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[956]
 
 [nbp_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s19i102[lbtim_ia=240,lbproc=128] - m01s19i053[lbtim_ia=240,lbproc=128] - m01s19i042[lbtim_ia=240,lbproc=128] - m01s19i044[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -806,9 +806,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1295]
 
 [nep_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = (m01s19i102[lbtim_ia=240,lbproc=128] - m01s19i053[lbtim_ia=240,lbproc=128]) / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -817,9 +817,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[958]
 
 [nppLut_tavg-u-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time
 expression = land_use_tile_mean( m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128])
@@ -828,9 +828,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[963]
 
 [npp_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i102[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -839,9 +839,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1296]
 
 [npp_tavg-u-hxy-ng]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean( m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
@@ -850,9 +850,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[962]
 
 [npp_tavg-u-hxy-shb]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean( m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
@@ -861,9 +861,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[965]
 
 [npp_tavg-u-hxy-tree]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean( m01s19i101[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
@@ -872,9 +872,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[967]
 
 [pastureFracC3_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typec3pastures
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128], land_class='c3Pasture')
@@ -883,9 +883,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[970]
 
 [pastureFracC4_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typec4pastures
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128], land_class='c4Pasture')
@@ -894,9 +894,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[971]
 
 [pastureFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typepasture
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128],m01s03i395[lbproc=128], land_class='pasture')
@@ -905,9 +905,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1299]
 
 [raLut_tavg-u-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time
 expression = land_use_tile_mean( m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128])
@@ -916,9 +916,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1860]
 
 [ra_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i185[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -927,9 +927,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1301]
 
 [ra_tavg-u-hxy-ng]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean( m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
@@ -938,9 +938,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[978]
 
 [ra_tavg-u-hxy-shb]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean( m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
@@ -949,9 +949,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[982]
 
 [ra_tavg-u-hxy-tree]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean( m01s19i184[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR), m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
@@ -960,9 +960,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[984]
 
 [residualFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typeresidual
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='residual')
@@ -971,9 +971,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1302, 1100]
 
 [rh_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s19i053[lbtim_ia=240,lbproc=128] / (SECONDS_IN_DAY * DAYS_IN_YEAR)
@@ -982,9 +982,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1303]
 
 [rootd_ti-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude
 expression = calc_rootd(m01s00i009, m01s00i216, ice_class='iceElev')
@@ -993,9 +993,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1853]
 
 [sftgif_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_area(m01s03i317[lbproc=128], m01s03i395[lbproc=128], land_class='iceElev')
@@ -1004,9 +1004,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1253, 1217, 1184]
 
 [sftgif_ti-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude
 expression = land_class_area(m01s00i216, m01s00i505, land_class='iceElev')
@@ -1015,9 +1015,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1854]
 
 [sftlaf_ti-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude typelkins
 expression = land_class_area(m01s00i216, m01s00i505, land_class='water')
@@ -1026,9 +1026,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1856]
 
 [shrubFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typeshrub
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='shrub')
@@ -1037,9 +1037,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1304, 1101]
 
 [slthick_ti-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth
 expression = calc_slthick(m01s00i009, m01s00i216, ice_class='iceElev')
@@ -1048,9 +1048,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[832]
 
 [srfrad_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s02i201[lbproc=128] - m01s01i201[lbproc=128]
@@ -1059,9 +1059,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[106]
 
 [sweLut_tavg-u-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time
 expression = land_use_tile_mean( m01s08i236[lbproc=128] / FRESHWATER_DENSITY, m01s03i317[lbproc=128])
@@ -1070,9 +1070,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1019]
 
 [tasLut_tavg-h2m-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time height2m
 expression = land_use_tile_mean(m01s03i328[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
@@ -1081,9 +1081,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1022]
 
 [tran_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i539[lbproc=128]
@@ -1092,9 +1092,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1305]
 
 [tran_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s03i539[lbproc=128] * m01s00i505
@@ -1103,9 +1103,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[112]
 
 [treeFracBdlDcd_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typetreebd
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='broadLeafTreeDeciduous')
@@ -1114,9 +1114,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1039]
 
 [treeFracBdlEvg_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typetreebe
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='broadLeafTreeEvergreen')
@@ -1125,9 +1125,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1040]
 
 [treeFracNdlDcd_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typetreend
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='needleLeafTreeDeciduous')
@@ -1136,9 +1136,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1041]
 
 [treeFracNdlEvg_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typetreene
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='needleLeafTreeEvergreen')
@@ -1147,9 +1147,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1042]
 
 [treeFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typetree
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='tree')
@@ -1158,9 +1158,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1306, 1102]
 
 [tsLut_tavg-u-hxy-multi]
-comment = 
 component = land
 dimension = longitude latitude landuse time
 expression = land_use_tile_mean(m01s03i316[lbproc=128],m01s19i013[lbtim_ia=240,lbproc=128])
@@ -1169,9 +1169,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1043]
 
 [tsl_tavg-sl-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude sdepth time
 expression = m01s08i225[lbproc=128]
@@ -1180,9 +1180,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1307, 798]
 
 [vegFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typeveg
 expression = land_class_area(m01s19i013[lbtim_ia=240,lbproc=128], m01s03i395[lbproc=128], land_class='veg')
@@ -1191,9 +1191,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1103, 1048]
 
 [vegHeight_tavg-u-hxy-ng]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='grass')
@@ -1202,9 +1202,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1050]
 
 [vegHeight_tavg-u-hxy-shb]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='shrub')
@@ -1213,9 +1213,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1051]
 
 [vegHeight_tavg-u-hxy-tree]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='tree')
@@ -1224,9 +1224,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1052]
 
 [vegHeight_tavg-u-hxy-veg]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = land_class_mean(m01s19i015[lbtim_ia=240,lbproc=128], m01s19i013[lbtim_ia=240,lbproc=128], land_class='veg')
@@ -1235,9 +1235,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1049]
 
 [wetlandCH4_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i242[lbproc=128] * MOLECULAR_MASS_OF_CH4 / ATOMIC_MASS_OF_C
@@ -1246,9 +1246,9 @@ positive =
 reviewer = none
 status = embargoed
 units = ug m-2 s-1
+# Issue number(s):[1055]
 
 [wetlandFrac_tavg-u-hxy-u]
-comment = 
 component = land
 dimension = longitude latitude time typewetla
 expression = m01s08i248[lbproc=128] * m01s03i395[lbproc=128]
@@ -1257,9 +1257,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1058]
 
 [wtd_tavg-u-hxy-lnd]
-comment = 
 component = land
 dimension = longitude latitude time
 expression = m01s08i249[lbproc=128]
@@ -1268,3 +1268,4 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[808]

--- a/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_ocean_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_ocean_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the ocean realm
 
 [agessc_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = agessc
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = yr
+# Issue number(s):[1376]
 
 [areacello_ti-u-hxy-u]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = areacello
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m2
+# Issue number(s):[1361]
 
 [basin_ti-u-hxy-u]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = basin
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1362]
 
 [deptho_ti-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = deptho
@@ -47,9 +46,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1363]
 
 [dxto_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e1t
@@ -58,9 +58,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1364]
 
 [dxuo_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e1u
@@ -69,9 +70,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1365]
 
 [dxvo_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e1v
@@ -80,9 +82,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1366]
 
 [dyto_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e2t
@@ -91,9 +94,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1367]
 
 [dyuo_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e2u
@@ -102,9 +106,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1368]
 
 [dyvo_ti-u-hxy-u]
-comment = 
+comment = Obtainable from the NEMO `domain_cfg.nc` file
 component = ocean
 dimension = longitude latitude
 expression = e2v
@@ -113,9 +118,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1369]
 
 [evspsbl_tavg-u-hxy-ifs]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = correct_evaporation(evs, empmr - (evs - (berg_total_melt + friver + snow_ao_cea + rain_ao_cea + fsitherm) ), areacello)
@@ -124,9 +129,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1417]
 
 [ficeberg_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(berg_total_melt, -1*fwfisf3d)
@@ -135,9 +140,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1430]
 
 [flandice_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = flandice
@@ -146,9 +151,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[916]
 
 [friver_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = friver
@@ -157,9 +162,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1434]
 
 [hfbasin_tavg-u-hyb-sea]
-comment = 
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasin_global, hfbasin_atlantic, hfbasin_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -168,9 +173,9 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1442]
 
 [hfbasinpadv_tavg-u-hyb-sea]
-comment = 
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpadv_global, hfbasinpadv_atlantic, hfbasinpadv_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -179,9 +184,9 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1443]
 
 [hfbasinpmadv_tavg-u-hyb-sea]
-comment = 
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpadv_global, hfbasinpadv_atlantic, hfbasinpadv_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -190,9 +195,9 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1444]
 
 [hfbasinpmdiff_tavg-u-hyb-sea]
-comment = 
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(hfbasinpmdiff_global, hfbasinpmdiff_atlantic, hfbasinpmdiff_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -201,9 +206,9 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1445]
 
 [hfds_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfds
@@ -212,9 +217,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1447]
 
 [hfevapds_tavg-u-hxy-ifs]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfevapds
@@ -223,9 +228,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1448]
 
 [hfgeou_ti-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = hfgeou
@@ -234,9 +239,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1370]
 
 [hfibthermds_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(-1*berg_total_heat_flux, qlatisf3d)
@@ -245,9 +250,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1450]
 
 [hfrainds_tavg-u-hxy-ifs]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfrainds
@@ -256,9 +261,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1452]
 
 [hfrunoffds_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = sum_2d_and_3d(hflx_rnf_cea, -1*qhcisf3d)
@@ -267,9 +272,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1453]
 
 [hfx_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfxint
@@ -278,9 +283,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W
+# Issue number(s):[1458, 1318]
 
 [hfy_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = hfyint
@@ -289,9 +294,9 @@ positive =
 reviewer = none
 status = embargoed
 units = W
+# Issue number(s):[1460, 1319]
 
 [htovgyre_tavg-u-hyb-sea]
-comment = 
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(htovgyre_global, htovgyre_atlantic, htovgyre_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -300,9 +305,9 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1461]
 
 [htovovrt_tavg-u-hyb-sea]
-comment = 
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(htovovrt_global, htovovrt_atlantic, htovovrt_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -311,9 +316,9 @@ positive =
 reviewer = none
 status = embargoed
 units = PW
+# Issue number(s):[1462]
 
 [masscello_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thkcello * SEAWATER_DENSITY
@@ -322,9 +327,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1497]
 
 [masso_tavg-u-hm-sea]
-comment = 
+comment = NEMO must be compiled with `key_diaar5`
 component = ocean
 dimension = time
 expression = masso
@@ -333,9 +339,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg
+# Issue number(s):[1498]
 
 [mlotst_tavg-u-hxy-sea]
-comment = 
+comment = Note that changes to the NEMO namelist are needed- see comments
 component = ocean
 dimension = longitude latitude time deltasigt
 expression = mlotst
@@ -344,9 +351,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1500, 748]
 
 [mlotst_tmax-u-hxy-sea]
-comment = 
+comment = Note that changes to the NEMO namelist are needed- see comments
 component = ocean
 dimension = longitude latitude time deltasigt
 expression = mlotstmax
@@ -355,9 +363,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1501]
 
 [mlotst_tmin-u-hxy-sea]
-comment = 
+comment = Note that changes to the NEMO namelist are needed- see comments
 component = ocean
 dimension = longitude latitude time deltasigt
 expression = mlotstmin
@@ -366,9 +375,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1502]
 
 [mlotstsq_tavg-u-hxy-sea]
-comment = 
+comment = Note that changes to the NEMO namelist are needed- see comments
 component = ocean
 dimension = longitude latitude time deltasigt
 expression = mlotstsq
@@ -377,9 +387,10 @@ positive =
 reviewer = none
 status = embargoed
 units = m2
+# Issue number(s):[1503]
 
 [msftbarot_tavg-u-hxy-sea]
-comment = 
+comment = `areacello` is a time-invariant variable sourced from CDDS ancillary files
 component = ocean
 dimension = longitude latitude time
 expression = ocean_quasi_barotropic_streamfunc(u_masstr_vint, areacello, cube_mask=mask_2D_T)
@@ -388,9 +399,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1507]
 
 [msfty_tavg-ol-ht-sea]
-comment = 
 component = ocean
 dimension = gridlatitude olevel basin time
 expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfglo, zomsfatl, zomsfipc, mask_global=global_ocean_2D_V, mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
@@ -399,9 +410,9 @@ positive =
 reviewer = none
 status = embargoed
 units = sverdrup kg m-3
+# Issue number(s):[1515]
 
 [msftypa_tavg-ol-ht-sea]
-comment = 
 component = ocean
 dimension = gridlatitude olevel basin time
 expression = SEAWATER_DENSITY * combine_cubes_to_basin_coord(zomsfeivglo, zomsfeivatl, zomsfeivipc, mask_global=global_ocean_2D_V, mask_atl=atlantic_arctic_ocean_2D_V, mask_indpac=indian_pacific_ocean_2D_V)
@@ -410,9 +421,9 @@ positive =
 reviewer = none
 status = embargoed
 units = sverdrup kg m-3
+# Issue number(s):[1516]
 
 [obvfsq_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = obvfsq
@@ -421,9 +432,10 @@ positive =
 reviewer = none
 status = embargoed
 units = s-2
+# Issue number(s):[1524]
 
 [pbo_tavg-u-hxy-sea]
-comment = 
+comment = NEMO must be compiled with `key_diaar5`
 component = ocean
 dimension = longitude latitude time
 expression = pbo
@@ -432,9 +444,9 @@ positive =
 reviewer = none
 status = embargoed
 units = dbar
+# Issue number(s):[1526]
 
 [rsdo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = rsdo
@@ -443,9 +455,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1336]
 
 [rsds_tavg-u-hxy-ifs]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = m01s01i235[lbproc=128]
@@ -454,9 +466,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = 
+# Issue number(s):[1005]
 
 [sf6_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = SF6_E3T / thkcello
@@ -465,9 +477,9 @@ positive =
 reviewer = none
 status = embargoed
 units = umol m-3
+# Issue number(s):[1550]
 
 [sfdsi_tavg-u-hxy-sea]
-comment = 
 component = ocean seaIce
 dimension = longitude latitude time
 expression = siflsaltbot
@@ -476,9 +488,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1552]
 
 [sftof_ti-u-hxy-u]
-comment = 
 component = ocean
 dimension = longitude latitude
 expression = sftof
@@ -487,9 +499,9 @@ positive =
 reviewer = none
 status = embargoed
 units = %
+# Issue number(s):[1372]
 
 [siflfwbot_tavg-u-hxy-sea]
-comment = 
 component = ocean seaIce
 dimension = longitude latitude time
 expression = fsitherm
@@ -498,9 +510,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1438]
 
 [sltbasin_tavg-u-hyb-sea]
-comment = 
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(sltbasin_global, sltbasin_atlantic, sltbasin_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -509,9 +521,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1560]
 
 [sltovgyre_tavg-u-hyb-sea]
-comment = 
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(sltovgyre_global, sltovgyre_atlantic, sltovgyre_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -520,9 +532,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1561]
 
 [sltovovrt_tavg-u-hyb-sea]
-comment = 
 component = ocean
 dimension = latitude basin time
 expression = combine_cubes_to_basin_coord(sltovovrt_global, sltovovrt_atlantic, sltovovrt_indopacific, mask_global=global_ocean_1D_V, mask_atl=atlantic_arctic_ocean_1D_V, mask_indpac=indian_pacific_ocean_1D_V)
@@ -531,9 +543,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1562]
 
 [so_tavg-ol-hm-sea]
-comment = 
 component = ocean
 dimension = olevel time
 expression = area_mean(so, volcello(thkcello, areacello))
@@ -542,9 +554,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1565]
 
 [so_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = so
@@ -553,9 +565,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1563, 1337]
 
 [sob_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = sob
@@ -564,9 +576,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1564]
 
 [sos_tavg-u-hm-sea]
-comment = 
 component = ocean
 dimension = time
 expression = area_mean(sos, volcello(thkcello[olevel=0], areacello))
@@ -575,9 +587,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1567]
 
 [sos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = sos
@@ -586,9 +598,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-3
+# Issue number(s):[1566, 1338]
 
 [sossq_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = sossq
@@ -597,9 +609,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1e-6
+# Issue number(s):[1568]
 
 [t20d_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = t20d
@@ -608,9 +620,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1021, 786]
 
 [tauuo_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = mask_copy(tauuo, mask_3D_U[depth<1])
@@ -619,9 +631,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1575]
 
 [tauvo_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = mask_copy(tauvo, mask_3D_V[depth<1])
@@ -630,9 +642,10 @@ positive = down
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1576]
 
 [thetao_tavg-d2000m-hxy-sea]
-comment = 
+comment = This processor will need adjusting to implement the new keyword arguments
 component = ocean
 dimension = longitude latitude time olayer2000m
 expression = level_mean(thetao, thkcello, bottom=2000)
@@ -641,9 +654,10 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1030]
 
 [thetao_tavg-d300m-hxy-sea]
-comment = 
+comment = This processor will need adjusting to implement the new keyword arguments
 component = ocean
 dimension = longitude latitude time olayer300m
 expression = level_mean(thetao, thkcello, bottom=300)
@@ -652,9 +666,10 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1031]
 
 [thetao_tavg-d700m-hxy-sea]
-comment = 
+comment = This processor will need adjusting to implement the new keyword arguments
 component = ocean
 dimension = longitude latitude time olayer700m
 expression = level_mean(thetao, thkcello, bottom=700)
@@ -663,9 +678,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1032]
 
 [thetao_tavg-ol-hm-sea]
-comment = 
 component = ocean
 dimension = olevel time
 expression = area_mean(thetao, volcello(thkcello, areacello))
@@ -674,9 +689,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1578]
 
 [thetao_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thetao
@@ -685,9 +700,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1577]
 
 [thetao_tavg-op20bar-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time op20bar
 expression = thetao[olevel=30]
@@ -696,9 +711,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1339]
 
 [thetaot_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = level_mean(thetao, thkcello)
@@ -707,9 +722,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1029]
 
 [thkcello_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thkcello
@@ -718,9 +733,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1579]
 
 [thkcelluo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thkcelluo
@@ -729,9 +744,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1580]
 
 [thkcellvo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = thkcellvo
@@ -740,9 +755,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1581]
 
 [tob_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = tob
@@ -751,9 +766,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1582]
 
 [tos_tavg-u-hm-sea]
-comment = 
 component = ocean
 dimension = time
 expression = area_mean(tos, volcello(thkcello[olevel=0], areacello))
@@ -762,9 +777,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1864]
 
 [tos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = tos
@@ -773,9 +788,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC
+# Issue number(s):[1583, 1340]
 
 [tossq_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = tossq
@@ -784,9 +799,9 @@ positive =
 reviewer = none
 status = embargoed
 units = degC2
+# Issue number(s):[1584, 1341]
 
 [umo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = umo
@@ -795,9 +810,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1585]
 
 [uo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = uo
@@ -806,9 +821,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1586]
 
 [uos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = uos
@@ -817,9 +832,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1342]
 
 [vmo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = vmo
@@ -828,9 +843,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1587]
 
 [vo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = vo
@@ -839,9 +854,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1588]
 
 [volcello_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = volcello(thkcello, areacello)
@@ -850,9 +865,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m3
+# Issue number(s):[1652, 1589]
 
 [volo_tavg-u-hm-sea]
-comment = 
 component = ocean
 dimension = time
 expression = volo
@@ -861,9 +876,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m3
+# Issue number(s):[1590]
 
 [vos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = vos
@@ -872,9 +887,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1343]
 
 [wfo_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = wfo
@@ -883,9 +898,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1601]
 
 [wmo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = wmo
@@ -894,9 +909,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1602]
 
 [wo_tavg-ol-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude olevel time
 expression = wo
@@ -905,9 +920,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1603, 1344]
 
 [zos_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = zos
@@ -916,9 +931,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1618, 1348]
 
 [zossq_tavg-u-hxy-sea]
-comment = 
 component = ocean
 dimension = longitude latitude time
 expression = zossq
@@ -927,9 +942,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m2
+# Issue number(s):[1619]
 
 [zostoga_tavg-u-hm-sea]
-comment = 
 component = ocean
 dimension = time
 expression = calc_zostoga(thetao, thkcello, areacello, zfullo_0, so_0, rho_0_mean, deptho_0_mean)
@@ -938,3 +953,4 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1620, 1349]

--- a/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_ocnBgchem_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_ocnBgchem_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the ocnBgchem realm
 
 [chl_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = (CHN_E3T + CHD_E3T) / thkcello
@@ -14,9 +13,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mg m-3
+# Issue number(s):[1385]
 
 [chl_tavg-op20bar-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time op20bar
 expression = (CHN_200 + CHD_200)
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mg m-3
+# Issue number(s):[1309]
 
 [chldiat_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = CHD_E3T / thkcello
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mg m-3
+# Issue number(s):[1388]
 
 [chldiat_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(CHD_E3T[depth=0] / thkcello[depth=0])
@@ -47,9 +46,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mg m-3
+# Issue number(s):[1389]
 
 [chlmisc_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = CHN_E3T / thkcello
@@ -58,9 +57,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mg m-3
+# Issue number(s):[1392]
 
 [chlmisc_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(CHN_E3T[depth=0] / thkcello[depth=0])
@@ -69,9 +68,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mg m-3
+# Issue number(s):[1393]
 
 [co3_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(CO3_0)
@@ -80,9 +79,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1312]
 
 [co3_tavg-op20bar-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time op20bar
 expression = CO3_200
@@ -91,9 +90,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1311]
 
 [co3satarag_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(CO3SATARAG_0)
@@ -102,9 +101,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1314]
 
 [co3satarag_tavg-op20bar-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time op20bar
 expression = CO3SATARAG_200
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1313]
 
 [detoc_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = DTC_E3T / thkcello
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1397]
 
 [dfe_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = FER_E3T / thkcello
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1398]
 
 [dfe_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(FER_E3T[depth=0] / thkcello[depth=0])
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1399]
 
 [dissic_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = DIC_E3T / thkcello
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1404]
 
 [dissic_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(DIC_E3T[depth=0] / thkcello[depth=0])
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1405]
 
 [dmso_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(DMS_SURF)
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = nmol L-1
+# Issue number(s):[1408]
 
 [dpco2_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = (OCN_PCO2 - ATM_PCO2)
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = uatm
+# Issue number(s):[1863]
 
 [epn_tavg-d100m-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time depth100m
 expression = epN100
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1414]
 
 [epp_tavg-d100m-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time depth100m
 expression = epN100 * P_TO_N_RATIO
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1415]
 
 [epsi_tavg-d100m-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time depth100m
 expression = epSI100
@@ -223,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1416]
 
 [expc_tavg-d1000m-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time depth1000m
 expression = EXPC3[depth=46]
@@ -234,9 +233,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1411]
 
 [expc_tavg-d100m-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time depth100m
 expression = epC100
@@ -245,9 +244,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1410]
 
 [expc_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = EXPC3
@@ -256,9 +255,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1419]
 
 [expcalc_tavg-d100m-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time depth100m
 expression = epCALC100
@@ -267,9 +266,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1412]
 
 [expcalc_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = FD_CAL3
@@ -278,9 +277,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[879]
 
 [expcalcob_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = IBEN_CA
@@ -289,9 +288,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1420]
 
 [expcob_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = IBEN_C
@@ -300,9 +299,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1421, 1317]
 
 [expfeob_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = IBEN_FE
@@ -311,9 +310,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1422]
 
 [expnob_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = IBEN_N
@@ -322,9 +321,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1423]
 
 [exppob_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = IBEN_N * P_TO_N_RATIO
@@ -333,9 +332,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1424]
 
 [expsiob_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = IBEN_SI
@@ -344,9 +343,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1425]
 
 [fgco2_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = CO2FLUX * ATOMIC_MASS_OF_C
@@ -355,9 +354,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = mg m-2 d-1
+# Issue number(s):[1428]
 
 [fgdms_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = calc_fgdms(m01s00i505, m01s50i214[lbproc=128] / MOLECULAR_MASS_OF_DMS )
@@ -366,9 +365,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kmol m-2 s-1
+# Issue number(s):[1429]
 
 [frfe_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = IBEN_FE
@@ -377,9 +376,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1432]
 
 [fric_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = IBEN_CA
@@ -388,9 +387,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1433]
 
 [froc_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = IBEN_C
@@ -399,9 +398,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1436]
 
 [fsfe_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = AEOLIAN + BENTHIC
@@ -410,9 +409,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1437]
 
 [graz_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = (MIGRAZP3 + MEGRAZP3) * C_TO_N_RATIO
@@ -421,9 +420,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3 d-1
+# Issue number(s):[1440]
 
 [intdic_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = INTDISSIC * ATOMIC_MASS_OF_C
@@ -432,9 +431,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mg m-2
+# Issue number(s):[1464]
 
 [intpbfe_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = (PRN + PRD) * FE_TO_N_RATIO
@@ -443,9 +442,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1467]
 
 [intpbn_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = PRN + PRD
@@ -454,9 +453,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1468]
 
 [intpbp_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = (PRN + PRD) * P_TO_N_RATIO
@@ -465,9 +464,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1469]
 
 [intpbsi_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = OPAL
@@ -476,9 +475,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1470]
 
 [intpcalcite_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = FASTCA
@@ -487,9 +486,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1471]
 
 [intpoc_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = (((INT_PN + INT_PD) * C_TO_N_RATIO) + ((INT_ZMI + INT_ZME) * C_TO_N_RATIO_ZOO) + INT_DTC)
@@ -498,9 +497,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2
+# Issue number(s):[1473, 1320]
 
 [intpp_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = (PRN + PRD) * C_TO_N_RATIO
@@ -509,9 +508,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1474, 1321]
 
 [intppdiat_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = PRD * C_TO_N_RATIO
@@ -520,9 +519,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1476]
 
 [intppmisc_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = PRN * C_TO_N_RATIO
@@ -531,9 +530,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-2 d-1
+# Issue number(s):[1478]
 
 [limfediat_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = PD_FELIM
@@ -542,9 +541,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1483]
 
 [limfemisc_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = PN_FELIM
@@ -553,9 +552,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1485]
 
 [limirrdiat_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = PD_JLIM
@@ -564,9 +563,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1488]
 
 [limirrmisc_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = PN_JLIM
@@ -575,9 +574,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1490]
 
 [limndiat_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = PD_NLIM
@@ -586,9 +585,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1493]
 
 [limnmisc_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = PN_NLIM
@@ -597,9 +596,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1495]
 
 [no3_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = DIN_E3T / thkcello
@@ -608,9 +607,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1519]
 
 [no3_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(DIN_E3T[depth=0] / thkcello[depth=0])
@@ -619,9 +618,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1520]
 
 [o2_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = OXY_E3T / thkcello
@@ -630,9 +629,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1521]
 
 [o2_tavg-op20bar-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time op20bar
 expression = OXY_200
@@ -641,9 +640,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1323]
 
 [o2sat_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = O2SAT3
@@ -652,9 +651,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1523]
 
 [ph_tavg-d0m-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time depth0m
 expression = OCN_PH
@@ -663,9 +662,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1530]
 
 [ph_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = PH3
@@ -674,9 +673,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1528]
 
 [ph_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(OCN_PH_0)
@@ -685,9 +684,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1327]
 
 [ph_tavg-op20bar-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time op20bar
 expression = OCN_PH_200
@@ -696,9 +695,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1326]
 
 [phyc_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = (PHN_E3T + PHD_E3T) * C_TO_N_RATIO / thkcello
@@ -707,9 +706,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1531]
 
 [phyc_tavg-op20bar-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time op20bar
 expression = (PHN_200 + PHD_200) * C_TO_N_RATIO
@@ -718,9 +717,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1328]
 
 [phydiat_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = PHD_E3T * C_TO_N_RATIO / thkcello
@@ -729,9 +728,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1535]
 
 [phymisc_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = PHN_E3T * C_TO_N_RATIO / thkcello
@@ -740,9 +739,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1539]
 
 [po4_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = DIN_E3T * P_TO_N_RATIO / thkcello
@@ -751,9 +750,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1543]
 
 [pp_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = TPP3 * C_TO_N_RATIO
@@ -762,9 +761,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3 d-1
+# Issue number(s):[1544]
 
 [pp_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(TPP3[depth=0] * C_TO_N_RATIO)
@@ -773,9 +772,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3 d-1
+# Issue number(s):[1545]
 
 [si_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = SIL_E3T / thkcello
@@ -784,9 +783,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1558]
 
 [si_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(SIL_E3T[depth=0] / thkcello[depth=0])
@@ -795,9 +794,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1559]
 
 [spco2_tavg-u-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time
 expression = OCN_PCO2
@@ -806,9 +805,9 @@ positive =
 reviewer = none
 status = embargoed
 units = uatm
+# Issue number(s):[1569]
 
 [talk_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = ALK_E3T / thkcello
@@ -817,9 +816,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1574]
 
 [zmeso_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = ZME_E3T * C_TO_N_RATIO_ZOO / thkcello
@@ -828,9 +827,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1610]
 
 [zmeso_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(ZME_E3T[depth=0] * C_TO_N_RATIO_ZOO / thkcello[depth=0])
@@ -839,9 +838,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1611]
 
 [zmicro_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = ZMI_E3T * C_TO_N_RATIO_ZOO / thkcello
@@ -850,9 +849,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1612]
 
 [zmicro_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis(ZMI_E3T[depth=0] * C_TO_N_RATIO_ZOO / thkcello[depth=0])
@@ -861,9 +860,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1613]
 
 [zooc_tavg-ol-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude olevel time
 expression = (ZMI_E3T + ZME_E3T) * C_TO_N_RATIO_ZOO / thkcello
@@ -872,9 +871,9 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1616]
 
 [zooc_tavg-ols-hxy-sea]
-comment = 
 component = ocnBgchem
 dimension = longitude latitude time osurf
 expression = add_osurf_axis((ZMI_E3T[depth=0] + ZME_E3T[depth=0]) * C_TO_N_RATIO_ZOO / thkcello[depth=0])
@@ -883,3 +882,4 @@ positive =
 reviewer = none
 status = embargoed
 units = mmol m-3
+# Issue number(s):[1617]

--- a/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_seaIce_mappings.cfg
+++ b/mip_convert/mip_convert/plugins/ukesm1p3/data/UKESM1p3_seaIce_mappings.cfg
@@ -5,7 +5,6 @@
 # for each 'MIP requested variable name' for the seaIce realm
 
 [evspsbl_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = -1 * evap_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
@@ -14,9 +13,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1711]
 
 [prra_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = rain_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
@@ -25,9 +24,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1758]
 
 [prsn_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = snow_ai * FRESHWATER_DENSITY / (100. * SECONDS_IN_DAY)
@@ -36,9 +35,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1769]
 
 [rlds_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s02i501[lbproc=128] / m01s00i031[lbproc=128]
@@ -47,9 +46,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1731, 1664]
 
 [rlus_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s03i531[lbproc=128] / m01s00i031[lbproc=128]
@@ -58,9 +57,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1732, 1665]
 
 [rsds_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s01i501[lbproc=128] / m01s00i031[lbproc=128]
@@ -69,9 +68,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1737, 1669]
 
 [rsus_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s01i503[lbproc=128] / m01s00i031[lbproc=128]
@@ -80,9 +79,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1738, 1670]
 
 [sbl_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = 
@@ -91,9 +90,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1770]
 
 [sfdsi_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = ((meltt + meltb + meltl - congel - frazil) * ICE_DENSITY + melts * SNOW_DENSITY) / (100. * SECONDS_IN_DAY * aice) * REF_SALINITY / 1000.
@@ -102,9 +101,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1733]
 
 [siage_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = iage * SECONDS_IN_DAY * DAYS_IN_YEAR
@@ -113,9 +112,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s
+# Issue number(s):[1698, 1653]
 
 [sicompstren_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sicompstren
@@ -124,9 +123,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-1
+# Issue number(s):[1704]
 
 [siconc_tavg-u-hxy-u]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = aice
@@ -135,9 +134,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1705, 1656]
 
 [siconca_tavg-u-hxy-u]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s00i031[lbproc=128]
@@ -146,9 +145,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1706, 1657]
 
 [sidconcdyn_tavg-u-hxy-sea]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidconcdyn
@@ -157,9 +156,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1707]
 
 [sidconcth_tavg-u-hxy-sea]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidconcth
@@ -168,9 +167,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1708]
 
 [sidivvel_tpt-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time1
 expression = sidivvel
@@ -179,9 +178,9 @@ positive =
 reviewer = none
 status = embargoed
 units = s-1
+# Issue number(s):[1709]
 
 [sidmassdyn_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = dvidtd * ICE_DENSITY / (100. * SECONDS_IN_DAY)
@@ -190,9 +189,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1710]
 
 [sidmassgrowthbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = congel * ICE_DENSITY / (100. * SECONDS_IN_DAY)
@@ -201,9 +200,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1712]
 
 [sidmassgrowthsi_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
@@ -212,9 +211,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1713]
 
 [sidmassgrowthwat_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = frazil * ICE_DENSITY / (100. * SECONDS_IN_DAY)
@@ -223,9 +222,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1714]
 
 [sidmassmeltbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = -1 * meltb * ICE_DENSITY / (100. * SECONDS_IN_DAY)
@@ -234,9 +233,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1715]
 
 [sidmassmeltlat_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = -1 * meltl * ICE_DENSITY / (100. * SECONDS_IN_DAY)
@@ -245,9 +244,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1716]
 
 [sidmassmelttop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = -1 * meltt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
@@ -256,9 +255,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1717]
 
 [sidmassth_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = dvidtt * ICE_DENSITY / (100. * SECONDS_IN_DAY)
@@ -267,9 +266,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1718]
 
 [sidmasstranx_tavg-u-hxy-u]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmasstranx
@@ -278,9 +277,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1719]
 
 [sidmasstrany_tavg-u-hxy-u]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sidmasstrany
@@ -289,9 +288,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg s-1
+# Issue number(s):[1720]
 
 [sidragtop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s03i538[lbproc=128] / m01s00i031[lbproc=128]
@@ -300,9 +299,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1722]
 
 [sieqthick_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = hi
@@ -311,9 +310,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1792]
 
 [sifb_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sifb
@@ -322,9 +321,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1725, 1660]
 
 [siflcondbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siflcondbot
@@ -333,9 +332,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1726, 1661]
 
 [siflcondtop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siflcondtop
@@ -344,9 +343,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1727, 1662]
 
 [siflfwbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = ((meltt + meltb + meltl - congel - frazil) * ICE_DENSITY + melts * SNOW_DENSITY) / (100. * SECONDS_IN_DAY)
@@ -355,9 +354,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1728]
 
 [siflfwdrain_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = (meltt * ICE_DENSITY + melts * SNOW_DENSITY) / (100. * SECONDS_IN_DAY)
@@ -366,9 +365,10 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1729]
 
 [sifllattop_tavg-u-hxy-si]
-comment = 
+comment = This data has been produced on the ocean grid rather than the atmosphere grid as originally requested.
 component = seaIce
 dimension = longitude latitude time
 expression = -1. * flat_ai / aice
@@ -377,9 +377,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1730, 1663]
 
 [siflsensbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siflsensupbot
@@ -388,9 +388,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1734, 1666]
 
 [siflsenstop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = -1. * m01s03i533[lbproc=128] / m01s00i031[lbproc=128]
@@ -399,9 +399,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = W m-2
+# Issue number(s):[1735, 1667]
 
 [siforcecoriolx_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siforcecoriolx
@@ -410,9 +410,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1739]
 
 [siforcecorioly_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siforcecorioly
@@ -421,9 +421,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1740]
 
 [siforceintstrx_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siforceintstrx
@@ -432,9 +432,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1741]
 
 [siforceintstry_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siforceintstry
@@ -443,9 +443,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1742]
 
 [siforcetiltx_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siforcetiltx
@@ -454,9 +454,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1743]
 
 [siforcetilty_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siforcetilty
@@ -465,9 +465,9 @@ positive =
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1744]
 
 [sihc_tavg-u-hxy-sea]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sihc
@@ -476,9 +476,9 @@ positive =
 reviewer = none
 status = embargoed
 units = J m-2
+# Issue number(s):[1746, 1671]
 
 [siitdconc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude iceband time
 expression = aicen
@@ -487,9 +487,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1747, 1672]
 
 [siitdsnconc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude iceband time
 expression = snowfracn
@@ -498,9 +498,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1748, 1673]
 
 [siitdsnthick_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude iceband time
 expression = vsnon / aicen
@@ -509,9 +509,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1749, 1674]
 
 [siitdthick_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude iceband time
 expression = vicen / aicen
@@ -520,9 +520,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1750, 1675]
 
 [simass_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = hi * ICE_DENSITY
@@ -531,9 +531,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1751]
 
 [simpconc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time typemp
 expression = apond_ai / aice
@@ -542,9 +542,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1753, 1676]
 
 [simpeffconc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time typemp
 expression = apeff_ai / aice
@@ -553,9 +553,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1754, 1677]
 
 [simprefrozen_tavg-u-hxy-simp]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = ipond_ai / apond_ai
@@ -564,9 +564,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1755, 1678]
 
 [simpthick_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = hpond_ai / apond_ai
@@ -575,9 +575,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1679]
 
 [simpthick_tavg-u-hxy-simp]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = hpond_ai / apond_ai
@@ -586,9 +586,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1756]
 
 [sirdgconc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time typesirdg
 expression = ardg/aice
@@ -597,9 +597,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1759, 1680]
 
 [sisaltmass_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sisaltmass
@@ -608,9 +608,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1762, 1683]
 
 [sisndmasssi_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = -1 * snoice * ICE_DENSITY / (100. * SECONDS_IN_DAY)
@@ -619,9 +619,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1768]
 
 [sisnhc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sisnhc
@@ -630,9 +630,9 @@ positive =
 reviewer = none
 status = embargoed
 units = J m-2
+# Issue number(s):[1772, 1684]
 
 [sispeed_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sispeed
@@ -641,9 +641,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1778, 1688]
 
 [sistrxdtop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sistrxdtop
@@ -652,9 +652,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1781]
 
 [sistrxubot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sistrxubot
@@ -663,9 +663,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1782]
 
 [sistrydtop_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sistrydtop
@@ -674,9 +674,9 @@ positive = down
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1783]
 
 [sistryubot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sistryubot
@@ -685,9 +685,9 @@ positive = up
 reviewer = none
 status = embargoed
 units = N m-2
+# Issue number(s):[1784]
 
 [sitempbot_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sitempbot
@@ -696,9 +696,9 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1785, 1689]
 
 [sithick_tavg-u-hxy-si]
-comment = 
 component = seaIce ocean
 dimension = longitude latitude time
 expression = sithick
@@ -707,9 +707,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1788, 1692]
 
 [sithick_tavg-u-hxy-sir]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = vrdg / ardg
@@ -718,9 +718,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1760, 1681]
 
 [sitimefrac_tavg-u-hxy-sea]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = ice_present
@@ -729,9 +729,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1789, 1693]
 
 [siu_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siu
@@ -740,9 +740,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1790, 1694]
 
 [siv_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = siv
@@ -751,9 +751,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m s-1
+# Issue number(s):[1791, 1695]
 
 [snc_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = snowfrac / aice
@@ -762,9 +762,9 @@ positive =
 reviewer = none
 status = embargoed
 units = 1
+# Issue number(s):[1765]
 
 [snd_tavg-u-hxy-sn]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = sisnthick
@@ -773,9 +773,9 @@ positive =
 reviewer = none
 status = embargoed
 units = m
+# Issue number(s):[1777, 1687]
 
 [snm_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = -1 * melts * SNOW_DENSITY / (100. * SECONDS_IN_DAY)
@@ -784,9 +784,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2 s-1
+# Issue number(s):[1767]
 
 [snw_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = hs * SNOW_DENSITY
@@ -795,9 +795,9 @@ positive =
 reviewer = none
 status = embargoed
 units = kg m-2
+# Issue number(s):[1773]
 
 [ts_tavg-u-hxy-si]
-comment = 
 component = seaIce
 dimension = longitude latitude time
 expression = m01s03i535[lbproc=128] / m01s00i031[lbproc=128]
@@ -806,3 +806,4 @@ positive =
 reviewer = none
 status = embargoed
 units = K
+# Issue number(s):[1787, 1691]


### PR DESCRIPTION
Adds a commits section (if available) to cmip7 mappings and notes the corresponding issue number(s) below each mapping configuration as a comment. 