### PR TITLE
#1035 Add OPERATION_FAILED to list of skip errors

### DIFF
--- a/cdds/cdds/extract/common.py
+++ b/cdds/cdds/extract/common.py
@@ -151,7 +151,7 @@ def check_moo_cmd(code, output):
     ]
     SKIP_ERRORS = [
         'EXCEEDS_DATA_VOLUME_LIMIT', 'EXCEEDS_FILE_NUMBER_LIMIT', 'SPANS_TOO_MANY_RESOURCES',
-        'QUERY_MATCHES_TOO_MANY_RESULTS', 'does not match',
+        'QUERY_MATCHES_TOO_MANY_RESULTS', 'does not match', 'OPERATION_FAILED',
         'ncks: ERROR'
     ]
     OK_ERRORS = ['PATH_ALREADY_EXISTS']


### PR DESCRIPTION
Closes #1035 

Initial testing shows that this works as expected. However, getting around the `OPERATION_FAILED` error always requires an extra subdivision which adds to the overall overhead due to extra `--dry-run` commands and extra selects. Hopefully there will be a fix upstream that will result in having to split the query into fewer select commands.

My testing used the `ap6` stream of the `piControl` with as many variables as possible for a 50 year period. The `--dry-run` testing took around an hour and the actual select commands took approximately 10 hours. Longer time periods might start pushing the limits of the `cpu-long` partition.