### PR TITLE
#1007: Reduce memory use of calc_zostoga processor and its dependencies

### DIFF
--- a/mip_convert/mip_convert/plugins/base/data/processors.py
+++ b/mip_convert/mip_convert/plugins/base/data/processors.py
@@ -978,9 +978,9 @@ def eos_insitu(zt, zs, zh):
         stability. Journal of Atmospheric and Oceanic Technology,
         12(2), pp.381-389.
     """
-    zt = np.float64(zt)
-    zs = np.float64(zs)
-    zh = np.float64(zh)
+    zt = zt.astype(np.float64)
+    zs = zs.astype(np.float64)
+    zh = zh.astype(np.float64)
 
     # zb = zbw + ze * zs
     zwrk = (-3.508914e-8 * zt - 1.248266e-8) * zt - 2.595994e-6   # ze
@@ -1106,7 +1106,7 @@ def calc_rho_mean(thetao, so, zfullo, areacello, thkcello):
         raise ValueError(message.format(a=thetao, b=so, c=zfullo, d=thkcello))
 
     # Calculate in-situ density
-    rho = thetao.copy(eos_insitu(thetao.data, so.data, zfullo.data))
+    rho = thetao.copy(eos_insitu(thetao.core_data(), so.core_data(), zfullo.core_data()))
 
     # Set some metadata
     rho.standard_name = 'sea_water_density'
@@ -1114,7 +1114,7 @@ def calc_rho_mean(thetao, so, zfullo, areacello, thkcello):
     rho.units = 'kg m-3'
 
     # Calculate weighted global mean
-    volcello = np.broadcast_to(areacello.data, thkcello.shape) * thkcello.data
+    volcello = areacello.core_data() * thkcello.core_data()
     rho_mean = rho.collapsed(['latitude', 'longitude', 'depth'], iris.analysis.MEAN, weights=volcello)
     return rho_mean
 
@@ -1198,10 +1198,10 @@ def calc_zostoga(thetao, thkcello, areacello, zfullo_0, so_0, rho_0_mean, deptho
         rho_mean += [calc_rho_mean(t_slice, so_0, zfullo_0, areacello, z_slice)]
 
     rho_mean = rho_mean.merge_cube()
-    rho_t = rho_mean.data / rho_0_mean.data
+    rho_t = rho_mean.core_data() / rho_0_mean.core_data()
 
     # zostoga is calculated by restating the change in mean in-situ density as a change in mean sea surface height
-    zostoga = deptho_0_mean.data * (1. - rho_t)
+    zostoga = deptho_0_mean.core_data() * (1. - rho_t)
     zostoga = rho_mean.copy(zostoga)
     zostoga.units = Unit('m')
     return zostoga

--- a/mip_convert/mip_convert/plugins/base/data/processors.py
+++ b/mip_convert/mip_convert/plugins/base/data/processors.py
@@ -951,12 +951,12 @@ def eos_insitu(zt, zs, zh):
 
     * From the NEMO `eos_insitu` docstring
 
-        >>> round(eos_insitu(40., 40., 10000.), 5)
+        >>> round(eos_insitu(np.float64(40.), np.float64(40.), np.float64(10000.)), 5)
         np.float64(1060.93299)
 
     * From Jackett and McDougall (1995) [eos_insitu_1]_
 
-        >>> round(eos_insitu(3., 35.5, 3000.), 3)
+        >>> round(eos_insitu(np.float64(3.), np.float64(35.5), np.float64(3000.)), 3)
         np.float64(1041.833)
 
     Notes

--- a/mip_convert/mip_convert/tests/test_process/test_processors.py
+++ b/mip_convert/mip_convert/tests/test_process/test_processors.py
@@ -533,7 +533,7 @@ class TestZostoga(unittest.TestCase):
         thetao_ref = thetao.copy()
         zfullo_ref = zfullo.copy()
         cube = calc_rho_mean(thetao, so, zfullo, areacello, thkcello)
-        ref = eos_insitu(40., 40., 10000.)
+        ref = eos_insitu(np.array(40.), np.array(40.), np.array(10000.))
 
         self.assertIsInstance(cube, Cube)
         self.assertEqual(cube.shape, (2,))


### PR DESCRIPTION
Closes #1007.

All `pytest mip_convert` unit tests pass.